### PR TITLE
Add Create Task link to header navigation

### DIFF
--- a/webui/src/routes/__root.tsx
+++ b/webui/src/routes/__root.tsx
@@ -30,6 +30,12 @@ function RootComponent() {
             >
               Events
             </Link>
+            <Link
+              to="/tasks/new"
+              className="text-muted-foreground hover:text-foreground transition-colors [&.active]:text-foreground"
+            >
+              Create Task
+            </Link>
           </div>
         </div>
       </nav>


### PR DESCRIPTION
## Summary
- Adds a "Create Task" link to the common header navigation
- Allows users to create a new task from any page without having to navigate to the Tasks page first

## Test plan
- [ ] Navigate to any page in the web UI
- [ ] Verify "Create Task" link appears in the header between "Events" and the right side
- [ ] Click the link and verify it navigates to `/tasks/new`
- [ ] Verify the active state styling works when on the create task page