### PR TITLE
Add v2 events page

### DIFF
--- a/webui/src/routes/__root.tsx
+++ b/webui/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { Outlet, createRootRouteWithContext } from '@tanstack/react-router'
+import { Outlet, createRootRouteWithContext, Link } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import { QueryClient } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
@@ -12,6 +12,27 @@ export const Route = createRootRouteWithContext<{
 function RootComponent() {
   return (
     <>
+      <nav className="border-b">
+        <div className="container mx-auto px-4 py-3 flex items-center gap-6">
+          <Link to="/" className="font-semibold text-lg">
+            XAgent
+          </Link>
+          <div className="flex gap-4">
+            <Link
+              to="/tasks"
+              className="text-muted-foreground hover:text-foreground transition-colors [&.active]:text-foreground"
+            >
+              Tasks
+            </Link>
+            <Link
+              to="/events"
+              className="text-muted-foreground hover:text-foreground transition-colors [&.active]:text-foreground"
+            >
+              Events
+            </Link>
+          </div>
+        </div>
+      </nav>
       <Outlet />
       <ReactQueryDevtools buttonPosition="top-right" />
       <TanStackRouterDevtools position="bottom-right" />

--- a/webui/src/routes/events.$id.tsx
+++ b/webui/src/routes/events.$id.tsx
@@ -1,0 +1,150 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useQuery } from '@connectrpc/connect-query'
+import { getEvent, listEventTasks } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
+import { timestampDate } from '@bufbuild/protobuf/wkt'
+
+export const Route = createFileRoute('/events/$id')({
+  component: EventDetail,
+})
+
+function EventDetail() {
+  const { id } = Route.useParams()
+  const eventId = BigInt(id)
+
+  const { data: eventData, isLoading: eventLoading, error: eventError } = useQuery(
+    getEvent,
+    { id: eventId },
+    { refetchInterval: 3000 }
+  )
+
+  const { data: tasksData, isLoading: tasksLoading } = useQuery(
+    listEventTasks,
+    { eventId },
+    { refetchInterval: 3000 }
+  )
+
+  if (eventLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-muted-foreground">Loading event...</div>
+      </div>
+    )
+  }
+
+  if (eventError) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-destructive">Error: {eventError.message}</div>
+      </div>
+    )
+  }
+
+  const event = eventData?.event
+
+  if (!event) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-muted-foreground">Event not found</div>
+      </div>
+    )
+  }
+
+  const taskIds = tasksData?.taskIds ?? []
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <div className="mb-6">
+        <Link to="/events" className="text-primary hover:underline">
+          &larr; Back to Events
+        </Link>
+      </div>
+
+      <h1 className="text-2xl font-bold mb-6">Event {String(event.id)}</h1>
+
+      <div className="space-y-6">
+        <div className="rounded-lg border p-6 space-y-4">
+          <div>
+            <h2 className="text-sm font-medium text-muted-foreground">Description</h2>
+            <p className="mt-1">{event.description || '-'}</p>
+          </div>
+
+          <div>
+            <h2 className="text-sm font-medium text-muted-foreground">URL</h2>
+            <p className="mt-1">
+              {event.url ? (
+                <a
+                  href={event.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline break-all"
+                >
+                  {event.url}
+                </a>
+              ) : (
+                '-'
+              )}
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-sm font-medium text-muted-foreground">Created</h2>
+            <p className="mt-1">
+              {event.createdAt ? formatDate(timestampDate(event.createdAt)) : '-'}
+            </p>
+          </div>
+
+          {event.data && (
+            <div>
+              <h2 className="text-sm font-medium text-muted-foreground">Data</h2>
+              <pre className="mt-1 p-4 bg-muted rounded-md overflow-x-auto text-sm">
+                {formatJson(event.data)}
+              </pre>
+            </div>
+          )}
+        </div>
+
+        <div className="rounded-lg border p-6">
+          <h2 className="text-lg font-semibold mb-4">Associated Tasks</h2>
+          {tasksLoading ? (
+            <p className="text-muted-foreground">Loading tasks...</p>
+          ) : taskIds.length === 0 ? (
+            <p className="text-muted-foreground">No associated tasks</p>
+          ) : (
+            <ul className="space-y-2">
+              {taskIds.map((taskId) => (
+                <li key={String(taskId)}>
+                  <Link
+                    to="/tasks/$id"
+                    params={{ id: String(taskId) }}
+                    className="text-primary hover:underline"
+                  >
+                    Task {String(taskId)}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+}
+
+function formatJson(data: string): string {
+  try {
+    return JSON.stringify(JSON.parse(data), null, 2)
+  } catch {
+    return data
+  }
+}

--- a/webui/src/routes/events.tsx
+++ b/webui/src/routes/events.tsx
@@ -1,0 +1,112 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useQuery } from '@connectrpc/connect-query'
+import { listEvents } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
+import type { Event } from '@/gen/xagent/v1/xagent_pb'
+import { timestampDate } from '@bufbuild/protobuf/wkt'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+export const Route = createFileRoute('/events')({
+  component: EventsPage,
+})
+
+function EventsPage() {
+  const { data, isLoading, error } = useQuery(listEvents, {}, {
+    refetchInterval: 3000,
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-muted-foreground">Loading events...</div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-destructive">Error: {error.message}</div>
+      </div>
+    )
+  }
+
+  const events = data?.events ?? []
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <h1 className="text-2xl font-bold mb-6">Events</h1>
+      {events.length === 0 ? (
+        <div className="text-muted-foreground text-center py-8">
+          No events found
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead>URL</TableHead>
+              <TableHead>Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {events.map((event) => (
+              <EventRow key={String(event.id)} event={event} />
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  )
+}
+
+function EventRow({ event }: { event: Event }) {
+  return (
+    <TableRow>
+      <TableCell>
+        <Link
+          to="/events/$id"
+          params={{ id: String(event.id) }}
+          className="text-primary hover:underline"
+        >
+          {String(event.id)}
+        </Link>
+      </TableCell>
+      <TableCell>{event.description || '-'}</TableCell>
+      <TableCell className="max-w-xs truncate">
+        {event.url ? (
+          <a
+            href={event.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+          >
+            {event.url}
+          </a>
+        ) : (
+          '-'
+        )}
+      </TableCell>
+      <TableCell className="text-muted-foreground">
+        {event.createdAt ? formatDate(timestampDate(event.createdAt)) : '-'}
+      </TableCell>
+    </TableRow>
+  )
+}
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+}


### PR DESCRIPTION
## Summary
- Add events list page at /events with table showing all events
- Add event detail page at /events/$id with full event information
- Add navigation header to root layout with links to Tasks and Events

## Features
- Events list shows ID, description, URL, and creation timestamp
- Event detail shows all fields including formatted JSON data
- Event detail links to associated tasks
- Navigation bar provides easy access to Tasks and Events pages
- Auto-refreshes data every 3 seconds for real-time updates

## Test plan
- [ ] Navigate to /events and verify events list displays
- [ ] Click on event ID to view event detail page
- [ ] Verify navigation header links work correctly
- [ ] Verify external URL links open in new tab
- [ ] Verify associated tasks are linked and clickable