### PR TITLE
Truncate milliseconds from relative time display

### DIFF
--- a/webui/src/components/ui/relative-time.tsx
+++ b/webui/src/components/ui/relative-time.tsx
@@ -10,7 +10,8 @@ export function RelativeTime({ date }: { date: Date }) {
   const diff = now.getTime() - date.getTime()
   const duration = new Duration(diff)
 
-  const relativeText = diff < 1000 ? 'just now' : `${duration.toString()} ago`
+  const relativeText =
+    diff < 1000 ? 'just now' : `${duration.truncate('1s').toString()} ago`
   const absoluteText = date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',


### PR DESCRIPTION
Use `Duration.truncate('1s')` to round relative time to the nearest second before displaying, removing milliseconds from the UI.

Before: `5m30s500ms ago`
After: `5m31s ago`