### PR TITLE
Move add instruction button to right side in v2 UI

### DIFF
--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -245,9 +245,11 @@ function TaskDetail() {
                 onChange={(e) => setInstruction(e.target.value)}
                 required
               />
-              <Button type="submit" disabled={updateMutation.isPending}>
-                Add Instruction
-              </Button>
+              <div className="flex justify-end">
+                <Button type="submit" disabled={updateMutation.isPending}>
+                  Add Instruction
+                </Button>
+              </div>
             </form>
           )}
         </CardContent>


### PR DESCRIPTION
## Summary
- Move the Add Instruction button from the left side to the right side in the task details page
- Uses flex container with `justify-end` to align the button

## Test plan
- [ ] Open the v2 UI
- [ ] Navigate to a task detail page
- [ ] Verify the Add Instruction button is now aligned to the right side of the form
