### PR TITLE
Show 'Unnamed - id' for tasks without names

### DIFF
--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -143,7 +143,7 @@ function TaskDetail() {
       </div>
 
       <div className="flex justify-between items-start mb-6">
-        <h1 className="text-2xl font-bold">{task.name || `Task ${id}`}</h1>
+        <h1 className="text-2xl font-bold">{task.name || `Unnamed - ${id}`}</h1>
         <div className="flex gap-2">
           {canCancel && (
             <Button
@@ -366,7 +366,7 @@ function ChildTasksTable({ tasks }: { tasks: Task[] }) {
                 params={{ id: String(task.id) }}
                 className="text-primary hover:underline"
               >
-                {task.name || <code className="text-xs">{String(task.id)}</code>}
+                {task.name || `Unnamed - ${task.id}`}
               </Link>
             </TableCell>
             <TableCell>{task.workspace}</TableCell>

--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -116,7 +116,7 @@ function TaskRow({ task }: { task: Task }) {
           params={{ id: String(task.id) }}
           className="text-primary hover:underline"
         >
-          {task.name || <code className="text-xs">{String(task.id)}</code>}
+          {task.name || `Unnamed - ${task.id}`}
         </Link>
       </TableCell>
       <TableCell>{task.workspace}</TableCell>


### PR DESCRIPTION
## Summary

- Tasks without names now consistently display "Unnamed - {id}" across all UI locations
- Previously showed just the numeric ID in lists and "Task {id}" in detail headers
- Makes it clearer when a task hasn't been named yet

## Changes

- `webui/src/routes/tasks.index.tsx`: Tasks list now shows "Unnamed - {id}"
- `webui/src/routes/tasks.$id.tsx`: Task detail header and child tasks table now show "Unnamed - {id}"

## Test plan

- [ ] Create a task without a name
- [ ] Verify it shows "Unnamed - {id}" in the tasks list
- [ ] Navigate to the task detail page and verify header shows "Unnamed - {id}"
- [ ] If task has children without names, verify they show "Unnamed - {id}" in child tasks table