### PR TITLE
Add SOPS configuration with AWS KMS key

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,2 @@
+creation_rules:
+  - kms: arn:aws:kms:us-east-1:401887214619:key/abc74cf2-742a-42cd-8e73-e05755f24e6b


### PR DESCRIPTION
## Summary
- Adds `.sops.yaml` configuration file with a creation rule for AWS KMS encryption
- Uses the provided KMS key ARN: `arn:aws:kms:us-east-1:401887214619:key/abc74cf2-742a-42cd-8e73-e05755f24e6b`

## Test plan
- [ ] Verify SOPS can encrypt files using the configured KMS key with `sops --encrypt <file>`
- [ ] Verify SOPS can decrypt files that were encrypted with this key