### PR TITLE
Fix repeated 'container restarting' log spam

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -117,7 +117,6 @@ func (r *Runner) Poll(ctx context.Context) error {
 				r.log(ctx, task.Id, "info", "task cancelled, container killed")
 			}
 		case "restarting":
-			r.log(ctx, task.Id, "info", "container restarting")
 			if err := r.killTask(ctx, task); err != nil {
 				slog.Error("failed to kill task for restart", "task", task.Id, "error", err)
 			}
@@ -125,6 +124,7 @@ func (r *Runner) Poll(ctx context.Context) error {
 				slog.Debug("concurrency limit reached, skipping restarting task", "task", task.Id, "running", r.runningCount.Load(), "limit", r.concurrency)
 				continue
 			}
+			r.log(ctx, task.Id, "info", "container restarting")
 			if err := r.startTask(ctx, task); err != nil {
 				slog.Error("failed to restart task", "task", task.Id, "error", err)
 				r.log(ctx, task.Id, "error", fmt.Sprintf("failed to restart task: %v", err))


### PR DESCRIPTION
## Summary

- Move the "container restarting" log message after the concurrency check

## Problem

When a task is in `restarting` status but the concurrency limit is reached, the runner logs "container restarting" on every poll cycle (every 5 seconds) without making progress. This can result in 100+ duplicate log entries.

## Solution

Move the log statement after the concurrency check so we only log when we're actually going to restart the container.

Fixes #44

## Test plan

- [x] Verify code compiles with `go build ./...`
- [x] Verify tests pass with `go test ./...`