### PR TITLE
Clarify notify=true usage for created resources

### DIFF
--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -89,7 +89,7 @@ var RunCommand = &cli.Command{
 				"",
 				"The task may have linked events. Events provide additional context such as GitHub webhooks or external triggers.",
 				"Events are routed to tasks that have a link with notify=true matching the event URL.",
-				"When creating links with xagent:create_link, set notify=true for any resource you create (PRs, issues, comments). Expect follow-up instructions and comments. Only use notify=false for reference links that don't need monitoring.",
+				"When creating links with xagent:create_link, ALWAYS set notify=true for resources you create (PRs, issues, comments), even if the task is complete. Others may respond and you'll need to handle those responses. Only use notify=false for reference links to external resources you didn't create.",
 				"Use xagent:update_child_task to delegate work to child tasks.",
 				"",
 				"When done, use xagent:create_link for any URLs you created (PRs, issues, etc).",


### PR DESCRIPTION
## Summary

Updated the agent prompt to make it clear that `notify=true` should **ALWAYS** be set for resources the agent creates (PRs, issues, comments), even if the task is complete. This ensures agents receive notifications when others respond to those resources.

## Problem

The previous wording suggested `notify=true` was only for resources "expecting follow-up", which led agents to incorrectly use `notify=false` for issues they created. Agents interpreted "expect follow-up" as meaning the agent itself expects to do more work, rather than others may respond.

## Solution

Changed the prompt from:
> "When creating links with xagent:create_link, set notify=true for any resource you create (PRs, issues, comments). Expect follow-up instructions and comments. Only use notify=false for reference links that don't need monitoring."

To:
> "When creating links with xagent:create_link, ALWAYS set notify=true for resources you create (PRs, issues, comments), even if the task is complete. Others may respond and you'll need to handle those responses. Only use notify=false for reference links to external resources you didn't create."