### PR TITLE
Fix task detail page routing

### DIFF
--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -14,7 +14,7 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
 
-export const Route = createFileRoute('/tasks')({
+export const Route = createFileRoute('/tasks/')({
   component: TasksPage,
 })
 


### PR DESCRIPTION
## Summary
- Fixes routing issue where clicking a task in the list would update the URL but still show the task list
- Renamed `tasks.tsx` to `tasks.index.tsx` so that `/tasks` and `/tasks/:id` are sibling routes

## Root cause
With TanStack Router's file-based routing, `tasks.tsx` was acting as a layout route for `tasks.$id.tsx`. Since `tasks.tsx` didn't render an `<Outlet />`, the child route component was never displayed.

## Test plan
- [ ] Navigate to `/tasks` and verify the task list is displayed
- [ ] Click on a task and verify the task detail page is displayed
- [ ] Click "Back to Tasks" and verify it returns to the task list