### PR TITLE
Fix task creation placeholder text

### DIFF
--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -84,7 +84,7 @@
         <form id="create-form">
             <input type="text" name="name" placeholder="Name (optional)">
             <input type="text" name="workspace" placeholder="Workspace (e.g. default)" required>
-            <textarea name="prompt" placeholder="Prompt" required></textarea>
+            <textarea name="prompt" placeholder="Instructions" required></textarea>
             <button type="submit">Create Task</button>
         </form>
     </div>


### PR DESCRIPTION
## Summary
- Updated the task creation form placeholder from "Prompt" to "Instructions"

## Changes
Changed the placeholder text in the textarea field from "Prompt" to "Instructions" to better align with the API field name and provide clearer guidance to users.

## Test plan
- Open the web UI
- Navigate to the task creation form
- Verify that the textarea placeholder now reads "Instructions"