### PR TITLE
Change Create Task nav link to button style

### DIFF
--- a/webui/src/routes/__root.tsx
+++ b/webui/src/routes/__root.tsx
@@ -19,7 +19,7 @@ function RootComponent() {
           <Link to="/" className="font-semibold text-lg">
             XAgent
           </Link>
-          <div className="flex gap-4">
+          <div className="flex items-center gap-4">
             <Link
               to="/tasks"
               className="text-muted-foreground hover:text-foreground transition-colors [&.active]:text-foreground"


### PR DESCRIPTION
## Summary
- Replace the plain text "Create Task" link in the navigation bar with a styled button
- Match the "+ Task" button appearance used in the task list view
- Use shadcn Button component with Plus icon from lucide-react

## Test plan
- [ ] Verify the button appears in the navigation bar with Plus icon and "Task" text
- [ ] Click the button and verify it navigates to `/tasks/new`
- [ ] Confirm visual consistency with the "+ Task" button in the task list view