### PR TITLE
Fix webhook event description and data fields

### DIFF
--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -182,9 +182,13 @@ func (h *Handler) extractGitHubEvent(webhookEvent any, rawBody string) *Event {
 			event.Comment.Body != nil && event.Issue.HTMLURL != nil {
 			body := strings.TrimSpace(*event.Comment.Body)
 			if strings.HasPrefix(body, "xagent:") {
+				description := "A comment was made on an issue"
+				if event.Issue.IsPullRequest() {
+					description = "A comment was made on a pull request"
+				}
 				return &Event{
-					Description: body,
-					Data:        rawBody,
+					Description: description,
+					Data:        body,
 					URL:         *event.Issue.HTMLURL,
 				}
 			}
@@ -196,8 +200,8 @@ func (h *Handler) extractGitHubEvent(webhookEvent any, rawBody string) *Event {
 			body := strings.TrimSpace(*event.Comment.Body)
 			if strings.HasPrefix(body, "xagent:") {
 				return &Event{
-					Description: body,
-					Data:        rawBody,
+					Description: "A review comment was made on a pull request",
+					Data:        body,
 					URL:         *event.PullRequest.HTMLURL,
 				}
 			}
@@ -231,8 +235,8 @@ func (h *Handler) extractJiraEvent(event *jiraWebhookEvent, rawBody string) *Eve
 	issueURL := fmt.Sprintf("%s/browse/%s", strings.TrimSuffix(h.config.JiraBaseURL, "/"), event.Issue.Key)
 
 	return &Event{
-		Description: body,
-		Data:        rawBody,
+		Description: "A comment was made on a Jira issue",
+		Data:        body,
 		URL:         issueURL,
 	}
 }

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/icholy/xagent/internal/webhook"
 	"gotest.tools/v3/assert"
 )
@@ -53,6 +52,7 @@ func TestGitHubPullRequestReviewComment(t *testing.T) {
 	assert.Equal(t, len(publisher.PublishCalls()), 1)
 	assert.DeepEqual(t, publisher.PublishCalls()[0].Event, &webhook.Event{
 		URL:         "https://github.com/icholy/xagent/pull/83",
-		Description: "xagent: test comment",
-	}, cmpopts.IgnoreFields(webhook.Event{}, "Data"))
+		Description: "A review comment was made on a pull request",
+		Data:        "xagent: test comment",
+	})
 }


### PR DESCRIPTION
## Summary

- Change webhook Event's `Description` field to contain a human-readable description of what happened (e.g., "A comment was made on a pull request") instead of the comment body
- Change `Data` field to contain the actual comment body instead of the entire raw webhook payload
- Affects GitHub issue comments, PR review comments, and Jira issue comments

## Changes

**GitHub Events:**
- Issue comment: Description = "A comment was made on an issue" or "A comment was made on a pull request"
- PR review comment: Description = "A review comment was made on a pull request"

**Jira Events:**
- Issue comment: Description = "A comment was made on a Jira issue"

## Test plan

- [x] Existing webhook tests updated and passing
- [x] All tests pass