### PR TITLE
Move Web UI documentation to /webui skill

### DIFF
--- a/.claude/skills/webui/SKILL.md
+++ b/.claude/skills/webui/SKILL.md
@@ -1,5 +1,6 @@
 ---
-description: Web UI development guidelines for the v2 React UI in webui/
+name: webui
+description: Web UI development guidelines for the v2 React UI in webui/. Apply when working on files in webui/, creating React components, or using TanStack Router/Query.
 ---
 
 # Web UI v2 Development Guide

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,4 +86,4 @@ Service definitions in `proto/xagent/v1/xagent.proto`, generated code goes to `i
 
 A modern React-based UI is being developed in `webui/` to replace the Go template-based UI in `internal/server/templates/`.
 
-For detailed development guidelines including TanStack Router, TanStack Query, and shadcn/ui component patterns, run `/webui`.
+For detailed development guidelines including TanStack Router, TanStack Query, and shadcn/ui component patterns, see the `webui` skill in `.claude/skills/webui/`.


### PR DESCRIPTION
## Summary
- Extract detailed Web UI v2 documentation from CLAUDE.md into a dedicated skill
- Create `.claude/commands/webui.md` with development guidelines
- Update CLAUDE.md to reference the new `/webui` command

## Test plan
- [ ] Verify `/webui` command is available in Claude Code
- [ ] Confirm CLAUDE.md now references the skill correctly
- [ ] Check that all documentation content was preserved in the skill file