### PR TITLE
Fix event list click navigation in webui

### DIFF
--- a/webui/src/routes/events.index.tsx
+++ b/webui/src/routes/events.index.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/table'
 import { RelativeTime } from '@/components/ui/relative-time'
 
-export const Route = createFileRoute('/events')({
+export const Route = createFileRoute('/events/')({
   component: EventsPage,
 })
 


### PR DESCRIPTION
## Summary
- Rename `events.tsx` to `events.index.tsx` to make it an index route
- Update route path from `/events` to `/events/` to match TanStack Router convention

## Problem
When clicking on an event in the list, the URL would update to `/events/$id` but the page wouldn't switch to show the event details. This was because `events.tsx` was configured as a leaf route instead of an index route.

## Solution
Following the same pattern used by the tasks routes (`tasks.index.tsx` + `tasks.$id.tsx`), renamed `events.tsx` to `events.index.tsx` and updated the route definition. This allows TanStack Router to properly handle the nested routing between the events list and event detail pages.