### PR TITLE
Update cdl workspace to set correct origin URL after local clone

### DIFF
--- a/workspaces.yaml
+++ b/workspaces.yaml
@@ -34,6 +34,7 @@ workspaces:
   cdl:
     commands:
       - git clone --local /repo /home/vscode/cdl
+      - git -C /home/vscode/cdl remote set-url origin git@github.com:Compass-Digital-Engineering/core-eng-mono.git
       - git -C /home/vscode/cdl switch -c task-$XAGENT_TASK_ID
     container:
       image: containeragent


### PR DESCRIPTION
## Summary
- Add command to update origin URL to GitHub after local clone in cdl workspace
- The local clone from /repo has its origin set to the local path, which prevents pushing/creating PRs
- Now sets origin to git@github.com:Compass-Digital-Engineering/core-eng-mono.git

## Test plan
- Verify cdl workspace tasks can push and create PRs after this change