### PR TITLE
Fix event create form data field label

### DIFF
--- a/webui/src/routes/events.new.tsx
+++ b/webui/src/routes/events.new.tsx
@@ -75,10 +75,10 @@ function CreateEventPage() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="data">Data (JSON)</Label>
+              <Label htmlFor="data">Data</Label>
               <Textarea
                 id="data"
-                placeholder='{"key": "value"}'
+                placeholder="Event data (text, JSON, etc.)"
                 value={data}
                 onChange={(e) => setData(e.target.value)}
                 rows={6}


### PR DESCRIPTION
## Summary

The data field on the Create Event page was incorrectly labeled as "(JSON)" with a JSON placeholder (`{"key": "value"}`), implying the field only accepts JSON. However, the data field can contain any text content - comments, JSON, or other arbitrary data.

Changes:
- Removed "(JSON)" from the label, now just "Data"
- Updated placeholder from `{"key": "value"}` to `Event data (text, JSON, etc.)`

## Test plan

- [ ] Navigate to Create Event page (`/events/new`)
- [ ] Verify the data field label now shows just "Data" instead of "Data (JSON)"
- [ ] Verify the placeholder shows "Event data (text, JSON, etc.)"
- [ ] Create an event with plain text in the data field and verify it works