### PR TITLE
Hide child tasks in task list by default

### DIFF
--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -69,6 +69,7 @@
         .nav { margin-bottom: 20px; }
         .nav a { margin-right: 15px; }
         #task-card:not(:has(#task-list tr)) { display: none; }
+        #task-list:not(.show-children) .child-task { display: none; }
     </style>
 </head>
 <body>
@@ -91,6 +92,12 @@
 
     <div class="card" id="task-card">
         <h2>Tasks</h2>
+        <div style="margin-bottom: 10px;">
+            <label>
+                <input type="checkbox" id="show-children">
+                Show child tasks
+            </label>
+        </div>
         <table>
             <thead>
                 <tr>
@@ -132,6 +139,10 @@
             });
             form.reset();
             refreshTaskList();
+        });
+
+        document.getElementById('show-children').addEventListener('change', (e) => {
+            document.getElementById('task-list').classList.toggle('show-children', e.target.checked);
         });
 
         setInterval(refreshTaskList, 5000);

--- a/internal/server/templates/task-row.html
+++ b/internal/server/templates/task-row.html
@@ -1,4 +1,4 @@
-<tr>
+<tr{{if .Parent}} class="child-task"{{end}}>
     <td><a href="/ui/tasks/{{.ID}}">{{if .Name}}{{.Name}}{{else}}<code>{{.ID}}</code>{{end}}</a></td>
     <td>{{.Workspace}}</td>
     <td><span class="status status-{{.Status}}">{{.Status}}</span></td>


### PR DESCRIPTION
## Summary
- Hide child tasks from the task list by default using CSS
- Add "Show child tasks" checkbox to toggle visibility

## Changes
- `task-row.html`: Add `child-task` CSS class to rows with a parent
- `index.html`: Add CSS rule to hide `.child-task` rows by default
- `index.html`: Add checkbox to toggle `show-children` class on task list

## Test plan
- [ ] Verify child tasks are hidden by default
- [ ] Verify checking "Show child tasks" reveals child tasks
- [ ] Verify state persists across task list refreshes (while checkbox is checked)