### PR TITLE
Default showChildTasks toggle to false

### DIFF
--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -30,7 +30,7 @@ export const Route = createFileRoute('/tasks/')({
 function TasksPage() {
   const [showChildTasks, setShowChildTasks] = useState(() => {
     const stored = localStorage.getItem('showChildTasks')
-    return stored !== null ? stored === 'true' : true
+    return stored !== null ? stored === 'true' : false
   })
 
   const { data, isLoading, error } = useQuery(listTasks, {}, {


### PR DESCRIPTION
## Summary

- Change the initial default value of the child tasks toggle from `true` to `false`
- Users will now see only parent tasks by default on the tasks list page
- The toggle preference is still persisted in localStorage once changed

## Test plan

- [ ] Load the tasks page with localStorage cleared
- [ ] Verify child tasks are hidden by default
- [ ] Toggle the switch on, reload, verify setting persists
