### PR TITLE
Use Opus 4.5 model for agent

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -52,6 +52,7 @@ func (a *Agent) Prompt(ctx context.Context, prompt string) error {
 		"--verbose",
 		"--output-format", "stream-json",
 		"--strict-mcp-config",
+		"--model", "opus",
 	}
 
 	// Add MCP config if present


### PR DESCRIPTION
Updates the agent to use Claude Opus 4.5 by adding the --model opus flag to the Claude Code CLI invocation in internal/agent/agent.go.