### PR TITLE
Fix child tasks button alignment

### DIFF
--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -91,9 +91,9 @@
     </div>
 
     <div class="card" id="task-card">
-        <h2>Tasks</h2>
-        <div style="margin-bottom: 10px;">
-            <label>
+        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <h2 style="margin: 0;">Tasks</h2>
+            <label style="font-size: 14px; color: #666; cursor: pointer;">
                 <input type="checkbox" id="show-children">
                 Show child tasks
             </label>


### PR DESCRIPTION
## Summary

- Move the "Show child tasks" checkbox from below the Tasks heading to be inline with the heading on the right side
- Use flexbox with `justify-content: space-between` to align the heading on the left and checkbox on the right
- Add subtle styling (smaller font, muted color) to the checkbox label for visual hierarchy

## Before/After

Before: The checkbox was in the middle of the card below the "Tasks" heading.

After: The checkbox is positioned in the top right of the card, aligned with the "Tasks" heading.