### PR TITLE
Use npm ci instead of npm install in webui instructions

### DIFF
--- a/.claude/skills/webui/SKILL.md
+++ b/.claude/skills/webui/SKILL.md
@@ -21,7 +21,7 @@ A modern React-based UI is being developed in `webui/` to replace the Go templat
 
 ```bash
 cd webui
-npm install
+npm ci
 npm run dev  # Runs on http://localhost:5173
 ```
 


### PR DESCRIPTION
## Summary
- Update webui development instructions to use `npm ci` instead of `npm install`

## Rationale
`npm ci` is preferred for development setups because it:
- Installs dependencies exactly as specified in `package-lock.json`
- Faster than `npm install` since it skips certain resolution steps
- Ensures reproducible builds across different environments