### PR TITLE
Improve MCP tests to use actual MCP server/client

### DIFF
--- a/internal/xmcp/xmcp_test.go
+++ b/internal/xmcp/xmcp_test.go
@@ -21,12 +21,12 @@ func setupTestSession(t *testing.T, srv *Server) *mcp.ClientSession {
 	clientTransport, serverTransport := mcp.NewInMemoryTransports()
 
 	// Connect server
-	_, err := mcpServer.Connect(context.Background(), serverTransport, nil)
+	_, err := mcpServer.Connect(t.Context(), serverTransport, nil)
 	assert.NilError(t, err)
 
 	// Create and connect client
 	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
-	clientSession, err := mcpClient.Connect(context.Background(), clientTransport, nil)
+	clientSession, err := mcpClient.Connect(t.Context(), clientTransport, nil)
 	assert.NilError(t, err)
 	t.Cleanup(func() { clientSession.Close() })
 
@@ -53,7 +53,7 @@ func TestGetMyTask(t *testing.T) {
 	session := setupTestSession(t, srv)
 
 	// Call the tool through the MCP framework
-	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+	result, err := session.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "get_my_task",
 		Arguments: map[string]any{},
 	})


### PR DESCRIPTION
## Summary
- Updated MCP tests to use actual mcp.Server and mcp.Client instead of directly calling unexported methods
- Added TestToolSchemas to verify all tools are properly registered with schemas
- Tests now validate the entire MCP integration path including JSON schema tag generation

## Changes
The previous test bypassed the MCP framework by directly calling the unexported `getMyTask` method. This meant it couldn't catch bugs with:
- Incorrect or missing `jsonschema` struct tags
- Tool registration issues
- Schema generation problems

The updated test:
1. Creates a real `mcp.Server` instance
2. Registers tools via `AddTools()` (which generates schemas from struct tags)
3. Uses in-memory transports to connect client and server
4. Calls tools through the MCP client's `CallTool()` method
5. Validates tool registration and schema generation with a new `TestToolSchemas` test

This ensures the tests validate the actual behavior that clients will experience.

## Test Plan
- [x] Ran `go test ./internal/xmcp -v` - all tests pass
- [x] Ran `go test ./...` - all tests pass