### PR TITLE
Move child tasks label to the left of checkbox

### DIFF
--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -93,9 +93,9 @@
     <div class="card" id="task-card">
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
             <h2 style="margin: 0;">Tasks</h2>
-            <label style="font-size: 14px; color: #666; cursor: pointer;">
-                <input type="checkbox" id="show-children">
+            <label style="font-size: 14px; color: #666; cursor: pointer; display: flex; align-items: center; gap: 6px;">
                 Show child tasks
+                <input type="checkbox" id="show-children">
             </label>
         </div>
         <table>


### PR DESCRIPTION
Move the "Show child tasks" label to appear on the left side of the checkbox instead of the right.

Changed the label element to use flexbox layout with `display: flex; align-items: center; gap: 6px` and moved the text before the checkbox input.