### PR TITLE
Skip archived tasks when processing events

### DIFF
--- a/internal/server/event_test.go
+++ b/internal/server/event_test.go
@@ -497,3 +497,86 @@ func TestProcessEventDeduplicatesTasks(t *testing.T) {
 	assert.Equal(t, len(processResp.TaskIds), 1)
 	assert.Equal(t, processResp.TaskIds[0], task.Task.Id)
 }
+
+func TestProcessEventSkipsArchivedTasks(t *testing.T) {
+	// Arrange
+	srv := setupTestServer(t)
+	ctx := context.Background()
+
+	// Create two tasks with links to the same URL with notify=true
+	activeTask, err := srv.CreateTask(ctx, &xagentv1.CreateTaskRequest{
+		Name:      "Active Task",
+		Workspace: "test-workspace",
+	})
+	assert.NilError(t, err)
+
+	archivedTask, err := srv.CreateTask(ctx, &xagentv1.CreateTaskRequest{
+		Name:      "Archived Task",
+		Workspace: "test-workspace",
+	})
+	assert.NilError(t, err)
+
+	// Archive the second task
+	_, err = srv.UpdateTask(ctx, &xagentv1.UpdateTaskRequest{
+		Id:     archivedTask.Task.Id,
+		Status: "archived",
+	})
+	assert.NilError(t, err)
+
+	// Create links with notify=true for both tasks
+	_, err = srv.CreateLink(ctx, &xagentv1.CreateLinkRequest{
+		TaskId:    activeTask.Task.Id,
+		Url:       "https://github.com/example/repo/pull/123",
+		Relevance: "PR to monitor",
+		Notify:    true,
+	})
+	assert.NilError(t, err)
+
+	_, err = srv.CreateLink(ctx, &xagentv1.CreateLinkRequest{
+		TaskId:    archivedTask.Task.Id,
+		Url:       "https://github.com/example/repo/pull/123",
+		Relevance: "PR to monitor",
+		Notify:    true,
+	})
+	assert.NilError(t, err)
+
+	// Create an event with matching URL
+	eventResp, err := srv.CreateEvent(ctx, &xagentv1.CreateEventRequest{
+		Description: "PR comment added",
+		Data:        `{"comment": "Please review"}`,
+		Url:         "https://github.com/example/repo/pull/123",
+	})
+	assert.NilError(t, err)
+
+	// Act
+	processResp, err := srv.ProcessEvent(ctx, &xagentv1.ProcessEventRequest{
+		Id: eventResp.Event.Id,
+	})
+
+	// Assert - should only route to the active task, not the archived one
+	assert.NilError(t, err)
+	assert.Equal(t, len(processResp.TaskIds), 1)
+	assert.Equal(t, processResp.TaskIds[0], activeTask.Task.Id)
+
+	// Verify active task received the event and was set to restarting
+	events1, err := srv.ListEventsByTask(ctx, &xagentv1.ListEventsByTaskRequest{
+		TaskId: activeTask.Task.Id,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(events1.Events), 1)
+
+	getActiveTask, err := srv.GetTask(ctx, &xagentv1.GetTaskRequest{Id: activeTask.Task.Id})
+	assert.NilError(t, err)
+	assert.Equal(t, getActiveTask.Task.Status, "restarting")
+
+	// Verify archived task did NOT receive the event and remains archived
+	events2, err := srv.ListEventsByTask(ctx, &xagentv1.ListEventsByTaskRequest{
+		TaskId: archivedTask.Task.Id,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(events2.Events), 0)
+
+	getArchivedTask, err := srv.GetTask(ctx, &xagentv1.GetTaskRequest{Id: archivedTask.Task.Id})
+	assert.NilError(t, err)
+	assert.Equal(t, getArchivedTask.Task.Status, "archived")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -422,6 +422,16 @@ func (s *Server) ProcessEvent(ctx context.Context, req *xagentv1.ProcessEventReq
 		if !link.Notify || taskIDs[link.TaskID] {
 			continue
 		}
+		// Skip archived tasks
+		task, err := s.tasks.Get(link.TaskID)
+		if err != nil {
+			s.log.Warn("failed to get task", "task_id", link.TaskID, "error", err)
+			continue
+		}
+		if task.Status == store.TaskStatusArchived {
+			s.log.Info("skipping archived task", "task_id", link.TaskID)
+			continue
+		}
 		taskIDs[link.TaskID] = true
 		if err := s.events.AddTask(req.Id, link.TaskID); err != nil {
 			s.log.Warn("failed to add event task", "event_id", req.Id, "task_id", link.TaskID, "error", err)


### PR DESCRIPTION
## Summary

- When `ProcessEvent` routes an event to tasks with matching notify links, it now checks if each task is archived before restarting it
- Archived tasks are skipped with an info log message
- This prevents archived tasks from being inadvertently restarted by incoming events

## Test plan

- [x] Added `TestProcessEventSkipsArchivedTasks` test case
- [x] All existing `ProcessEvent` tests continue to pass
- [x] All server tests pass