### PR TITLE
Add event creation page in v2 webui

### DIFF
--- a/webui/src/routes/events.index.tsx
+++ b/webui/src/routes/events.index.tsx
@@ -12,6 +12,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { RelativeTime } from '@/components/ui/relative-time'
+import { Button } from '@/components/ui/button'
 
 export const Route = createFileRoute('/events/')({
   component: EventsPage,
@@ -42,7 +43,12 @@ function EventsPage() {
 
   return (
     <div className="container mx-auto py-8 px-4">
-      <h1 className="text-2xl font-bold mb-6">Events</h1>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">Events</h1>
+        <Link to="/events/new">
+          <Button>Create Event</Button>
+        </Link>
+      </div>
       {events.length === 0 ? (
         <div className="text-muted-foreground text-center py-8">
           No events found

--- a/webui/src/routes/events.new.tsx
+++ b/webui/src/routes/events.new.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { useMutation } from '@connectrpc/connect-query'
+import { createEvent } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+
+export const Route = createFileRoute('/events/new')({
+  component: CreateEventPage,
+})
+
+function CreateEventPage() {
+  const navigate = useNavigate()
+  const [description, setDescription] = useState('')
+  const [url, setUrl] = useState('')
+  const [data, setData] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation(createEvent)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    try {
+      const response = await mutation.mutateAsync({
+        description,
+        url,
+        data,
+      })
+      if (response.event) {
+        navigate({ to: '/events/$id', params: { id: String(response.event.id) } })
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create event')
+    }
+  }
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <Link to="/events" className="text-primary hover:underline">
+        &larr; Back to Events
+      </Link>
+
+      <Card className="mt-6 max-w-2xl">
+        <CardHeader>
+          <CardTitle>Create Event</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <Input
+                id="description"
+                placeholder="Event description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="url">URL</Label>
+              <Input
+                id="url"
+                type="url"
+                placeholder="https://example.com/resource"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="data">Data (JSON)</Label>
+              <Textarea
+                id="data"
+                placeholder='{"key": "value"}'
+                value={data}
+                onChange={(e) => setData(e.target.value)}
+                rows={6}
+              />
+            </div>
+
+            {error && (
+              <div className="text-destructive text-sm">{error}</div>
+            )}
+
+            <div className="flex gap-2">
+              <Button type="submit" disabled={mutation.isPending}>
+                {mutation.isPending ? 'Creating...' : 'Create Event'}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => navigate({ to: '/events' })}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add new `/events/new` route with a form to create events
- Form includes fields for description, URL, and JSON data
- Add "Create Event" button to the events listing page
- Upon successful creation, redirects to the event detail page

## Test plan
- [ ] Navigate to `/events` and verify "Create Event" button appears
- [ ] Click "Create Event" and verify form displays with description, URL, and data fields
- [ ] Submit form with valid data and verify redirect to event detail page
- [ ] Verify the created event appears in the events list