### PR TITLE
Prevent editing archived child tasks via MCP

### DIFF
--- a/internal/xmcp/xmcp.go
+++ b/internal/xmcp/xmcp.go
@@ -262,6 +262,9 @@ func (s *Server) updateChildTask(ctx context.Context, req *mcp.CallToolRequest, 
 	if childResp.Task.Parent != s.taskID {
 		return errorResult("task is not a child of the current task"), nil, nil
 	}
+	if childResp.Task.Status == "archived" {
+		return errorResult("cannot update archived task"), nil, nil
+	}
 
 	_, err = s.client.UpdateTask(ctx, &xagentv1.UpdateTaskRequest{
 		Id:     input.TaskID,

--- a/internal/xmcp/xmcp_test.go
+++ b/internal/xmcp/xmcp_test.go
@@ -70,6 +70,41 @@ func TestGetMyTask(t *testing.T) {
 	})
 }
 
+func TestUpdateChildTask_ArchivedTask(t *testing.T) {
+	parentTaskID := int64(123)
+	childTaskID := int64(456)
+
+	client := &ClientMock{
+		GetTaskFunc: func(ctx context.Context, req *xagentv1.GetTaskRequest) (*xagentv1.GetTaskResponse, error) {
+			assert.Equal(t, req.Id, childTaskID)
+			return &xagentv1.GetTaskResponse{
+				Task: &xagentv1.Task{
+					Id:     childTaskID,
+					Parent: parentTaskID,
+					Status: "archived",
+				},
+			}, nil
+		},
+	}
+
+	srv := NewServer(client, parentTaskID, "test-workspace")
+	session := setupTestSession(t, srv)
+
+	result, err := session.CallTool(t.Context(), &mcp.CallToolParams{
+		Name: "update_child_task",
+		Arguments: map[string]any{
+			"task_id":     float64(childTaskID),
+			"instruction": "do something",
+		},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, result.IsError, "expected error result")
+
+	text, ok := result.Content[0].(*mcp.TextContent)
+	assert.Assert(t, ok, "expected TextContent")
+	assert.Assert(t, text.Text == "cannot update archived task", "expected archived error message, got: %s", text.Text)
+}
+
 func assertTextResult(t *testing.T, result *mcp.CallToolResult, want map[string]any) {
 	t.Helper()
 	assert.Assert(t, result != nil, "CallTool returned nil result")


### PR DESCRIPTION
## Summary

- Adds a check in `updateChildTask` MCP tool to reject updates to archived child tasks
- Returns an error "cannot update archived task" when attempting to update a child task with status "archived"
- Includes a unit test to verify the behavior

## Test plan

- [x] Unit tests pass (`go test ./internal/xmcp/...`)
- [x] All existing tests continue to pass (`go test ./...`)