### PR TITLE
Remove outdated excludes from terraform archive_file

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -117,7 +117,7 @@ data "archive_file" "webhooks_lambda" {
   type        = "zip"
   source_dir  = "${path.module}/../lambda"
   output_path = "${path.module}/builds/webhooks-lambda.zip"
-  excludes    = ["go.sum", "Makefile", "README.md", ".gitignore", "webhooks"]
+  excludes    = []
 }
 
 # Webhooks Lambda function


### PR DESCRIPTION
## Summary

- Removes the outdated `excludes` list from the terraform `archive_file` for the webhooks lambda

The excludes list `["go.sum", "Makefile", "README.md", ".gitignore", "webhooks"]` was from when the lambda directory contained Go source files that needed to be compiled.

Since the lambda code was consolidated into the main Go module (#13), the `lambda/` directory now only contains the pre-built `bootstrap` binary created by `mise run build`. There are no files to exclude.

## Test plan

- [ ] Verify `mise run build` creates `lambda/bootstrap`
- [ ] Verify `terraform plan` shows no unexpected changes