### PR TITLE
Fix go:embed placeholder file in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           go-version: '1.23'
 
       - name: Create empty webui directory for go:embed
-        run: mkdir -p internal/server/webui && touch internal/server/webui/.gitkeep
+        run: mkdir -p internal/server/webui && echo "placeholder" > internal/server/webui/index.html
 
       - name: Download dependencies
         run: go mod download


### PR DESCRIPTION
## Summary
- Fix CI test workflow that was failing with `pattern webui: cannot embed directory webui: contains no embeddable files`
- The `.gitkeep` file was not embeddable because Go's `embed` directive ignores files starting with `.` by default
- Changed placeholder to `index.html` which is a valid embeddable file

## Test plan
- [x] Verified fix locally by running `go build ./...` and `go test ./...`