### PR TITLE
Hide child tasks in task list by default

### DIFF
--- a/internal/proto/xagent/v1/xagent.pb.go
+++ b/internal/proto/xagent/v1/xagent.pb.go
@@ -243,10 +243,11 @@ func (x *McpServer) GetEnv() map[string]string {
 }
 
 type ListTasksRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Statuses      []string               `protobuf:"bytes,1,rep,name=statuses,proto3" json:"statuses,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Statuses        []string               `protobuf:"bytes,1,rep,name=statuses,proto3" json:"statuses,omitempty"`
+	IncludeChildren bool                   `protobuf:"varint,2,opt,name=include_children,json=includeChildren,proto3" json:"include_children,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ListTasksRequest) Reset() {
@@ -284,6 +285,13 @@ func (x *ListTasksRequest) GetStatuses() []string {
 		return x.Statuses
 	}
 	return nil
+}
+
+func (x *ListTasksRequest) GetIncludeChildren() bool {
+	if x != nil {
+		return x.IncludeChildren
+	}
+	return false
 }
 
 type ListTasksResponse struct {
@@ -2424,9 +2432,10 @@ const file_xagent_v1_xagent_proto_rawDesc = "" +
 	"\x03env\x18\x04 \x03(\v2\x1d.xagent.v1.McpServer.EnvEntryR\x03env\x1a6\n" +
 	"\bEnvEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\".\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"Y\n" +
 	"\x10ListTasksRequest\x12\x1a\n" +
-	"\bstatuses\x18\x01 \x03(\tR\bstatuses\":\n" +
+	"\bstatuses\x18\x01 \x03(\tR\bstatuses\x12)\n" +
+	"\x10include_children\x18\x02 \x01(\bR\x0fincludeChildren\":\n" +
 	"\x11ListTasksResponse\x12%\n" +
 	"\x05tasks\x18\x01 \x03(\v2\x0f.xagent.v1.TaskR\x05tasks\"4\n" +
 	"\x15ListChildTasksRequest\x12\x1b\n" +

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -78,9 +78,9 @@ func (s *Server) ListTasks(ctx context.Context, req *xagentv1.ListTasksRequest) 
 		for i, s := range req.Statuses {
 			statuses[i] = store.TaskStatus(s)
 		}
-		tasks, err = s.tasks.ListByStatuses(statuses)
+		tasks, err = s.tasks.ListByStatuses(statuses, req.IncludeChildren)
 	} else {
-		tasks, err = s.tasks.List()
+		tasks, err = s.tasks.List(req.IncludeChildren)
 	}
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -91,6 +91,12 @@
 
     <div class="card" id="task-card">
         <h2>Tasks</h2>
+        <div style="margin-bottom: 10px;">
+            <label>
+                <input type="checkbox" id="show-children" {{if .ShowChildren}}checked{{end}}>
+                Show child tasks
+            </label>
+        </div>
         <table>
             <thead>
                 <tr>
@@ -117,8 +123,13 @@
             return resp.json();
         }
 
+        function getShowChildren() {
+            return document.getElementById('show-children').checked;
+        }
+
         async function refreshTaskList() {
-            const resp = await fetch('/ui/tasks/list');
+            const showChildren = getShowChildren();
+            const resp = await fetch('/ui/tasks/list?children=' + showChildren);
             document.getElementById('task-list').innerHTML = await resp.text();
         }
 
@@ -131,6 +142,17 @@
                 instructions: [{text: form.prompt.value}]
             });
             form.reset();
+            refreshTaskList();
+        });
+
+        document.getElementById('show-children').addEventListener('change', (e) => {
+            const url = new URL(window.location);
+            if (e.target.checked) {
+                url.searchParams.set('children', 'true');
+            } else {
+                url.searchParams.delete('children');
+            }
+            window.history.replaceState({}, '', url);
             refreshTaskList();
         });
 

--- a/internal/server/ui.go
+++ b/internal/server/ui.go
@@ -24,14 +24,17 @@ var templates = template.Must(
 )
 
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
-	tasks, _ := s.tasks.List()
+	showChildren := r.URL.Query().Get("children") == "true"
+	tasks, _ := s.tasks.List(showChildren)
 	templates.ExecuteTemplate(w, "index.html", map[string]any{
-		"Tasks": tasks,
+		"Tasks":        tasks,
+		"ShowChildren": showChildren,
 	})
 }
 
 func (s *Server) handleTaskList(w http.ResponseWriter, r *http.Request) {
-	tasks, _ := s.tasks.List()
+	showChildren := r.URL.Query().Get("children") == "true"
+	tasks, _ := s.tasks.List(showChildren)
 	templates.ExecuteTemplate(w, "task-list.html", map[string]any{
 		"Tasks": tasks,
 	})

--- a/internal/store/task.go
+++ b/internal/store/task.go
@@ -77,11 +77,15 @@ func (r *TaskRepository) Get(id int64) (*Task, error) {
 	return r.scanTask(row)
 }
 
-func (r *TaskRepository) List() ([]*Task, error) {
-	rows, err := r.db.Query(`
+func (r *TaskRepository) List(includeChildren bool) ([]*Task, error) {
+	query := `
 		SELECT id, name, parent, workspace, prompts, status, created_at, updated_at
-		FROM tasks WHERE status != 'archived' ORDER BY created_at DESC
-	`)
+		FROM tasks WHERE status != 'archived'`
+	if !includeChildren {
+		query += ` AND parent = 0`
+	}
+	query += ` ORDER BY created_at DESC`
+	rows, err := r.db.Query(query)
 	if err != nil {
 		return nil, err
 	}
@@ -90,9 +94,9 @@ func (r *TaskRepository) List() ([]*Task, error) {
 	return r.scanTasks(rows)
 }
 
-func (r *TaskRepository) ListByStatuses(statuses []TaskStatus) ([]*Task, error) {
+func (r *TaskRepository) ListByStatuses(statuses []TaskStatus, includeChildren bool) ([]*Task, error) {
 	if len(statuses) == 0 {
-		return r.List()
+		return r.List(includeChildren)
 	}
 	placeholders := make([]string, len(statuses))
 	args := make([]any, len(statuses))
@@ -102,8 +106,11 @@ func (r *TaskRepository) ListByStatuses(statuses []TaskStatus) ([]*Task, error) 
 	}
 	query := fmt.Sprintf(`
 		SELECT id, name, parent, workspace, prompts, status, created_at, updated_at
-		FROM tasks WHERE status IN (%s) ORDER BY created_at DESC
-	`, strings.Join(placeholders, ","))
+		FROM tasks WHERE status IN (%s)`, strings.Join(placeholders, ","))
+	if !includeChildren {
+		query += ` AND parent = 0`
+	}
+	query += ` ORDER BY created_at DESC`
 	rows, err := r.db.Query(query, args...)
 	if err != nil {
 		return nil, err

--- a/proto/xagent/v1/xagent.proto
+++ b/proto/xagent/v1/xagent.proto
@@ -55,6 +55,7 @@ message McpServer {
 
 message ListTasksRequest {
   repeated string statuses = 1;
+  bool include_children = 2;
 }
 
 message ListTasksResponse {


### PR DESCRIPTION
## Summary
- Add `include_children` filter to task list endpoints in store and proto
- By default, only top-level tasks (parent=0) are shown in the task list
- Add a "Show child tasks" checkbox in the frontend to toggle visibility

## Changes
- `internal/store/task.go`: Add `includeChildren` parameter to `List()` and `ListByStatuses()` methods
- `proto/xagent/v1/xagent.proto`: Add `include_children` field to `ListTasksRequest`
- `internal/server/server.go`: Pass `req.IncludeChildren` to store methods
- `internal/server/ui.go`: Read `children` query parameter and pass to store
- `internal/server/templates/index.html`: Add checkbox UI control to toggle child task visibility

## Test plan
- [ ] Verify task list only shows top-level tasks by default
- [ ] Verify "Show child tasks" checkbox shows child tasks when checked
- [ ] Verify checkbox state persists via URL query parameter
- [ ] Verify auto-refresh respects the filter setting