### PR TITLE
Add gRPC API skill

### DIFF
--- a/.claude/skills/grpc/SKILL.md
+++ b/.claude/skills/grpc/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: grpc
+description: Guidelines for working with the Connect RPC (gRPC) API. Apply when modifying proto definitions, implementing server handlers, or creating API clients.
+---
+
+# gRPC API Development Guide
+
+XAGENT uses [Connect RPC](https://connectrpc.com/) for its API, providing protocol flexibility (gRPC, gRPC-Web, Connect protocol) over HTTP.
+
+## Architecture Overview
+
+- **Proto definitions**: `proto/xagent/v1/xagent.proto`
+- **Generated code**: `internal/proto/xagent/v1/` (gitignored)
+- **Server implementation**: `internal/server/server.go`
+- **Client package**: `internal/xagentclient/`
+
+## Adding a New RPC
+
+### 1. Define the proto messages and service method
+
+Edit `proto/xagent/v1/xagent.proto`:
+
+```protobuf
+service XAgentService {
+  // ... existing RPCs ...
+  rpc MyNewMethod(MyNewRequest) returns (MyNewResponse);
+}
+
+message MyNewRequest {
+  int64 id = 1;
+  string name = 2;
+}
+
+message MyNewResponse {
+  bool success = 1;
+}
+```
+
+### 2. Generate the code
+
+```bash
+mise run generate
+```
+
+This runs:
+- `go tool buf generate` - generates protobuf messages and Connect client/server interfaces
+- `go generate ./...` - runs any other code generators
+
+### 3. Implement the server handler
+
+The server embeds `UnimplementedXAgentServiceHandler`, which provides default "not implemented" responses for all RPCs. Override the method in `internal/server/server.go`:
+
+```go
+func (s *Server) MyNewMethod(ctx context.Context, req *xagentv1.MyNewMethodRequest) (*xagentv1.MyNewMethodResponse, error) {
+    // Validate input
+    if req.Id == 0 {
+        return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("id is required"))
+    }
+
+    // Call store layer
+    result, err := s.tasks.DoSomething(req.Id)
+    if err != nil {
+        return nil, connect.NewError(connect.CodeInternal, err)
+    }
+
+    // Return response
+    return &xagentv1.MyNewMethodResponse{
+        Success: true,
+    }, nil
+}
+```
+
+### 4. Use Connect error codes
+
+Always use appropriate Connect error codes:
+
+```go
+import "connectrpc.com/connect"
+
+// Common error codes
+connect.CodeInvalidArgument  // Bad request parameters
+connect.CodeNotFound         // Resource doesn't exist
+connect.CodeInternal         // Server-side error
+connect.CodeUnimplemented    // Method not supported
+connect.CodeAlreadyExists    // Duplicate resource
+connect.CodePermissionDenied // Authorization failure
+```
+
+## Client Usage
+
+### Creating a client
+
+```go
+import "github.com/icholy/xagent/internal/xagentclient"
+
+// HTTP client
+client := xagentclient.New("http://localhost:8080")
+
+// Unix socket client (used inside containers)
+client := xagentclient.New("unix:///var/run/xagent.sock")
+```
+
+### Making RPC calls
+
+```go
+import xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
+
+// Unary call
+resp, err := client.GetTask(ctx, &xagentv1.GetTaskRequest{Id: 123})
+if err != nil {
+    // Handle error
+}
+task := resp.Task
+
+// Call with multiple fields
+resp, err := client.CreateTask(ctx, &xagentv1.CreateTaskRequest{
+    Name:      "My Task",
+    Workspace: "default",
+    Instructions: []*xagentv1.Instruction{
+        {Text: "Do something", Url: "https://example.com"},
+    },
+})
+```
+
+## Data Conversion Patterns
+
+The server converts between proto messages and store domain models:
+
+```go
+// Proto to store (in handler)
+instructions := make([]store.Instruction, len(req.Instructions))
+for i, inst := range req.Instructions {
+    instructions[i] = store.Instruction{
+        Text: inst.Text,
+        URL:  inst.Url,  // Note: proto uses "Url", store uses "URL"
+    }
+}
+
+// Store to proto (for responses)
+func taskToProto(t *store.Task) *xagentv1.Task {
+    return &xagentv1.Task{
+        Id:        t.ID,
+        Name:      t.Name,
+        Status:    string(t.Status),
+        CreatedAt: timestamppb.New(t.CreatedAt),
+    }
+}
+```
+
+## Protobuf Best Practices
+
+### Field naming
+- Use snake_case in proto files: `parent_id`, `created_at`
+- Generated Go uses PascalCase: `ParentId`, `CreatedAt`
+
+### Timestamps
+```protobuf
+import "google/protobuf/timestamp.proto";
+
+message Task {
+  google.protobuf.Timestamp created_at = 7;
+}
+```
+
+Convert with `timestamppb`:
+```go
+import "google.golang.org/protobuf/types/known/timestamppb"
+
+// Go time to proto
+protoTime := timestamppb.New(time.Now())
+
+// Proto to Go time
+goTime := protoTimestamp.AsTime()
+```
+
+### Repeated fields (lists)
+```protobuf
+message ListTasksResponse {
+  repeated Task tasks = 1;
+}
+```
+
+### Optional fields
+In proto3, all fields are optional by default. Empty/zero values are not serialized.
+
+### Maps
+```protobuf
+message McpServer {
+  map<string, string> env = 4;
+}
+```
+
+## HTTP/JSON API Access
+
+Connect RPC endpoints are accessible via HTTP POST with JSON:
+
+```bash
+# List tasks
+curl -X POST http://localhost:8080/xagent.v1.XAgentService/ListTasks \
+  -H "Content-Type: application/json" \
+  -d '{"statuses": ["pending", "running"]}'
+
+# Get task
+curl -X POST http://localhost:8080/xagent.v1.XAgentService/GetTask \
+  -H "Content-Type: application/json" \
+  -d '{"id": 123}'
+```
+
+URL pattern: `/{package}.{service}/{method}`
+
+## Testing
+
+### Unit testing handlers
+
+Mock the client interface for testing:
+
+```go
+//go:generate go tool moq -pkg mypackage -out client_moq_test.go ../xagentclient Client
+
+func TestMyHandler(t *testing.T) {
+    mockClient := &ClientMock{
+        GetTaskFunc: func(ctx context.Context, req *xagentv1.GetTaskRequest) (*xagentv1.GetTaskResponse, error) {
+            return &xagentv1.GetTaskResponse{
+                Task: &xagentv1.Task{Id: req.Id, Name: "Test"},
+            }, nil
+        },
+    }
+    // Use mockClient in tests
+}
+```
+
+## Buf Configuration
+
+### buf.yaml
+Configures the protobuf module and linting rules:
+```yaml
+version: v2
+modules:
+  - path: proto
+lint:
+  use:
+    - STANDARD
+```
+
+### buf.gen.yaml
+Specifies code generation plugins:
+```yaml
+version: v2
+plugins:
+  - remote: buf.build/protocolbuffers/go
+    out: internal/proto
+    opt: paths=source_relative
+  - remote: buf.build/connectrpc/go
+    out: internal/proto
+    opt:
+      - paths=source_relative
+      - simple
+```
+
+## Common Patterns
+
+### Logging in handlers
+```go
+s.log.Info("task created", "id", task.ID, "workspace", task.Workspace)
+```
+
+### Handling not found
+```go
+task, err := s.tasks.Get(req.Id)
+if err != nil {
+    return nil, connect.NewError(connect.CodeNotFound, err)
+}
+```
+
+### Batch operations
+```go
+func (s *Server) UploadLogs(ctx context.Context, req *xagentv1.UploadLogsRequest) (*xagentv1.UploadLogsResponse, error) {
+    logs := make([]*store.Log, len(req.Entries))
+    for i, entry := range req.Entries {
+        logs[i] = &store.Log{
+            TaskID:  req.TaskId,
+            Type:    entry.Type,
+            Content: entry.Content,
+        }
+    }
+    if err := s.logs.CreateBatch(logs); err != nil {
+        return nil, connect.NewError(connect.CodeInternal, err)
+    }
+    return &xagentv1.UploadLogsResponse{}, nil
+}
+```


### PR DESCRIPTION
## Summary
- Add comprehensive documentation for working with the Connect RPC (gRPC) API
- Cover adding new RPCs, implementing server handlers, client usage, and testing patterns
- Include examples for error handling, data conversion, and HTTP/JSON API access

## Test plan
- [ ] Verify the skill file is properly formatted
- [ ] Check that the skill is auto-discovered in the `.claude/skills/` directory
- [ ] Review the documented patterns match actual codebase conventions