### PR TITLE
Fix task list archive button to update UI immediately

### DIFF
--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -29,7 +29,7 @@ function TasksPage() {
     return stored !== null ? stored === 'true' : false
   })
 
-  const { data, isLoading, error } = useQuery(listTasks, {}, {
+  const { data, isLoading, error, refetch } = useQuery(listTasks, {}, {
     refetchInterval: 3000,
   })
 
@@ -97,7 +97,7 @@ function TasksPage() {
           </TableHeader>
           <TableBody>
             {tasks.map((task) => (
-              <TaskRow key={String(task.id)} task={task} />
+              <TaskRow key={String(task.id)} task={task} onUpdate={refetch} />
             ))}
           </TableBody>
         </Table>
@@ -106,13 +106,14 @@ function TasksPage() {
   )
 }
 
-function TaskRow({ task }: { task: Task }) {
+function TaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) {
   const isChild = task.parent !== 0n
   const updateMutation = useMutation(updateTask)
   const canArchive = task.status === 'completed' || task.status === 'failed'
 
   const handleArchive = async () => {
     await updateMutation.mutateAsync({ id: task.id, status: 'archived' })
+    onUpdate()
   }
 
   return (


### PR DESCRIPTION
## Summary

- Pass `refetch` function from parent `TasksPage` to `TaskRow` component
- Call `refetch()` after successful archive mutation to immediately update the task list
- Follows the same pattern used in `tasks.$id.tsx` for status updates

## Test plan

- Navigate to task list page
- Click "Archive" button on a completed or failed task
- Verify the task immediately updates to archived status without waiting for refresh