### PR TITLE
Fix event create form width to match task create form

### DIFF
--- a/webui/src/routes/events.new.tsx
+++ b/webui/src/routes/events.new.tsx
@@ -49,7 +49,7 @@ function CreateEventPage() {
 
       <h1 className="text-2xl font-bold mb-6">Create Event</h1>
 
-      <Card className="max-w-2xl">
+      <Card>
         <CardContent className="pt-6">
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="space-y-2">


### PR DESCRIPTION
## Summary
- Remove `max-w-2xl` class from Card component on create event page so the form container matches the full-width styling of the create task page

## Test plan
- Navigate to /events/new and /tasks/new
- Verify the form containers have consistent width