### PR TITLE
Fix Lambda webhook 404 by using V2 adapter for Function URLs

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -40,5 +40,5 @@ func main() {
 		Publisher:    publisher,
 	})
 
-	lambda.Start(httpadapter.New(handler).ProxyWithContext)
+	lambda.Start(httpadapter.NewV2(handler).ProxyWithContext)
 }


### PR DESCRIPTION
## Summary

- Fix GitHub webhook returning 404 by using the correct Lambda adapter for Function URLs
- Lambda Function URLs use the API Gateway V2 HTTP request format, but the code was using `httpadapter.New()` which expects the V1 format
- Changed to `httpadapter.NewV2()` which properly handles the V2 event format

## Root Cause

The `aws-lambda-go-api-proxy` library provides different adapters for different AWS event types:
- `httpadapter.New()` - For API Gateway v1 (REST APIs) - handles `events.APIGatewayProxyRequest`
- `httpadapter.NewV2()` - For API Gateway v2 (HTTP APIs) - handles `events.APIGatewayV2HTTPRequest`

Lambda Function URLs use the same event format as API Gateway v2 HTTP APIs, so `NewV2()` is required.

## Test plan

- [ ] Deploy the Lambda with the fix
- [ ] Test the GitHub webhook endpoint at `/webhook/github`
- [ ] Verify webhooks are processed correctly