### PR TITLE
Add resume parameter to Driver.Prompt method

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -10,7 +10,6 @@ import (
 type Options struct {
 	Cwd        string
 	Log        *slog.Logger
-	Resume     bool
 	McpServers map[string]McpServer
 }
 
@@ -24,7 +23,6 @@ func Start(ctx context.Context, opts Options) (*Agent, error) {
 	driver := NewClaudeDriver(ClaudeOptions{
 		Cwd:        cmp.Or(opts.Cwd, "."),
 		Log:        cmp.Or(opts.Log, slog.Default()),
-		Resume:     opts.Resume,
 		McpServers: opts.McpServers,
 	})
 	return &Agent{driver: driver}, nil
@@ -36,6 +34,6 @@ func (a *Agent) Close() error {
 }
 
 // Prompt sends a prompt to the agent and waits for completion.
-func (a *Agent) Prompt(ctx context.Context, prompt string) error {
-	return a.driver.Prompt(ctx, prompt)
+func (a *Agent) Prompt(ctx context.Context, prompt string, resume bool) error {
+	return a.driver.Prompt(ctx, prompt, resume)
 }

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -14,7 +14,6 @@ import (
 type ClaudeOptions struct {
 	Cwd        string
 	Log        *slog.Logger
-	Resume     bool
 	McpServers map[string]McpServer
 }
 
@@ -23,7 +22,6 @@ type ClaudeDriver struct {
 	log        *slog.Logger
 	cwd        string
 	mcpServers map[string]McpServer
-	resume     bool
 }
 
 // NewClaudeDriver creates a new ClaudeDriver.
@@ -32,12 +30,11 @@ func NewClaudeDriver(opts ClaudeOptions) *ClaudeDriver {
 		log:        cmp.Or(opts.Log, slog.Default()),
 		cwd:        cmp.Or(opts.Cwd, "."),
 		mcpServers: opts.McpServers,
-		resume:     opts.Resume,
 	}
 }
 
 // Prompt sends a prompt to Claude and waits for completion.
-func (d *ClaudeDriver) Prompt(ctx context.Context, prompt string) error {
+func (d *ClaudeDriver) Prompt(ctx context.Context, prompt string, resume bool) error {
 	d.log.Info("sending prompt", "text", prompt)
 
 	args := []string{
@@ -59,11 +56,10 @@ func (d *ClaudeDriver) Prompt(ctx context.Context, prompt string) error {
 		args = append(args, "--mcp-config", string(mcpJSON))
 	}
 
-	// Session handling
-	if d.resume {
+	// Resume previous session if requested
+	if resume {
 		args = append(args, "--continue")
 	}
-	d.resume = true
 
 	args = append(args, "--print", prompt)
 

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -7,7 +7,8 @@ import (
 // Driver abstracts the underlying agent implementation (e.g., Claude Code, Cursor).
 type Driver interface {
 	// Prompt sends a prompt to the agent and waits for completion.
-	Prompt(ctx context.Context, prompt string) error
+	// If resume is true, the agent should continue from the previous session.
+	Prompt(ctx context.Context, prompt string, resume bool) error
 
 	// Close releases any resources held by the driver.
 	Close() error

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -66,7 +66,6 @@ var RunCommand = &cli.Command{
 		// Start agent
 		a, err := agent.Start(ctx, agent.Options{
 			Cwd:        os.ExpandEnv(cfg.Cwd),
-			Resume:     cfg.Started,
 			McpServers: cfg.McpServers,
 		})
 		if err != nil {
@@ -104,7 +103,7 @@ var RunCommand = &cli.Command{
 			prompt = prompt + "\n\n" + cfg.Prompt
 		}
 
-		if err := a.Prompt(ctx, prompt); err != nil {
+		if err := a.Prompt(ctx, prompt, cfg.Started); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
## Summary
- Move resume tracking from the Driver constructor to the Prompt method
- Allows callers to control session resumption per-call instead of per-driver instance
- Gives more flexibility for controlling when sessions should continue vs. start fresh

## Changes
- `Driver.Prompt(ctx, prompt)` → `Driver.Prompt(ctx, prompt, resume bool)`
- Remove `Resume` field from `Options`, `ClaudeOptions`, and `ClaudeDriver`
- Update `run.go` to pass `cfg.Started` as the resume parameter