### PR TITLE
Add explicit agent type and model settings to cdl workspace

### DIFF
--- a/workspaces.yaml
+++ b/workspaces.yaml
@@ -53,6 +53,9 @@ workspaces:
         CLAUDE_CODE_OAUTH_TOKEN: ${env:CLAUDE_CODE_OAUTH_TOKEN}
         DISABLE_AUTOUPDATER: 1
     agent:
+      type: "claude"
+      claude:
+        model: "opus"
       cwd: /home/vscode/cdl
       mcp_servers:
         meta:


### PR DESCRIPTION
## Summary
- Explicitly configure the cdl workspace to use `type: "claude"` and `model: "opus"` in agent settings
- Makes the agent configuration explicit rather than relying on defaults

## Test plan
- [ ] Verify workspace configuration validates correctly with `xagent workspaces`
- [ ] Test that cdl workspace tasks use the correct agent type and model