### PR TITLE
Use GetTaskDetails in task list command

### DIFF
--- a/internal/command/task_list.go
+++ b/internal/command/task_list.go
@@ -36,8 +36,20 @@ var TaskListCommand = &cli.Command{
 			return fmt.Errorf("failed to list tasks: %w", err)
 		}
 
+		// Fetch detailed information for each task
+		var taskDetails []*xagentv1.GetTaskDetailsResponse
+		for _, task := range resp.Tasks {
+			detailResp, err := client.GetTaskDetails(ctx, &xagentv1.GetTaskDetailsRequest{
+				Id: task.Id,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to get task details for task %d: %w", task.Id, err)
+			}
+			taskDetails = append(taskDetails, detailResp)
+		}
+
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(resp.Tasks)
+		return enc.Encode(taskDetails)
 	},
 }


### PR DESCRIPTION
## Summary

The `xagent task list` command now uses the `GetTaskDetails` API call instead of `ListTasks` to provide more comprehensive information for each task, including:
- Child tasks
- Associated events  
- Task links

## Changes

- Updated `/home/vscode/xagent/internal/command/task_list.go` to fetch detailed information by calling `GetTaskDetails` for each task returned from `ListTasks`
- Output now includes the full `GetTaskDetailsResponse` structure with children, events, and links

🤖 Generated with [Claude Code](https://claude.com/claude-code)