### PR TITLE
Add agent-specific configuration options

### DIFF
--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -14,11 +14,18 @@ type ClaudeAgent struct {
 	log        *slog.Logger
 	cwd        string
 	mcpServers map[string]McpServer
+	options    *ClaudeOptions
 }
 
 // Prompt sends a prompt to Claude and waits for completion.
 func (a *ClaudeAgent) Prompt(ctx context.Context, prompt string, resume bool) error {
 	a.log.Info("sending prompt", "text", prompt)
+
+	// Use model from options, defaulting to "opus"
+	model := "opus"
+	if a.options != nil && a.options.Model != "" {
+		model = a.options.Model
+	}
 
 	args := []string{
 		"@anthropic-ai/claude-code",
@@ -26,7 +33,7 @@ func (a *ClaudeAgent) Prompt(ctx context.Context, prompt string, resume bool) er
 		"--verbose",
 		"--output-format", "stream-json",
 		"--strict-mcp-config",
-		"--model", "opus",
+		"--model", model,
 	}
 
 	// Add MCP config if present

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	Prompt     string               `json:"prompt,omitempty"`
 	McpServers map[string]McpServer `json:"mcp_servers,omitempty"`
 	Commands   []string             `json:"commands,omitempty"`
+	Claude     *ClaudeOptions       `json:"claude,omitempty"`
+	Copilot    *CopilotOptions      `json:"copilot,omitempty"`
 
 	// Agent-managed state
 	Setup   bool `json:"setup,omitempty"`

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -14,6 +14,7 @@ type CopilotAgent struct {
 	log        *slog.Logger
 	cwd        string
 	mcpServers map[string]McpServer
+	options    *CopilotOptions
 }
 
 // Prompt sends a prompt to Copilot and waits for completion.
@@ -22,6 +23,11 @@ func (a *CopilotAgent) Prompt(ctx context.Context, prompt string, resume bool) e
 
 	args := []string{
 		"--silent",
+	}
+
+	// Add model if specified in options
+	if a.options != nil && a.options.Model != "" {
+		args = append(args, "--model", a.options.Model)
 	}
 
 	// Add MCP config if present

--- a/internal/agent/interface.go
+++ b/internal/agent/interface.go
@@ -30,6 +30,18 @@ type Options struct {
 	Cwd        string
 	Log        *slog.Logger
 	McpServers map[string]McpServer
+	Claude     *ClaudeOptions
+	Copilot    *CopilotOptions
+}
+
+// ClaudeOptions contains Claude-specific agent options.
+type ClaudeOptions struct {
+	Model string
+}
+
+// CopilotOptions contains Copilot-specific agent options.
+type CopilotOptions struct {
+	Model string
 }
 
 // NewAgent creates an Agent based on the type specified in options.
@@ -43,12 +55,14 @@ func NewAgent(opts Options) (Agent, error) {
 			log:        log,
 			cwd:        cmp.Or(opts.Cwd, "."),
 			mcpServers: opts.McpServers,
+			options:    opts.Claude,
 		}, nil
 	case TypeCopilot:
 		return &CopilotAgent{
 			log:        log,
 			cwd:        cmp.Or(opts.Cwd, "."),
 			mcpServers: opts.McpServers,
+			options:    opts.Copilot,
 		}, nil
 	case TypeDummy:
 		return &DummyAgent{log: log}, nil

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -68,6 +68,8 @@ var RunCommand = &cli.Command{
 			Type:       cfg.Type,
 			Cwd:        os.ExpandEnv(cfg.Cwd),
 			McpServers: cfg.McpServers,
+			Claude:     cfg.Claude,
+			Copilot:    cfg.Copilot,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create agent: %w", err)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -414,6 +414,18 @@ func (r *Runner) copyConfig(ctx context.Context, containerID string, task *xagen
 		Commands:   ws.Commands,
 	}
 
+	// Copy agent-specific config
+	if ws.Agent.Claude != nil {
+		cfg.Claude = &agent.ClaudeOptions{
+			Model: ws.Agent.Claude.Model,
+		}
+	}
+	if ws.Agent.Copilot != nil {
+		cfg.Copilot = &agent.CopilotOptions{
+			Model: ws.Agent.Copilot.Model,
+		}
+	}
+
 	// Inject xagent MCP server for link creation
 	cfg.McpServers["xagent"] = agent.McpServer{
 		Type:    "stdio",

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -38,6 +38,18 @@ type Agent struct {
 	Cwd        string                     `yaml:"cwd"`
 	Prompt     string                     `yaml:"prompt"`
 	McpServers map[string]agent.McpServer `yaml:"mcp_servers"`
+	Claude     *ClaudeConfig              `yaml:"claude,omitempty"`
+	Copilot    *CopilotConfig             `yaml:"copilot,omitempty"`
+}
+
+// ClaudeConfig contains Claude-specific agent configuration.
+type ClaudeConfig struct {
+	Model string `yaml:"model"`
+}
+
+// CopilotConfig contains Copilot-specific agent configuration.
+type CopilotConfig struct {
+	Model string `yaml:"model"`
 }
 
 func (w *Workspace) Validate() error {


### PR DESCRIPTION
## Summary
- Add per-agent configuration support (e.g., `claude`, `copilot` sections)
- Each agent type can now have its own configuration options like `model`
- ClaudeAgent defaults to "opus" model but can be overridden via config

## Example Usage
```yaml
agent:
  type: claude
  claude:
    model: "sonnet"
```

## Test plan
- [ ] Build project with `go build ./...`
- [ ] Run tests with `go test ./...`
- [ ] Test with a workspace that includes agent-specific config