### PR TITLE
Move name field to top of create task form

### DIFF
--- a/webui/src/routes/tasks.new.tsx
+++ b/webui/src/routes/tasks.new.tsx
@@ -55,6 +55,16 @@ function NewTaskPage() {
         <CardContent className="pt-6">
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="space-y-2">
+              <Label htmlFor="name">Name (optional)</Label>
+              <Input
+                id="name"
+                placeholder="Enter task name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
               <Label htmlFor="workspace">Workspace</Label>
               <Input
                 id="workspace"
@@ -66,16 +76,6 @@ function NewTaskPage() {
               <p className="text-sm text-muted-foreground">
                 The workspace defines the container configuration for the task
               </p>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="name">Name (optional)</Label>
-              <Input
-                id="name"
-                placeholder="Enter task name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-              />
             </div>
 
             <div className="space-y-2">


### PR DESCRIPTION
## Summary
- Reorders form fields in the create task page so that the name field appears first
- New field order: Name → Workspace → Initial Instruction

## Test plan
- [ ] Navigate to the create task page (/tasks/new)
- [ ] Verify name field appears before workspace field
- [ ] Create a task and verify form still works correctly