### PR TITLE
Fix children checkbox not applying after page refresh

### DIFF
--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -124,9 +124,15 @@
             return resp.json();
         }
 
+        function syncChildrenCheckbox() {
+            const checked = document.getElementById('show-children').checked;
+            document.getElementById('task-list').classList.toggle('show-children', checked);
+        }
+
         async function refreshTaskList() {
             const resp = await fetch('/ui/tasks/list');
             document.getElementById('task-list').innerHTML = await resp.text();
+            syncChildrenCheckbox();
         }
 
         document.getElementById('create-form').addEventListener('submit', async (e) => {
@@ -141,10 +147,9 @@
             refreshTaskList();
         });
 
-        document.getElementById('show-children').addEventListener('change', (e) => {
-            document.getElementById('task-list').classList.toggle('show-children', e.target.checked);
-        });
+        document.getElementById('show-children').addEventListener('change', syncChildrenCheckbox);
 
+        syncChildrenCheckbox();
         setInterval(refreshTaskList, 5000);
     </script>
 </body>


### PR DESCRIPTION
## Summary

- Fix bug where children checkbox state was not being synced to the CSS class after page refresh
- If browser restored checkbox as checked (via autofill), the `show-children` class wasn't applied, so child tasks remained hidden

## Changes

Extract `syncChildrenCheckbox()` function and call it:
- On page load (handles browser autofill)
- After `refreshTaskList()` replaces the task list HTML
- On checkbox change events