### PR TITLE
Fix cdl workspace cross-device link error

### DIFF
--- a/workspaces.yaml
+++ b/workspaces.yaml
@@ -33,7 +33,7 @@ workspaces:
 
   cdl:
     commands:
-      - git clone --local /repo /home/vscode/cdl
+      - git clone --no-hardlinks /repo /home/vscode/cdl
       - git -C /home/vscode/cdl remote set-url origin git@github.com:Compass-Digital-Engineering/core-eng-mono.git
       - git -C /home/vscode/cdl switch -c task-$XAGENT_TASK_ID
     container:


### PR DESCRIPTION
## Summary

- Replace `--local` with `--no-hardlinks` for the git clone command in the cdl workspace
- The `--local` flag attempts to create hardlinks which fails when cloning from a mounted volume to the container filesystem
- `--no-hardlinks` forces git to copy objects instead, which works across filesystem boundaries

## Problem

When starting the cdl workspace, git clone fails with:
```
fatal: failed to create link '/home/vscode/cdl/.git/objects/...': Invalid cross-device link
```

This happens because `/repo` is mounted from the host while `/home/vscode/cdl` is on the container's filesystem, and hardlinks cannot span across different filesystems.