### PR TITLE
Add page to create new task in webui

### DIFF
--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -13,6 +13,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { RelativeTime } from '@/components/ui/relative-time'
 import { Label } from '@/components/ui/label'
@@ -63,15 +64,20 @@ function TasksPage() {
     <div className="container mx-auto py-8 px-4">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Tasks</h1>
-        <div className="flex items-center gap-2">
-          <Label htmlFor="show-child-tasks" className="text-sm text-muted-foreground cursor-pointer">
-            Show child tasks{hiddenCount > 0 && !showChildTasks && ` (${hiddenCount} hidden)`}
-          </Label>
-          <Switch
-            id="show-child-tasks"
-            checked={showChildTasks}
-            onCheckedChange={handleToggleChildTasks}
-          />
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <Label htmlFor="show-child-tasks" className="text-sm text-muted-foreground cursor-pointer">
+              Show child tasks{hiddenCount > 0 && !showChildTasks && ` (${hiddenCount} hidden)`}
+            </Label>
+            <Switch
+              id="show-child-tasks"
+              checked={showChildTasks}
+              onCheckedChange={handleToggleChildTasks}
+            />
+          </div>
+          <Link to="/tasks/new">
+            <Button>New Task</Button>
+          </Link>
         </div>
       </div>
       {tasks.length === 0 ? (

--- a/webui/src/routes/tasks.new.tsx
+++ b/webui/src/routes/tasks.new.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { useMutation } from '@connectrpc/connect-query'
+import { createTask } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+
+export const Route = createFileRoute('/tasks/new')({
+  component: NewTaskPage,
+})
+
+function NewTaskPage() {
+  const navigate = useNavigate()
+
+  const [name, setName] = useState('')
+  const [workspace, setWorkspace] = useState('')
+  const [instruction, setInstruction] = useState('')
+
+  const mutation = useMutation(createTask, {
+    onSuccess: (data) => {
+      if (data.task) {
+        navigate({ to: '/tasks/$id', params: { id: String(data.task.id) } })
+      } else {
+        navigate({ to: '/tasks' })
+      }
+    },
+  })
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!workspace.trim()) return
+
+    const instructions = instruction.trim()
+      ? [{ text: instruction.trim(), url: '' }]
+      : []
+
+    await mutation.mutateAsync({
+      name: name.trim(),
+      workspace: workspace.trim(),
+      parent: 0n,
+      instructions,
+    })
+  }
+
+  return (
+    <div className="container mx-auto py-8 px-4 space-y-6">
+      <Link to="/tasks" className="text-primary hover:underline">
+        &larr; Back to Tasks
+      </Link>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl">Create New Task</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="workspace">Workspace</Label>
+              <Input
+                id="workspace"
+                placeholder="Enter workspace name"
+                value={workspace}
+                onChange={(e) => setWorkspace(e.target.value)}
+                required
+              />
+              <p className="text-sm text-muted-foreground">
+                The workspace defines the container configuration for the task
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="name">Name (optional)</Label>
+              <Input
+                id="name"
+                placeholder="Enter task name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="instruction">Initial Instruction (optional)</Label>
+              <Textarea
+                id="instruction"
+                placeholder="Enter the initial instruction for the task..."
+                value={instruction}
+                onChange={(e) => setInstruction(e.target.value)}
+                rows={4}
+              />
+            </div>
+
+            {mutation.error && (
+              <div className="text-destructive text-sm">
+                Error: {mutation.error.message}
+              </div>
+            )}
+
+            <div className="flex gap-2">
+              <Button type="submit" disabled={mutation.isPending}>
+                {mutation.isPending ? 'Creating...' : 'Create Task'}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => navigate({ to: '/tasks' })}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `/tasks/new` route with a form for creating new tasks
- Form includes workspace (required), name (optional), and initial instruction (optional) fields
- On successful creation, navigates to the new task's detail page
- Add "New Task" button to the tasks list page header

## Test plan
- [ ] Navigate to /tasks and verify "New Task" button appears in the header
- [ ] Click "New Task" button and verify it navigates to /tasks/new
- [ ] Submit form with only workspace field filled - verify task is created
- [ ] Submit form with all fields filled - verify task is created with name and instruction
- [ ] Verify Cancel button navigates back to tasks list
- [ ] Verify successful task creation navigates to the new task's detail page