### PR TITLE
Improve task instructions UI layout

### DIFF
--- a/internal/server/templates/task-detail.html
+++ b/internal/server/templates/task-detail.html
@@ -19,13 +19,14 @@
 <p><strong>Created:</strong> {{.Task.CreatedAt.Format "2006-01-02 15:04:05"}}</p>
 
 <h3>Instructions</h3>
-<ul>
+<div class="instructions-list">
 {{range .Task.Instructions}}
-    <li>
-        {{if .URL}}<a href="{{.URL}}" target="_blank">{{.Text}}</a>{{else}}{{.Text}}{{end}}
-    </li>
+    <div class="instruction-card">
+        <div class="instruction-text">{{.Text}}</div>
+        {{if .URL}}<a href="{{.URL}}" target="_blank" class="instruction-link">{{.URL}}</a>{{end}}
+    </div>
 {{end}}
-</ul>
+</div>
 
 {{if .Links}}
 <h3>Links</h3>

--- a/internal/server/templates/task-page.html
+++ b/internal/server/templates/task-page.html
@@ -81,6 +81,27 @@
         a { color: #2563eb; text-decoration: none; }
         a:hover { text-decoration: underline; }
         .back-link { margin-bottom: 20px; display: inline-block; }
+        .instructions-list { display: flex; flex-direction: column; gap: 12px; }
+        .instruction-card {
+            background: #f8fafc;
+            border: 1px solid #e2e8f0;
+            border-radius: 6px;
+            padding: 12px 16px;
+        }
+        .instruction-text {
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            line-height: 1.5;
+            color: #1e293b;
+        }
+        .instruction-link {
+            display: inline-block;
+            margin-top: 8px;
+            font-size: 13px;
+            color: #64748b;
+            word-break: break-all;
+        }
+        .instruction-link:hover { color: #2563eb; }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

Replace unordered list with card-based layout for better readability of task instructions:

- Display each instruction in a separate card with proper text wrapping
- Show URL as a separate link below the instruction text instead of wrapping the entire text in a link
- Add `pre-wrap` whitespace handling for long instruction text  
- Use subtle background color and borders for visual separation between instructions

## Before

Instructions were displayed as a simple `<ul>` list where the entire text became a clickable link when a URL was present. Long text was difficult to read.

## After

Instructions are now displayed in individual cards with:
- Proper text formatting with `pre-wrap` for preserving line breaks
- URL displayed as a separate muted link below the text
- Clear visual separation between multiple instructions