### PR TITLE
Restrict xagent workspace to only create issues in icholy/xagent

### DIFF
--- a/workspaces.yaml
+++ b/workspaces.yaml
@@ -128,4 +128,7 @@ workspaces:
         - Do NOT mention yourself, Claude, or AI in commits/PRs
         - Keep commit messages focused on the technical changes only
 
+        IMPORTANT: When creating GitHub issues, you must ONLY create issues in the icholy/xagent repository.
+        Do NOT create issues in any other repository.
+
 


### PR DESCRIPTION
## Summary
- Updates the xagent workspace prompt to restrict GitHub issue creation to only the icholy/xagent repository
- Prevents agents working in the xagent workspace from creating issues in unrelated repositories

## Test plan
- [ ] Verify the new prompt instruction is included when the xagent workspace is used
- [ ] Test that agents receive the restriction message about only creating issues in icholy/xagent