### PR TITLE
Fix archive button appearing unclickable in task details

### DIFF
--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -189,7 +189,7 @@ function TaskDetail() {
               )}
               {canArchive && (
                 <Button
-                  variant="secondary"
+                  variant="outline"
                   size="sm"
                   onClick={() => handleUpdateStatus('archived')}
                   disabled={updateMutation.isPending}


### PR DESCRIPTION
## Summary

- Change the Archive button variant from `secondary` to `outline` to make it visually appear clickable
- The `secondary` variant uses very light gray background colors that make the button look disabled
- The `outline` variant provides border and shadow styling consistent with the Restart button

## Test plan

- [ ] Navigate to task details page for a completed or failed task
- [ ] Verify Archive button now appears clickable with visible border
- [ ] Click the Archive button and confirm it works correctly