### PR TITLE
Add sops config with age encryption

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,2 @@
+creation_rules:
+  - age: age1z6gj02hsha9m4wasgalhyudtwu9z9fkhf298ksle6r7nk30y6cgqydhhlx


### PR DESCRIPTION
Add a `.sops.yaml` configuration file with creation rules to use age encryption with the specified public key.

This allows secrets to be encrypted using sops with age encryption.