### PR TITLE
Add proxy configuration for webui dev server

### DIFF
--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -12,4 +12,13 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    proxy: {
+      // Proxy Connect RPC requests to the backend server
+      "/xagent.v1.XAgentService": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- Configure Vite dev server to proxy Connect RPC requests to the backend server (localhost:8080)
- Fixes the "[unimplemented] HTTP 404" error when running `npm run dev` on the task page

## Test plan
- [ ] Run the xagent server: `go run ./cmd/xagent server`
- [ ] Run the webui dev server: `cd webui && npm run dev`
- [ ] Navigate to `/tasks` - should load the task list without errors