### PR TITLE
Add explicit git author configuration to xagent workspace prompt

### DIFF
--- a/workspaces.yaml
+++ b/workspaces.yaml
@@ -83,4 +83,12 @@ workspaces:
         You have the xagent repo cloned locally. When asked to make code changes, you should open a PR.
         Never attribute yourself in the commit or the PR.
 
+        IMPORTANT: All git commits must use the following author information:
+        - Name: Ilia Choly
+        - Email: ilia.choly@gmail.com
+
+        Before making any commits, ensure git is configured with:
+        git config user.name "Ilia Choly"
+        git config user.email "ilia.choly@gmail.com"
+
 


### PR DESCRIPTION
## Summary
- Updated the xagent workspace prompt to explicitly require git configuration with specific author information
- Ensures all commits made by Claude agents use the name "Ilia Choly" and email "ilia.choly@gmail.com"

## Changes
- Added clear instructions in the workspace prompt to configure git before making commits
- Specified exact name and email to use for git author attribution

## Context
Previously, the prompt only said "never attribute yourself" but didn't specify what author information to use, leading to inconsistent commit attribution.