### PR TITLE
Update mise build for CLI moved to cmd/xagent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 mise run build          # Build main binary + prebuilt binaries for linux amd64/arm64
 mise run generate       # Generate protobuf code (go tool buf generate)
 mise run wipe           # Delete the database
-go build                # Build main binary only
+go build -o xagent ./cmd/xagent  # Build main binary only
 ```
 
 ## Architecture

--- a/mise.toml
+++ b/mise.toml
@@ -6,10 +6,10 @@ age = "latest"
 [tasks.build]
 description = "Build xagent binaries for all architectures and lambda"
 run = [
-	"go build",
+	"go build -o xagent ./cmd/xagent",
 	"mkdir -p prebuilt",
-	"CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o prebuilt/xagent-linux-amd64 .",
-	"CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o prebuilt/xagent-linux-arm64 .",
+	"CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o prebuilt/xagent-linux-amd64 ./cmd/xagent",
+	"CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o prebuilt/xagent-linux-arm64 ./cmd/xagent",
 	"mkdir -p lambda",
 	"CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o lambda/bootstrap ./cmd/lambda"
 ]


### PR DESCRIPTION
## Summary
- Update `mise.toml` build commands to reference `./cmd/xagent` instead of the root directory
- Update `CLAUDE.md` build documentation to reflect the new build command
- Binary is still output to the root directory (`./xagent`)

## Test plan
- [x] Verified `mise run build` works and outputs xagent binary to root directory
- [x] Verified prebuilt binaries are created in prebuilt/
- [x] Verified lambda binary is created in lambda/