### PR TITLE
Move add instruction button to left side

### DIFF
--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -244,7 +244,7 @@ function TaskDetail() {
               onChange={(e) => setInstruction(e.target.value)}
               required
             />
-            <div className="flex justify-end">
+            <div className="flex justify-start">
               <Button type="submit" disabled={updateMutation.isPending}>
                 Add Instruction
               </Button>


### PR DESCRIPTION
## Summary

Move the "Add Instruction" button from the right side to the left side in the task detail page.

## Changes

- Changed the flex container alignment from `justify-end` to `justify-start` for the add instruction button