### PR TITLE
Add sops, terraform, and age to mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,8 @@
+[tools]
+sops = "latest"
+terraform = "latest"
+age = "latest"
+
 [tasks.build]
 description = "Build xagent binaries for all architectures"
 run = [


### PR DESCRIPTION
Adds the following tools to mise.toml:

- `sops` - for secret management
- `terraform` - for infrastructure as code
- `age` - for encryption