### PR TITLE
Add ParseWebHook helper to githubx package

### DIFF
--- a/internal/githubx/webhook.go
+++ b/internal/githubx/webhook.go
@@ -1,0 +1,30 @@
+package githubx
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-github/v68/github"
+)
+
+// ParseWebHook parses a webhook request.
+// If a secret is provided, the signature is validated.
+func ParseWebHook(body []byte, h http.Header, secret []byte) (any, error) {
+	if len(secret) > 0 {
+		signature := h.Get(github.SHA256SignatureHeader)
+		if signature == "" {
+			signature = h.Get(github.SHA1SignatureHeader)
+		}
+		if signature == "" {
+			return nil, fmt.Errorf("missing request signature header: %s", github.SHA256SignatureHeader)
+		}
+		if err := github.ValidateSignature(signature, body, secret); err != nil {
+			return nil, err
+		}
+	}
+	eventType := h.Get(github.EventTypeHeader)
+	if eventType == "" {
+		return nil, fmt.Errorf("missing request event type header: %s", github.EventTypeHeader)
+	}
+	return github.ParseWebHook(eventType, body)
+}


### PR DESCRIPTION
## Summary

- Adds `ParseWebHook` helper function to the `internal/githubx` package
- Validates webhook signatures when a secret is provided (supports both SHA256 and SHA1)
- Parses the webhook event body using the go-github library

## Test plan

- [ ] Verify the code compiles: `go build ./internal/githubx/...`
- [ ] Use the helper in webhook handling code