### PR TITLE
Add main_branch option to workspace agent config

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -421,12 +421,19 @@ func (r *Runner) copyBinary(ctx context.Context, containerID, image string) erro
 func (r *Runner) copyConfig(ctx context.Context, containerID string, task *xagentv1.Task, ws *workspace.Workspace) error {
 	taskIDStr := strconv.FormatInt(task.Id, 10)
 
+	// Build commands list, prepending main branch checkout if configured
+	var commands []string
+	if ws.Agent.MainBranch != "" {
+		commands = append(commands, fmt.Sprintf("git checkout %s", ws.Agent.MainBranch))
+	}
+	commands = append(commands, ws.Commands...)
+
 	// Convert workspace to agent config format
 	cfg := agent.Config{
 		Cwd:        ws.Agent.Cwd,
 		Prompt:     ws.Agent.Prompt,
 		McpServers: make(map[string]agent.McpServer),
-		Commands:   ws.Commands,
+		Commands:   commands,
 	}
 
 	// Inject xagent MCP server for link creation

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -37,6 +37,7 @@ type Agent struct {
 	Cwd        string                     `yaml:"cwd"`
 	Prompt     string                     `yaml:"prompt"`
 	McpServers map[string]agent.McpServer `yaml:"mcp_servers"`
+	MainBranch string                     `yaml:"main_branch"`
 }
 
 func (w *Workspace) Validate() error {


### PR DESCRIPTION
## Summary

- Adds `main_branch` option to workspace agent configuration
- When configured, the runner prepends a git checkout command to setup commands
- Ensures the correct branch is checked out before Claude Code starts, fixing main branch detection

## Problem

Claude Code incorrectly detects the main branch when a feature branch is checked out at container startup. This causes agents to create PRs targeting the wrong branch.

## Solution

Add a `main_branch` option that automatically checks out the specified branch during container setup:

```yaml
workspaces:
  cdl:
    agent:
      main_branch: master
      cwd: /path/to/repo
```

## Test plan

- [ ] Configure a workspace with `main_branch: master`
- [ ] Start a task with a feature branch checked out in the mounted volume
- [ ] Verify Claude Code correctly identifies `master` as the main branch

Fixes #47