### PR TITLE
Use relative time for all Created & Updated timestamps

### DIFF
--- a/webui/src/components/ui/relative-time.tsx
+++ b/webui/src/components/ui/relative-time.tsx
@@ -1,0 +1,33 @@
+import { Duration } from '@icholy/duration'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+export function RelativeTime({ date }: { date: Date }) {
+  const now = new Date()
+  const diff = now.getTime() - date.getTime()
+  const duration = new Duration(diff)
+
+  const relativeText = diff < 1000 ? 'just now' : `${duration.toString()} ago`
+  const absoluteText = date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+
+  return (
+    <Tooltip>
+      <TooltipTrigger className="cursor-default">
+        {relativeText}
+      </TooltipTrigger>
+      <TooltipContent>
+        {absoluteText}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/webui/src/routes/events.$id.tsx
+++ b/webui/src/routes/events.$id.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import { useQuery } from '@connectrpc/connect-query'
 import { getEvent, listEventTasks } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
 import { timestampDate } from '@bufbuild/protobuf/wkt'
+import { RelativeTime } from '@/components/ui/relative-time'
 
 export const Route = createFileRoute('/events/$id')({
   component: EventDetail,
@@ -89,7 +90,7 @@ function EventDetail() {
           <div>
             <h2 className="text-sm font-medium text-muted-foreground">Created</h2>
             <p className="mt-1">
-              {event.createdAt ? formatDate(timestampDate(event.createdAt)) : '-'}
+              {event.createdAt ? <RelativeTime date={timestampDate(event.createdAt)} /> : '-'}
             </p>
           </div>
 
@@ -128,17 +129,6 @@ function EventDetail() {
       </div>
     </div>
   )
-}
-
-function formatDate(date: Date): string {
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  })
 }
 
 function formatJson(data: string): string {

--- a/webui/src/routes/events.tsx
+++ b/webui/src/routes/events.tsx
@@ -11,6 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { RelativeTime } from '@/components/ui/relative-time'
 
 export const Route = createFileRoute('/events')({
   component: EventsPage,
@@ -95,18 +96,9 @@ function EventRow({ event }: { event: Event }) {
         )}
       </TableCell>
       <TableCell className="text-muted-foreground">
-        {event.createdAt ? formatDate(timestampDate(event.createdAt)) : '-'}
+        {event.createdAt ? <RelativeTime date={timestampDate(event.createdAt)} /> : '-'}
       </TableCell>
     </TableRow>
   )
 }
 
-function formatDate(date: Date): string {
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  })
-}

--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -26,6 +26,7 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { Textarea } from '@/components/ui/textarea'
+import { RelativeTime } from '@/components/ui/relative-time'
 
 export const Route = createFileRoute('/tasks/$id')({
   component: TaskDetail,
@@ -58,15 +59,6 @@ function StatusBadge({ status }: { status: string }) {
   )
 }
 
-function formatDate(date: Date): string {
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  })
-}
 
 function TaskDetail() {
   const { id } = Route.useParams()
@@ -217,14 +209,14 @@ function TaskDetail() {
             <strong>Status:</strong>
             <StatusBadge status={task.status} />
           </div>
-          <div>
+          <div className="flex items-center gap-2">
             <strong>Created:</strong>{' '}
-            {task.createdAt ? formatDate(timestampDate(task.createdAt)) : '-'}
+            {task.createdAt ? <RelativeTime date={timestampDate(task.createdAt)} /> : '-'}
           </div>
           {task.updatedAt && (
-            <div>
+            <div className="flex items-center gap-2">
               <strong>Updated:</strong>{' '}
-              {formatDate(timestampDate(task.updatedAt))}
+              <RelativeTime date={timestampDate(task.updatedAt)} />
             </div>
           )}
         </CardContent>
@@ -409,7 +401,7 @@ function ChildTasksTable({ tasks }: { tasks: Task[] }) {
               <StatusBadge status={task.status} />
             </TableCell>
             <TableCell className="text-muted-foreground">
-              {task.createdAt ? formatDate(timestampDate(task.createdAt)) : '-'}
+              {task.createdAt ? <RelativeTime date={timestampDate(task.createdAt)} /> : '-'}
             </TableCell>
           </TableRow>
         ))}

--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -13,15 +13,10 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Badge } from '@/components/ui/badge'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
 import { Switch } from '@/components/ui/switch'
+import { RelativeTime } from '@/components/ui/relative-time'
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
-import { Duration } from '@icholy/duration'
 
 export const Route = createFileRoute('/tasks/')({
   component: TasksPage,
@@ -150,29 +145,3 @@ function StatusBadge({ status }: { status: string }) {
   )
 }
 
-function RelativeTime({ date }: { date: Date }) {
-  const now = new Date()
-  const diff = now.getTime() - date.getTime()
-  const duration = new Duration(diff)
-
-  const relativeText = diff < 1000 ? 'just now' : `${duration.toString()} ago`
-  const absoluteText = date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  })
-
-  return (
-    <Tooltip>
-      <TooltipTrigger className="cursor-default">
-        {relativeText}
-      </TooltipTrigger>
-      <TooltipContent>
-        {absoluteText}
-      </TooltipContent>
-    </Tooltip>
-  )
-}


### PR DESCRIPTION
## Summary
- Extract `RelativeTime` component to shared `components/ui/relative-time.tsx`
- Apply relative time display to task detail page (Created and Updated)
- Apply relative time display to child tasks table in task detail
- Apply relative time display to events list and event detail page

Hover over any timestamp to see the full date/time in tooltip.