### PR TITLE
Add GitHub Copilot CLI agent implementation

### DIFF
--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"os/exec"
+)
+
+// CopilotAgent implements Agent using GitHub Copilot CLI.
+type CopilotAgent struct {
+	log        *slog.Logger
+	cwd        string
+	mcpServers map[string]McpServer
+}
+
+// Prompt sends a prompt to Copilot and waits for completion.
+func (a *CopilotAgent) Prompt(ctx context.Context, prompt string, resume bool) error {
+	a.log.Info("sending prompt", "text", prompt)
+
+	args := []string{
+		"--silent",
+	}
+
+	// Add MCP config if present
+	if len(a.mcpServers) > 0 {
+		mcpConfig := map[string]any{"mcpServers": a.mcpServers}
+		mcpJSON, err := json.Marshal(mcpConfig)
+		if err != nil {
+			return err
+		}
+		args = append(args, "--additional-mcp-config", string(mcpJSON))
+	}
+
+	// Resume previous session if requested
+	if resume {
+		args = append(args, "--resume")
+	}
+
+	args = append(args, "-p", prompt)
+
+	cmd := exec.CommandContext(ctx, "copilot", args...)
+	cmd.Dir = a.cwd
+	cmd.Stderr = os.Stderr
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		line := scanner.Text()
+		a.log.Info("output", "line", line)
+	}
+
+	return cmd.Wait()
+}
+
+// Close releases any resources held by the agent.
+func (a *CopilotAgent) Close() error {
+	return nil
+}

--- a/internal/agent/interface.go
+++ b/internal/agent/interface.go
@@ -9,8 +9,9 @@ import (
 
 // Agent type constants.
 const (
-	TypeClaude = "claude"
-	TypeDummy  = "dummy"
+	TypeClaude  = "claude"
+	TypeCopilot = "copilot"
+	TypeDummy   = "dummy"
 )
 
 // Agent abstracts the underlying agent implementation (e.g., Claude Code, Cursor).
@@ -39,6 +40,12 @@ func NewAgent(opts Options) (Agent, error) {
 	switch cmp.Or(opts.Type, TypeClaude) {
 	case TypeClaude:
 		return &ClaudeAgent{
+			log:        log,
+			cwd:        cmp.Or(opts.Cwd, "."),
+			mcpServers: opts.McpServers,
+		}, nil
+	case TypeCopilot:
+		return &CopilotAgent{
 			log:        log,
 			cwd:        cmp.Or(opts.Cwd, "."),
 			mcpServers: opts.McpServers,


### PR DESCRIPTION
## Summary

- Add a new `copilot` agent type that uses the GitHub Copilot CLI instead of Claude Code
- The copilot agent runs in non-interactive mode with `-p`/`--prompt` flag
- Supports MCP server configuration via `--additional-mcp-config` with inline JSON
- Uses `--resume` flag for session continuation
- Uses `--silent` flag to suppress stats output for cleaner log output

## Usage

Configure a workspace to use the copilot agent:

```yaml
workspaces:
  myworkspace:
    agent:
      type: "copilot"
      cwd: /path/to/project
```

## Test plan

- [ ] Build the project successfully with `go build`
- [ ] Verify copilot agent can be instantiated via the factory
- [ ] Test with a workspace configured to use `type: "copilot"`