### PR TITLE
Remove redundant back links from detail and create pages

### DIFF
--- a/webui/src/routes/events.$id.tsx
+++ b/webui/src/routes/events.$id.tsx
@@ -54,12 +54,6 @@ function EventDetail() {
 
   return (
     <div className="container mx-auto py-8 px-4">
-      <div className="mb-6">
-        <Link to="/events" className="text-primary hover:underline">
-          &larr; Back to Events
-        </Link>
-      </div>
-
       <h1 className="text-2xl font-bold mb-6">Event {String(event.id)}</h1>
 
       <div className="space-y-6">

--- a/webui/src/routes/events.new.tsx
+++ b/webui/src/routes/events.new.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useMutation } from '@connectrpc/connect-query'
 import { createEvent } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
 import { Card, CardContent } from '@/components/ui/card'
@@ -41,12 +41,6 @@ function CreateEventPage() {
 
   return (
     <div className="container mx-auto py-8 px-4 space-y-6">
-      <div className="mb-6">
-        <Link to="/events" className="text-primary hover:underline">
-          &larr; Back to Events
-        </Link>
-      </div>
-
       <h1 className="text-2xl font-bold mb-6">Create Event</h1>
 
       <Card>

--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -136,12 +136,6 @@ function TaskDetail() {
 
   return (
     <div className="container mx-auto py-8 px-4 space-y-6">
-      <div className="mb-6">
-        <Link to="/tasks" className="text-primary hover:underline">
-          &larr; Back to Tasks
-        </Link>
-      </div>
-
       <div className="flex justify-between items-start mb-6">
         <h1 className="text-2xl font-bold">{task.name || `Task ${id}`}</h1>
         <div className="flex gap-2">

--- a/webui/src/routes/tasks.new.tsx
+++ b/webui/src/routes/tasks.new.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useMutation } from '@connectrpc/connect-query'
 import { createTask } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
 import { Button } from '@/components/ui/button'
@@ -43,12 +43,6 @@ function NewTaskPage() {
 
   return (
     <div className="container mx-auto py-8 px-4 space-y-6">
-      <div className="mb-6">
-        <Link to="/tasks" className="text-primary hover:underline">
-          &larr; Back to Tasks
-        </Link>
-      </div>
-
       <h1 className="text-2xl font-bold mb-6">Create New Task</h1>
 
       <Card>


### PR DESCRIPTION
## Summary

- Remove "Back to Tasks" links from task detail and task create pages
- Remove "Back to Events" links from event detail and event create pages
- These links are redundant since the common header already provides navigation to Tasks and Events

## Test plan

- [ ] Navigate to a task detail page and verify navigation works via header
- [ ] Navigate to the create task page and verify navigation works via header
- [ ] Navigate to an event detail page and verify navigation works via header
- [ ] Navigate to the create event page and verify navigation works via header