### PR TITLE
Combine instructions display and add form in single card

### DIFF
--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -227,7 +227,7 @@ function TaskDetail() {
         <CardHeader>
           <CardTitle>Instructions</CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-4">
           {task.instructions.length === 0 ? (
             <div className="text-muted-foreground">No instructions</div>
           ) : (
@@ -237,17 +237,8 @@ function TaskDetail() {
               ))}
             </div>
           )}
-        </CardContent>
-      </Card>
-
-      {/* Add Instruction Form */}
-      {!isArchived && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Add Instruction</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handleAddInstruction} className="space-y-4">
+          {!isArchived && (
+            <form onSubmit={handleAddInstruction} className="space-y-4 pt-4 border-t">
               <Textarea
                 placeholder="Enter a new instruction..."
                 value={instruction}
@@ -258,9 +249,9 @@ function TaskDetail() {
                 Add Instruction
               </Button>
             </form>
-          </CardContent>
-        </Card>
-      )}
+          )}
+        </CardContent>
+      </Card>
 
       {/* Links */}
       {links.length > 0 && (


### PR DESCRIPTION
## Summary

- Combines the Instructions display and Add Instruction form into a single card in the v2 UI task details page
- Adds a border separator between existing instructions and the form when task is not archived
- Reduces visual clutter by consolidating related UI elements

## Changes

- Moved the add instruction form inside the Instructions card component
- Added `pt-4 border-t` styling to visually separate the form from the instructions list
- Added `space-y-4` to the CardContent for consistent spacing