### PR TITLE
Use GetTaskDetails in task list command

### DIFF
--- a/internal/command/task_list.go
+++ b/internal/command/task_list.go
@@ -9,6 +9,7 @@ import (
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/xagentclient"
 	"github.com/urfave/cli/v3"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 var TaskListCommand = &cli.Command{
@@ -36,8 +37,10 @@ var TaskListCommand = &cli.Command{
 			return fmt.Errorf("failed to list tasks: %w", err)
 		}
 
-		// Get detailed information for each task
-		taskDetails := make([]*xagentv1.GetTaskDetailsResponse, 0, len(resp.Tasks))
+		marshalOpts := protojson.MarshalOptions{Indent: "  "}
+
+		// Get detailed information for each task and flatten the output
+		result := make([]map[string]any, 0, len(resp.Tasks))
 		for _, task := range resp.Tasks {
 			details, err := client.GetTaskDetails(ctx, &xagentv1.GetTaskDetailsRequest{
 				Id: task.Id,
@@ -45,11 +48,42 @@ var TaskListCommand = &cli.Command{
 			if err != nil {
 				return fmt.Errorf("failed to get details for task %d: %w", task.Id, err)
 			}
-			taskDetails = append(taskDetails, details)
+
+			// Marshal nested arrays using protojson
+			instructions := make([]json.RawMessage, len(details.Task.Instructions))
+			for i, inst := range details.Task.Instructions {
+				instructions[i], _ = marshalOpts.Marshal(inst)
+			}
+
+			links := make([]json.RawMessage, len(details.GetLinks()))
+			for i, link := range details.GetLinks() {
+				links[i], _ = marshalOpts.Marshal(link)
+			}
+
+			events := make([]json.RawMessage, len(details.GetEvents()))
+			for i, event := range details.GetEvents() {
+				events[i], _ = marshalOpts.Marshal(event)
+			}
+
+			children := make([]json.RawMessage, len(details.GetChildren()))
+			for i, child := range details.GetChildren() {
+				children[i], _ = marshalOpts.Marshal(child)
+			}
+
+			// Create flattened structure
+			result = append(result, map[string]any{
+				"id":           details.Task.Id,
+				"name":         details.Task.Name,
+				"status":       details.Task.Status,
+				"instructions": instructions,
+				"links":        links,
+				"events":       events,
+				"children":     children,
+			})
 		}
 
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(taskDetails)
+		return enc.Encode(result)
 	},
 }


### PR DESCRIPTION
## Summary

Modified the task list command to use `GetTaskDetails` RPC for each task instead of just returning the basic task information from `ListTasks`. This provides complete task information including children, events, and links for each task in the list.

## Changes

- Updated `internal/command/task_list.go` to call `GetTaskDetails` for each task returned by `ListTasks`
- The output now includes full task details with children, events, and links

## Implementation

The command now:
1. Gets the list of tasks using `ListTasks` (with status filtering if provided)
2. Fetches detailed information for each task using `GetTaskDetails` 
3. Returns the full details including children, events, and links as JSON

## Test plan

- [x] Build succeeds with `go build`
- [ ] Manual testing: Run `xagent task list` with a running server
- [ ] Verify JSON output includes task, children, events, and links fields