### PR TITLE
Set origin/HEAD to master in cdl workspace

### DIFF
--- a/workspaces.yaml
+++ b/workspaces.yaml
@@ -35,6 +35,7 @@ workspaces:
     commands:
       - git clone --no-hardlinks -b master /repo /home/vscode/cdl
       - git -C /home/vscode/cdl remote set-url origin git@github.com:Compass-Digital-Engineering/core-eng-mono.git
+      - git -C /home/vscode/cdl remote set-head origin master
       - git -C /home/vscode/cdl switch -c task-$XAGENT_TASK_ID
     container:
       image: containeragent


### PR DESCRIPTION
## Summary

- Adds `git remote set-head origin master` command to cdl workspace setup
- Ensures Claude Code correctly detects master as the main branch

## Problem

When cloning from a local repo where a feature branch is checked out, Claude Code incorrectly detects that feature branch as the main branch (because `origin/HEAD` isn't set). This causes agents to create PRs targeting the wrong branch.

## Solution

Explicitly set `origin/HEAD` to `master` after cloning, so Claude Code uses it for main branch detection.

Fixes #47