### PR TITLE
Add Driver interface for agent abstraction

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,13 +1,9 @@
 package agent
 
 import (
-	"bufio"
 	"cmp"
 	"context"
-	"encoding/json"
 	"log/slog"
-	"os"
-	"os/exec"
 )
 
 // Options contains configuration for creating an Agent.
@@ -18,113 +14,28 @@ type Options struct {
 	McpServers map[string]McpServer
 }
 
-// Agent manages Claude CLI interactions.
+// Agent manages agent interactions via a Driver.
 type Agent struct {
-	log        *slog.Logger
-	cwd        string
-	mcpServers map[string]McpServer
-	resume     bool
+	driver Driver
 }
 
-// Start creates and starts a new Agent.
+// Start creates and starts a new Agent with a ClaudeDriver.
 func Start(ctx context.Context, opts Options) (*Agent, error) {
-	log := cmp.Or(opts.Log, slog.Default())
-	return &Agent{
-		log:        log,
-		cwd:        cmp.Or(opts.Cwd, "."),
-		mcpServers: opts.McpServers,
-		resume:     opts.Resume,
-	}, nil
+	driver := NewClaudeDriver(ClaudeOptions{
+		Cwd:        cmp.Or(opts.Cwd, "."),
+		Log:        cmp.Or(opts.Log, slog.Default()),
+		Resume:     opts.Resume,
+		McpServers: opts.McpServers,
+	})
+	return &Agent{driver: driver}, nil
 }
 
 // Close shuts down the agent.
 func (a *Agent) Close() error {
-	return nil
+	return a.driver.Close()
 }
 
-// Prompt sends a prompt to Claude and waits for completion.
+// Prompt sends a prompt to the agent and waits for completion.
 func (a *Agent) Prompt(ctx context.Context, prompt string) error {
-	a.log.Info("sending prompt", "text", prompt)
-
-	args := []string{
-		"@anthropic-ai/claude-code",
-		"--dangerously-skip-permissions",
-		"--verbose",
-		"--output-format", "stream-json",
-		"--strict-mcp-config",
-		"--model", "opus",
-	}
-
-	// Add MCP config if present
-	if len(a.mcpServers) > 0 {
-		mcpConfig := map[string]any{"mcpServers": a.mcpServers}
-		mcpJSON, err := json.Marshal(mcpConfig)
-		if err != nil {
-			return err
-		}
-		args = append(args, "--mcp-config", string(mcpJSON))
-	}
-
-	// Session handling
-	if a.resume {
-		args = append(args, "--continue")
-	}
-	a.resume = true
-
-	args = append(args, "--print", prompt)
-
-	cmd := exec.CommandContext(ctx, "npx", args...)
-	cmd.Dir = a.cwd
-	cmd.Env = append(os.Environ(), "DISABLE_AUTOUPDATER=1")
-	cmd.Stderr = os.Stderr
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-
-	scanner := bufio.NewScanner(stdout)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if !a.handleStreamEvent(line) {
-			a.log.Info("output", "line", string(line))
-		}
-	}
-
-	return cmd.Wait()
-}
-
-func (a *Agent) handleStreamEvent(data []byte) bool {
-	var event struct {
-		Type    string `json:"type"`
-		Message struct {
-			Content []struct {
-				Type  string `json:"type"`
-				Text  string `json:"text"`
-				Name  string `json:"name"`
-				Input any    `json:"input"`
-			} `json:"content"`
-		} `json:"message"`
-	}
-	if err := json.Unmarshal(data, &event); err != nil {
-		return false
-	}
-	switch event.Type {
-	case "assistant":
-		for _, block := range event.Message.Content {
-			switch block.Type {
-			case "text":
-				if block.Text != "" {
-					a.log.Info("text", "content", block.Text)
-				}
-			case "tool_use":
-				a.log.Info("tool", "name", block.Name)
-			}
-		}
-	}
-	return true
+	return a.driver.Prompt(ctx, prompt)
 }

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -1,0 +1,129 @@
+package agent
+
+import (
+	"bufio"
+	"cmp"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"os/exec"
+)
+
+// ClaudeOptions contains configuration for creating a ClaudeDriver.
+type ClaudeOptions struct {
+	Cwd        string
+	Log        *slog.Logger
+	Resume     bool
+	McpServers map[string]McpServer
+}
+
+// ClaudeDriver implements Driver using Claude Code CLI.
+type ClaudeDriver struct {
+	log        *slog.Logger
+	cwd        string
+	mcpServers map[string]McpServer
+	resume     bool
+}
+
+// NewClaudeDriver creates a new ClaudeDriver.
+func NewClaudeDriver(opts ClaudeOptions) *ClaudeDriver {
+	return &ClaudeDriver{
+		log:        cmp.Or(opts.Log, slog.Default()),
+		cwd:        cmp.Or(opts.Cwd, "."),
+		mcpServers: opts.McpServers,
+		resume:     opts.Resume,
+	}
+}
+
+// Prompt sends a prompt to Claude and waits for completion.
+func (d *ClaudeDriver) Prompt(ctx context.Context, prompt string) error {
+	d.log.Info("sending prompt", "text", prompt)
+
+	args := []string{
+		"@anthropic-ai/claude-code",
+		"--dangerously-skip-permissions",
+		"--verbose",
+		"--output-format", "stream-json",
+		"--strict-mcp-config",
+		"--model", "opus",
+	}
+
+	// Add MCP config if present
+	if len(d.mcpServers) > 0 {
+		mcpConfig := map[string]any{"mcpServers": d.mcpServers}
+		mcpJSON, err := json.Marshal(mcpConfig)
+		if err != nil {
+			return err
+		}
+		args = append(args, "--mcp-config", string(mcpJSON))
+	}
+
+	// Session handling
+	if d.resume {
+		args = append(args, "--continue")
+	}
+	d.resume = true
+
+	args = append(args, "--print", prompt)
+
+	cmd := exec.CommandContext(ctx, "npx", args...)
+	cmd.Dir = d.cwd
+	cmd.Env = append(os.Environ(), "DISABLE_AUTOUPDATER=1")
+	cmd.Stderr = os.Stderr
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if !d.handleStreamEvent(line) {
+			d.log.Info("output", "line", string(line))
+		}
+	}
+
+	return cmd.Wait()
+}
+
+// Close releases any resources held by the driver.
+func (d *ClaudeDriver) Close() error {
+	return nil
+}
+
+func (d *ClaudeDriver) handleStreamEvent(data []byte) bool {
+	var event struct {
+		Type    string `json:"type"`
+		Message struct {
+			Content []struct {
+				Type  string `json:"type"`
+				Text  string `json:"text"`
+				Name  string `json:"name"`
+				Input any    `json:"input"`
+			} `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(data, &event); err != nil {
+		return false
+	}
+	switch event.Type {
+	case "assistant":
+		for _, block := range event.Message.Content {
+			switch block.Type {
+			case "text":
+				if block.Text != "" {
+					d.log.Info("text", "content", block.Text)
+				}
+			case "tool_use":
+				d.log.Info("tool", "name", block.Name)
+			}
+		}
+	}
+	return true
+}

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -1,0 +1,14 @@
+package agent
+
+import (
+	"context"
+)
+
+// Driver abstracts the underlying agent implementation (e.g., Claude Code, Cursor).
+type Driver interface {
+	// Prompt sends a prompt to the agent and waits for completion.
+	Prompt(ctx context.Context, prompt string) error
+
+	// Close releases any resources held by the driver.
+	Close() error
+}


### PR DESCRIPTION
## Summary

- Introduce a `Driver` interface that abstracts the underlying agent implementation
- Implement `ClaudeDriver` that wraps Claude Code CLI
- Update `Agent` to delegate to the `Driver` interface

This prepares the codebase for supporting multiple agent backends (e.g., Cursor) in the future.

## Changes

- **`driver.go`**: New file with `Driver` interface defining `Prompt` and `Close` methods
- **`claude.go`**: New file with `ClaudeDriver` implementation (extracted from original `agent.go`)
- **`agent.go`**: Simplified to delegate to `Driver`, making it backend-agnostic

## Test plan

- [x] Code compiles successfully
- [ ] Manual testing with existing Claude Code workflow