### PR TITLE
Add --notify flag to runner for system notifications

### DIFF
--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -47,6 +47,10 @@ var RunnerCommand = &cli.Command{
 			Usage: "Maximum number of concurrent tasks (0 for unlimited)",
 			Value: 0,
 		},
+		&cli.BoolFlag{
+			Name:  "notify",
+			Usage: "Send system notification when a task finishes",
+		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		serverAddr := cmd.String("server")
@@ -55,6 +59,7 @@ var RunnerCommand = &cli.Command{
 		prebuiltDir := cmd.String("prebuilt")
 		debug := cmd.Bool("debug")
 		concurrency := cmd.Int("concurrency")
+		notifyFlag := cmd.Bool("notify")
 
 		workspaces, err := workspace.LoadConfig(configPath, nil)
 		if err != nil {
@@ -67,6 +72,7 @@ var RunnerCommand = &cli.Command{
 			Workspaces:  workspaces,
 			Debug:       debug,
 			Concurrency: int(concurrency),
+			Notify:      notifyFlag,
 		})
 		if err != nil {
 			return err

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,44 @@
+package notify
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// Send sends a system notification with the given title and message.
+// It uses platform-specific commands:
+// - Linux: notify-send
+// - macOS: osascript
+// - Windows: powershell
+func Send(title, message string) error {
+	switch runtime.GOOS {
+	case "linux":
+		return exec.Command("notify-send", title, message).Run()
+	case "darwin":
+		script := fmt.Sprintf(`display notification %q with title %q`, message, title)
+		return exec.Command("osascript", "-e", script).Run()
+	case "windows":
+		script := fmt.Sprintf(`
+[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+[Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime] | Out-Null
+$template = @"
+<toast>
+    <visual>
+        <binding template="ToastText02">
+            <text id="1">%s</text>
+            <text id="2">%s</text>
+        </binding>
+    </visual>
+</toast>
+"@
+$xml = New-Object Windows.Data.Xml.Dom.XmlDocument
+$xml.LoadXml($template)
+$toast = [Windows.UI.Notifications.ToastNotification]::new($xml)
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("xagent").Show($toast)
+`, title, message)
+		return exec.Command("powershell", "-Command", script).Run()
+	default:
+		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/icholy/xagent/internal/agent"
+	"github.com/icholy/xagent/internal/notify"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/workspace"
 	"github.com/icholy/xagent/internal/xagentclient"
@@ -34,6 +35,7 @@ type Runner struct {
 	workspaces   *workspace.Config
 	debug        bool
 	concurrency  int
+	notify       bool
 	runningCount atomic.Int32
 }
 
@@ -43,6 +45,7 @@ type Options struct {
 	Workspaces  *workspace.Config
 	Debug       bool
 	Concurrency int
+	Notify      bool
 }
 
 func New(opts Options) (*Runner, error) {
@@ -67,6 +70,7 @@ func New(opts Options) (*Runner, error) {
 		workspaces:  opts.Workspaces,
 		debug:       opts.Debug,
 		concurrency: opts.Concurrency,
+		notify:      opts.Notify,
 	}, nil
 }
 
@@ -484,11 +488,21 @@ func (r *Runner) Monitor(ctx context.Context) error {
 				if _, err := r.client.UpdateTask(ctx, &xagentv1.UpdateTaskRequest{Id: taskID, Status: "completed"}); err != nil {
 					slog.Error("failed to update task status", "task", taskID, "error", err)
 				}
+				if r.notify {
+					if err := notify.Send("xagent", fmt.Sprintf("Task %d completed", taskID)); err != nil {
+						slog.Error("failed to send notification", "task", taskID, "error", err)
+					}
+				}
 			} else {
 				slog.Error("container exited with error", "task", taskID, "exitCode", exitCode)
 				r.log(ctx, taskID, "error", fmt.Sprintf("container exited with code %s", exitCode))
 				if _, err := r.client.UpdateTask(ctx, &xagentv1.UpdateTaskRequest{Id: taskID, Status: "failed"}); err != nil {
 					slog.Error("failed to update task status", "task", taskID, "error", err)
+				}
+				if r.notify {
+					if err := notify.Send("xagent", fmt.Sprintf("Task %d failed (exit code %s)", taskID, exitCode)); err != nil {
+						slog.Error("failed to send notification", "task", taskID, "error", err)
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary
- Add `--notify` flag to the runner command
- When enabled, sends system notifications when tasks complete or fail
- Cross-platform support: uses `notify-send` on Linux, `osascript` on macOS, and PowerShell toast notifications on Windows

## Test plan
- [ ] Run the runner with `--notify` flag
- [ ] Complete a task and verify notification appears
- [ ] Fail a task and verify notification appears with exit code