### PR TITLE
Add -autoprune flag to runner

### DIFF
--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -51,6 +51,10 @@ var RunnerCommand = &cli.Command{
 			Name:  "notify",
 			Usage: "Send system notification when a task finishes",
 		},
+		&cli.BoolFlag{
+			Name:  "autoprune",
+			Usage: "Automatically remove containers for archived tasks",
+		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		serverAddr := cmd.String("server")
@@ -60,6 +64,7 @@ var RunnerCommand = &cli.Command{
 		debug := cmd.Bool("debug")
 		concurrency := cmd.Int("concurrency")
 		notifyFlag := cmd.Bool("notify")
+		autoprune := cmd.Bool("autoprune")
 
 		workspaces, err := workspace.LoadConfig(configPath, nil)
 		if err != nil {
@@ -92,6 +97,22 @@ var RunnerCommand = &cli.Command{
 				time.Sleep(time.Second)
 			}
 		}()
+
+		// Start autoprune goroutine if enabled
+		if autoprune {
+			go func() {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-time.After(pollInterval):
+						if err := r.Prune(ctx); err != nil {
+							slog.Error("failed to prune containers", "error", err)
+						}
+					}
+				}
+			}()
+		}
 
 		// Reconcile any tasks that were running when the runner was stopped
 		if err := r.Reconcile(ctx); err != nil {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -525,3 +525,50 @@ func (r *Runner) Monitor(ctx context.Context) error {
 		}
 	}
 }
+
+// Prune removes containers for archived tasks.
+func (r *Runner) Prune(ctx context.Context) error {
+	// List all stopped xagent containers
+	containers, err := r.docker.ContainerList(ctx, container.ListOptions{
+		All: true,
+		Filters: filters.NewArgs(
+			filters.Arg("label", "xagent=true"),
+			filters.Arg("status", "exited"),
+		),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list containers: %w", err)
+	}
+
+	// Check each container's task status and remove if archived
+	for _, c := range containers {
+		taskIDStr := c.Labels["xagent.task"]
+		if taskIDStr == "" {
+			continue
+		}
+
+		taskID, err := strconv.ParseInt(taskIDStr, 10, 64)
+		if err != nil {
+			slog.Error("invalid task ID in container label", "task", taskIDStr, "error", err)
+			continue
+		}
+
+		// Fetch task status
+		task, err := r.client.GetTask(ctx, &xagentv1.GetTaskRequest{Id: taskID})
+		if err != nil {
+			slog.Error("failed to get task", "task", taskID, "error", err)
+			continue
+		}
+
+		// Remove container if task is archived
+		if task.Task.Status == "archived" {
+			if err := r.docker.ContainerRemove(ctx, c.ID, container.RemoveOptions{Force: true}); err != nil {
+				slog.Error("failed to remove container", "task", taskID, "error", err)
+			} else {
+				slog.Info("container removed (task archived)", "task", taskID)
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `-autoprune` flag to the runner command
- When enabled, a background goroutine periodically removes containers for archived tasks
- Uses the same poll interval as the task poller
- Matches the behavior of `xagent prune` command but runs automatically

## Test plan
- [ ] Run the runner with `-autoprune` flag
- [ ] Create a task and let it complete
- [ ] Archive the task
- [ ] Verify the container is automatically removed after archival