### PR TITLE
Move create buttons from list pages to common header

### DIFF
--- a/webui/src/routes/__root.tsx
+++ b/webui/src/routes/__root.tsx
@@ -1,7 +1,9 @@
-import { Outlet, createRootRouteWithContext, Link } from '@tanstack/react-router'
+import { Outlet, createRootRouteWithContext, Link, useRouterState } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import { QueryClient } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { Button } from '@/components/ui/button'
+import { Plus } from 'lucide-react'
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient
@@ -10,6 +12,13 @@ export const Route = createRootRouteWithContext<{
 })
 
 function RootComponent() {
+  const routerState = useRouterState()
+  const pathname = routerState.location.pathname
+
+  // Show "+ Task" button on /tasks, "+ Event" button on /events
+  const showTaskButton = pathname === '/tasks' || pathname === '/tasks/'
+  const showEventButton = pathname === '/events' || pathname === '/events/'
+
   return (
     <>
       <nav className="border-b">
@@ -30,13 +39,24 @@ function RootComponent() {
             >
               Events
             </Link>
-            <Link
-              to="/tasks/new"
-              className="text-muted-foreground hover:text-foreground transition-colors [&.active]:text-foreground"
-            >
-              Create Task
-            </Link>
           </div>
+          <div className="flex-1" />
+          {showTaskButton && (
+            <Link to="/tasks/new">
+              <Button>
+                <Plus className="h-4 w-4" />
+                Task
+              </Button>
+            </Link>
+          )}
+          {showEventButton && (
+            <Link to="/events/new">
+              <Button>
+                <Plus className="h-4 w-4" />
+                Event
+              </Button>
+            </Link>
+          )}
         </div>
       </nav>
       <Outlet />

--- a/webui/src/routes/events.index.tsx
+++ b/webui/src/routes/events.index.tsx
@@ -12,8 +12,6 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { RelativeTime } from '@/components/ui/relative-time'
-import { Button } from '@/components/ui/button'
-import { Plus } from 'lucide-react'
 
 export const Route = createFileRoute('/events/')({
   component: EventsPage,
@@ -44,14 +42,8 @@ function EventsPage() {
 
   return (
     <div className="container mx-auto py-8 px-4">
-      <div className="flex items-center justify-between mb-6">
+      <div className="mb-6">
         <h1 className="text-2xl font-bold">Events</h1>
-        <Link to="/events/new">
-          <Button>
-            <Plus className="h-4 w-4" />
-            Event
-          </Button>
-        </Link>
       </div>
       {events.length === 0 ? (
         <div className="text-muted-foreground text-center py-8">

--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -18,7 +18,6 @@ import { Switch } from '@/components/ui/switch'
 import { RelativeTime } from '@/components/ui/relative-time'
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
-import { Plus } from 'lucide-react'
 
 export const Route = createFileRoute('/tasks/')({
   component: TasksPage,
@@ -65,23 +64,15 @@ function TasksPage() {
     <div className="container mx-auto py-8 px-4">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Tasks</h1>
-        <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2">
-            <Label htmlFor="show-child-tasks" className="text-sm text-muted-foreground cursor-pointer">
-              Show child tasks{hiddenCount > 0 && !showChildTasks && ` (${hiddenCount} hidden)`}
-            </Label>
-            <Switch
-              id="show-child-tasks"
-              checked={showChildTasks}
-              onCheckedChange={handleToggleChildTasks}
-            />
-          </div>
-          <Link to="/tasks/new">
-            <Button>
-              <Plus className="h-4 w-4" />
-              Task
-            </Button>
-          </Link>
+        <div className="flex items-center gap-2">
+          <Label htmlFor="show-child-tasks" className="text-sm text-muted-foreground cursor-pointer">
+            Show child tasks{hiddenCount > 0 && !showChildTasks && ` (${hiddenCount} hidden)`}
+          </Label>
+          <Switch
+            id="show-child-tasks"
+            checked={showChildTasks}
+            onCheckedChange={handleToggleChildTasks}
+          />
         </div>
       </div>
       {tasks.length === 0 ? (


### PR DESCRIPTION
## Summary

- Move "+ Task" button from tasks list page to the common header
- Move "+ Event" button from events list page to the common header
- Buttons appear contextually on the right side of the header based on the current route
- Remove the static "Create Task" link from the header navigation

## Test plan

- [ ] Visit `/tasks` page and verify "+ Task" button appears in the header
- [ ] Visit `/events` page and verify "+ Event" button appears in the header
- [ ] Visit other pages and verify no create buttons appear in the header
- [ ] Click the buttons and verify they navigate to the correct create pages