### PR TITLE
Always clone master branch in cdl workspace

### DIFF
--- a/workspaces.yaml
+++ b/workspaces.yaml
@@ -33,7 +33,7 @@ workspaces:
 
   cdl:
     commands:
-      - git clone --no-hardlinks /repo /home/vscode/cdl
+      - git clone --no-hardlinks -b master /repo /home/vscode/cdl
       - git -C /home/vscode/cdl remote set-url origin git@github.com:Compass-Digital-Engineering/core-eng-mono.git
       - git -C /home/vscode/cdl switch -c task-$XAGENT_TASK_ID
     container:


### PR DESCRIPTION
## Summary

- Add `-b master` flag to the git clone command in the cdl workspace
- Ensures the master branch is always cloned regardless of which branch is checked out locally in `/repo`

## Changes

The cdl workspace uses a local mount (`/repo`) as the clone source. Without specifying a branch, `git clone` defaults to cloning whatever branch happens to be checked out in the source. This change explicitly specifies the master branch to ensure consistent behavior.