### PR TITLE
Move links section above instructions in task detail view

### DIFF
--- a/internal/server/templates/task-detail.html
+++ b/internal/server/templates/task-detail.html
@@ -18,16 +18,6 @@
 <p><strong>Status:</strong> {{template "task-status.html" .Task}}</p>
 <p><strong>Created:</strong> {{.Task.CreatedAt.Format "2006-01-02 15:04:05"}}</p>
 
-<h3>Instructions</h3>
-<div class="instructions-list">
-{{range .Task.Instructions}}
-    <div class="instruction-card">
-        <div class="instruction-text">{{.Text}}</div>
-        {{if .URL}}<a href="{{.URL}}" target="_blank" class="instruction-link">{{.URL}}</a>{{end}}
-    </div>
-{{end}}
-</div>
-
 {{if .Links}}
 <h3>Links</h3>
 <ul class="task-links">
@@ -40,4 +30,14 @@
 {{end}}
 </ul>
 {{end}}
+
+<h3>Instructions</h3>
+<div class="instructions-list">
+{{range .Task.Instructions}}
+    <div class="instruction-card">
+        <div class="instruction-text">{{.Text}}</div>
+        {{if .URL}}<a href="{{.URL}}" target="_blank" class="instruction-link">{{.URL}}</a>{{end}}
+    </div>
+{{end}}
+</div>
 


### PR DESCRIPTION
## Summary
- Reorders the task detail view to display Links section before Instructions section
- This makes links more visible at the top of the task information

## Test plan
- [ ] Open a task detail page with both links and instructions
- [ ] Verify that the Links section appears above the Instructions section