### PR TITLE
Rename 'Show child tasks' label to 'children'

### DIFF
--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -94,7 +94,7 @@
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
             <h2 style="margin: 0;">Tasks</h2>
             <label style="font-size: 14px; color: #666; cursor: pointer; display: flex; align-items: center; gap: 6px;">
-                Show child tasks
+                children
                 <input type="checkbox" id="show-children">
             </label>
         </div>


### PR DESCRIPTION
The "Show child tasks" label was displaying with each word stacked on top of each other. Shortened the label to just "children" for better display.