### PR TITLE
Move links section above instructions in task detail page

### DIFF
--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -224,6 +224,14 @@ function TaskDetail() {
         )}
       </div>
 
+      {/* Links */}
+      {links.length > 0 && (
+        <div className="rounded-lg border p-6">
+          <h2 className="text-lg font-semibold mb-4">Links</h2>
+          <LinksSection links={links} />
+        </div>
+      )}
+
       {/* Instructions */}
       <div className="rounded-lg border p-6">
         <h2 className="text-lg font-semibold mb-4">Instructions</h2>
@@ -252,14 +260,6 @@ function TaskDetail() {
           </form>
         )}
       </div>
-
-      {/* Links */}
-      {links.length > 0 && (
-        <div className="rounded-lg border p-6">
-          <h2 className="text-lg font-semibold mb-4">Links</h2>
-          <LinksSection links={links} />
-        </div>
-      )}
 
       {/* Child Tasks */}
       {children.length > 0 && (


### PR DESCRIPTION
## Summary

- Reorders the task detail page (v2 webui) so that the Links section appears above the Instructions section
- This makes related resources (PRs, Jira tickets, etc.) more prominent on the page

## Test plan

- [ ] Visit a task detail page with links
- [ ] Verify the Links section appears above the Instructions section