### PR TITLE
Add context parameter to all repository methods

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -68,7 +68,7 @@ func (s *Server) ListTasks(ctx context.Context, req *xagentv1.ListTasksRequest) 
 	for i, s := range req.Statuses {
 		statuses[i] = model.TaskStatus(s)
 	}
-	tasks, err = s.tasks.ListByStatuses(statuses)
+	tasks, err = s.tasks.ListByStatuses(ctx, statuses)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -83,7 +83,7 @@ func (s *Server) ListTasks(ctx context.Context, req *xagentv1.ListTasksRequest) 
 }
 
 func (s *Server) ListChildTasks(ctx context.Context, req *xagentv1.ListChildTasksRequest) (*xagentv1.ListChildTasksResponse, error) {
-	tasks, err := s.tasks.ListChildren(req.ParentId)
+	tasks, err := s.tasks.ListChildren(ctx, req.ParentId)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -111,7 +111,7 @@ func (s *Server) CreateTask(ctx context.Context, req *xagentv1.CreateTaskRequest
 		Status:       model.TaskStatusPending,
 	}
 
-	if err := s.tasks.Create(task); err != nil {
+	if err := s.tasks.Create(ctx, task); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
@@ -122,7 +122,7 @@ func (s *Server) CreateTask(ctx context.Context, req *xagentv1.CreateTaskRequest
 }
 
 func (s *Server) GetTask(ctx context.Context, req *xagentv1.GetTaskRequest) (*xagentv1.GetTaskResponse, error) {
-	task, err := s.tasks.Get(req.Id)
+	task, err := s.tasks.Get(ctx, req.Id)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
@@ -133,14 +133,14 @@ func (s *Server) GetTask(ctx context.Context, req *xagentv1.GetTaskRequest) (*xa
 }
 
 func (s *Server) GetTaskDetails(ctx context.Context, req *xagentv1.GetTaskDetailsRequest) (*xagentv1.GetTaskDetailsResponse, error) {
-	task, err := s.tasks.Get(req.Id)
+	task, err := s.tasks.Get(ctx, req.Id)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
 
-	children, _ := s.tasks.ListChildren(req.Id)
-	events, _ := s.events.ListByTask(req.Id)
-	links, _ := s.links.ListByTask(req.Id)
+	children, _ := s.tasks.ListChildren(ctx, req.Id)
+	events, _ := s.events.ListByTask(ctx, req.Id)
+	links, _ := s.links.ListByTask(ctx, req.Id)
 
 	resp := &xagentv1.GetTaskDetailsResponse{
 		Task:     task.Proto(),
@@ -166,7 +166,7 @@ func (s *Server) UpdateTask(ctx context.Context, req *xagentv1.UpdateTaskRequest
 		instructions[i] = model.InstructionFromProto(inst)
 	}
 
-	if err := s.tasks.Update(req.Id, store.TaskUpdate{
+	if err := s.tasks.Update(ctx, req.Id, store.TaskUpdate{
 		Name:            req.Name,
 		Status:          model.TaskStatus(req.Status),
 		AddInstructions: instructions,
@@ -179,7 +179,7 @@ func (s *Server) UpdateTask(ctx context.Context, req *xagentv1.UpdateTaskRequest
 }
 
 func (s *Server) DeleteTask(ctx context.Context, req *xagentv1.DeleteTaskRequest) (*xagentv1.DeleteTaskResponse, error) {
-	if err := s.tasks.Delete(req.Id); err != nil {
+	if err := s.tasks.Delete(ctx, req.Id); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
@@ -196,14 +196,14 @@ func (s *Server) UploadLogs(ctx context.Context, req *xagentv1.UploadLogsRequest
 			Content: entry.Content,
 		}
 	}
-	if err := s.logs.CreateBatch(logs); err != nil {
+	if err := s.logs.CreateBatch(ctx, logs); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	return &xagentv1.UploadLogsResponse{}, nil
 }
 
 func (s *Server) ListLogs(ctx context.Context, req *xagentv1.ListLogsRequest) (*xagentv1.ListLogsResponse, error) {
-	logs, err := s.logs.ListByTask(req.TaskId)
+	logs, err := s.logs.ListByTask(ctx, req.TaskId)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -228,7 +228,7 @@ func (s *Server) CreateLink(ctx context.Context, req *xagentv1.CreateLinkRequest
 		Notify:    req.Notify,
 		CreatedAt: time.Now(),
 	}
-	if err := s.links.Create(link); err != nil {
+	if err := s.links.Create(ctx, link); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	s.log.Info("link created", "task", req.TaskId, "relevance", req.Relevance, "url", req.Url)
@@ -238,7 +238,7 @@ func (s *Server) CreateLink(ctx context.Context, req *xagentv1.CreateLinkRequest
 }
 
 func (s *Server) ListLinks(ctx context.Context, req *xagentv1.ListLinksRequest) (*xagentv1.ListLinksResponse, error) {
-	links, err := s.links.ListByTask(req.TaskId)
+	links, err := s.links.ListByTask(ctx, req.TaskId)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -252,7 +252,7 @@ func (s *Server) ListLinks(ctx context.Context, req *xagentv1.ListLinksRequest) 
 }
 
 func (s *Server) FindLinksByURL(ctx context.Context, req *xagentv1.FindLinksByURLRequest) (*xagentv1.FindLinksByURLResponse, error) {
-	links, err := s.links.FindByURL(req.Url)
+	links, err := s.links.FindByURL(ctx, req.Url)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -272,7 +272,7 @@ func (s *Server) ListEvents(ctx context.Context, req *xagentv1.ListEventsRequest
 	if limit < 0 || limit > maxLimit {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("limit must be at most %d", maxLimit))
 	}
-	events, err := s.events.List(limit)
+	events, err := s.events.List(ctx, limit)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -291,7 +291,7 @@ func (s *Server) CreateEvent(ctx context.Context, req *xagentv1.CreateEventReque
 		Data:        req.Data,
 		URL:         req.Url,
 	}
-	if err := s.events.Create(event); err != nil {
+	if err := s.events.Create(ctx, event); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	s.log.Info("event created", "id", event.ID, "description", event.Description)
@@ -301,7 +301,7 @@ func (s *Server) CreateEvent(ctx context.Context, req *xagentv1.CreateEventReque
 }
 
 func (s *Server) GetEvent(ctx context.Context, req *xagentv1.GetEventRequest) (*xagentv1.GetEventResponse, error) {
-	event, err := s.events.Get(req.Id)
+	event, err := s.events.Get(ctx, req.Id)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
@@ -311,7 +311,7 @@ func (s *Server) GetEvent(ctx context.Context, req *xagentv1.GetEventRequest) (*
 }
 
 func (s *Server) DeleteEvent(ctx context.Context, req *xagentv1.DeleteEventRequest) (*xagentv1.DeleteEventResponse, error) {
-	if err := s.events.Delete(req.Id); err != nil {
+	if err := s.events.Delete(ctx, req.Id); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	s.log.Info("event deleted", "id", req.Id)
@@ -319,7 +319,7 @@ func (s *Server) DeleteEvent(ctx context.Context, req *xagentv1.DeleteEventReque
 }
 
 func (s *Server) AddEventTask(ctx context.Context, req *xagentv1.AddEventTaskRequest) (*xagentv1.AddEventTaskResponse, error) {
-	if err := s.events.AddTask(req.EventId, req.TaskId); err != nil {
+	if err := s.events.AddTask(ctx, req.EventId, req.TaskId); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	s.log.Info("event task added", "event_id", req.EventId, "task_id", req.TaskId)
@@ -327,7 +327,7 @@ func (s *Server) AddEventTask(ctx context.Context, req *xagentv1.AddEventTaskReq
 }
 
 func (s *Server) RemoveEventTask(ctx context.Context, req *xagentv1.RemoveEventTaskRequest) (*xagentv1.RemoveEventTaskResponse, error) {
-	if err := s.events.RemoveTask(req.EventId, req.TaskId); err != nil {
+	if err := s.events.RemoveTask(ctx, req.EventId, req.TaskId); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	s.log.Info("event task removed", "event_id", req.EventId, "task_id", req.TaskId)
@@ -335,7 +335,7 @@ func (s *Server) RemoveEventTask(ctx context.Context, req *xagentv1.RemoveEventT
 }
 
 func (s *Server) ListEventTasks(ctx context.Context, req *xagentv1.ListEventTasksRequest) (*xagentv1.ListEventTasksResponse, error) {
-	tasks, err := s.events.ListTasks(req.EventId)
+	tasks, err := s.events.ListTasks(ctx, req.EventId)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -343,7 +343,7 @@ func (s *Server) ListEventTasks(ctx context.Context, req *xagentv1.ListEventTask
 }
 
 func (s *Server) ListEventsByTask(ctx context.Context, req *xagentv1.ListEventsByTaskRequest) (*xagentv1.ListEventsByTaskResponse, error) {
-	events, err := s.events.ListByTask(req.TaskId)
+	events, err := s.events.ListByTask(ctx, req.TaskId)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -357,7 +357,7 @@ func (s *Server) ListEventsByTask(ctx context.Context, req *xagentv1.ListEventsB
 }
 
 func (s *Server) ProcessEvent(ctx context.Context, req *xagentv1.ProcessEventRequest) (*xagentv1.ProcessEventResponse, error) {
-	event, err := s.events.Get(req.Id)
+	event, err := s.events.Get(ctx, req.Id)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
@@ -366,7 +366,7 @@ func (s *Server) ProcessEvent(ctx context.Context, req *xagentv1.ProcessEventReq
 		return &xagentv1.ProcessEventResponse{}, nil
 	}
 
-	links, err := s.links.FindByURL(event.URL)
+	links, err := s.links.FindByURL(ctx, event.URL)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -378,7 +378,7 @@ func (s *Server) ProcessEvent(ctx context.Context, req *xagentv1.ProcessEventReq
 			continue
 		}
 		// Skip archived tasks
-		task, err := s.tasks.Get(link.TaskID)
+		task, err := s.tasks.Get(ctx, link.TaskID)
 		if err != nil {
 			s.log.Warn("failed to get task", "task_id", link.TaskID, "error", err)
 			continue
@@ -388,10 +388,10 @@ func (s *Server) ProcessEvent(ctx context.Context, req *xagentv1.ProcessEventReq
 			continue
 		}
 		taskIDs[link.TaskID] = true
-		if err := s.events.AddTask(req.Id, link.TaskID); err != nil {
+		if err := s.events.AddTask(ctx, req.Id, link.TaskID); err != nil {
 			s.log.Warn("failed to add event task", "event_id", req.Id, "task_id", link.TaskID, "error", err)
 		}
-		if err := s.tasks.Update(link.TaskID, store.TaskUpdate{Status: model.TaskStatusRestarting}); err != nil {
+		if err := s.tasks.Update(ctx, link.TaskID, store.TaskUpdate{Status: model.TaskStatusRestarting}); err != nil {
 			s.log.Warn("failed to restart task", "task_id", link.TaskID, "error", err)
 		}
 	}

--- a/internal/store/event.go
+++ b/internal/store/event.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"time"
 
@@ -15,8 +16,8 @@ func NewEventRepository(db *sql.DB) *EventRepository {
 	return &EventRepository{db: db}
 }
 
-func (r *EventRepository) Create(event *model.Event) error {
-	result, err := r.db.Exec(`
+func (r *EventRepository) Create(ctx context.Context, event *model.Event) error {
+	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO events (description, data, url, created_at)
 		VALUES (?, ?, ?, ?)
 	`, event.Description, event.Data, event.URL, time.Now())
@@ -27,10 +28,10 @@ func (r *EventRepository) Create(event *model.Event) error {
 	return nil
 }
 
-func (r *EventRepository) Get(id int64) (*model.Event, error) {
+func (r *EventRepository) Get(ctx context.Context, id int64) (*model.Event, error) {
 	var event model.Event
 	var url sql.NullString
-	err := r.db.QueryRow(`
+	err := r.db.QueryRowContext(ctx, `
 		SELECT id, description, data, url, created_at
 		FROM events WHERE id = ?
 	`, id).Scan(&event.ID, &event.Description, &event.Data, &url, &event.CreatedAt)
@@ -41,8 +42,8 @@ func (r *EventRepository) Get(id int64) (*model.Event, error) {
 	return &event, nil
 }
 
-func (r *EventRepository) List(limit int) ([]*model.Event, error) {
-	rows, err := r.db.Query(`
+func (r *EventRepository) List(ctx context.Context, limit int) ([]*model.Event, error) {
+	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, description, data, url, created_at
 		FROM events ORDER BY created_at DESC
 		LIMIT ?
@@ -54,8 +55,8 @@ func (r *EventRepository) List(limit int) ([]*model.Event, error) {
 	return r.scanEvents(rows)
 }
 
-func (r *EventRepository) FindByURL(url string) ([]*model.Event, error) {
-	rows, err := r.db.Query(`
+func (r *EventRepository) FindByURL(ctx context.Context, url string) ([]*model.Event, error) {
+	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, description, data, url, created_at
 		FROM events WHERE url = ? ORDER BY created_at DESC
 	`, url)
@@ -66,38 +67,38 @@ func (r *EventRepository) FindByURL(url string) ([]*model.Event, error) {
 	return r.scanEvents(rows)
 }
 
-func (r *EventRepository) Delete(id int64) error {
-	tx, err := r.db.Begin()
+func (r *EventRepository) Delete(ctx context.Context, id int64) error {
+	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
 
-	if _, err := tx.Exec(`DELETE FROM event_tasks WHERE event_id = ?`, id); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM event_tasks WHERE event_id = ?`, id); err != nil {
 		return err
 	}
-	if _, err := tx.Exec(`DELETE FROM events WHERE id = ?`, id); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE id = ?`, id); err != nil {
 		return err
 	}
 	return tx.Commit()
 }
 
-func (r *EventRepository) AddTask(eventID int64, taskID int64) error {
-	_, err := r.db.Exec(`
+func (r *EventRepository) AddTask(ctx context.Context, eventID int64, taskID int64) error {
+	_, err := r.db.ExecContext(ctx, `
 		INSERT OR IGNORE INTO event_tasks (event_id, task_id) VALUES (?, ?)
 	`, eventID, taskID)
 	return err
 }
 
-func (r *EventRepository) RemoveTask(eventID int64, taskID int64) error {
-	_, err := r.db.Exec(`
+func (r *EventRepository) RemoveTask(ctx context.Context, eventID int64, taskID int64) error {
+	_, err := r.db.ExecContext(ctx, `
 		DELETE FROM event_tasks WHERE event_id = ? AND task_id = ?
 	`, eventID, taskID)
 	return err
 }
 
-func (r *EventRepository) ListTasks(eventID int64) ([]int64, error) {
-	rows, err := r.db.Query(`
+func (r *EventRepository) ListTasks(ctx context.Context, eventID int64) ([]int64, error) {
+	rows, err := r.db.QueryContext(ctx, `
 		SELECT task_id FROM event_tasks WHERE event_id = ?
 	`, eventID)
 	if err != nil {
@@ -116,8 +117,8 @@ func (r *EventRepository) ListTasks(eventID int64) ([]int64, error) {
 	return tasks, rows.Err()
 }
 
-func (r *EventRepository) ListByTask(taskID int64) ([]*model.Event, error) {
-	rows, err := r.db.Query(`
+func (r *EventRepository) ListByTask(ctx context.Context, taskID int64) ([]*model.Event, error) {
+	rows, err := r.db.QueryContext(ctx, `
 		SELECT e.id, e.description, e.data, e.url, e.created_at
 		FROM events e
 		JOIN event_tasks et ON e.id = et.event_id

--- a/internal/store/link.go
+++ b/internal/store/link.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/icholy/xagent/internal/model"
@@ -14,8 +15,8 @@ func NewLinkRepository(db *sql.DB) *LinkRepository {
 	return &LinkRepository{db: db}
 }
 
-func (r *LinkRepository) Create(link *model.Link) error {
-	result, err := r.db.Exec(`
+func (r *LinkRepository) Create(ctx context.Context, link *model.Link) error {
+	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO task_links (task_id, relevance, url, title, notify, created_at)
 		VALUES (?, ?, ?, ?, ?, ?)
 	`, link.TaskID, link.Relevance, link.URL, link.Title, link.Notify, link.CreatedAt)
@@ -26,8 +27,8 @@ func (r *LinkRepository) Create(link *model.Link) error {
 	return nil
 }
 
-func (r *LinkRepository) ListByTask(taskID int64) ([]*model.Link, error) {
-	rows, err := r.db.Query(`
+func (r *LinkRepository) ListByTask(ctx context.Context, taskID int64) ([]*model.Link, error) {
+	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, task_id, relevance, url, title, notify, created_at
 		FROM task_links WHERE task_id = ? ORDER BY created_at ASC
 	`, taskID)
@@ -49,13 +50,13 @@ func (r *LinkRepository) ListByTask(taskID int64) ([]*model.Link, error) {
 	return links, rows.Err()
 }
 
-func (r *LinkRepository) Delete(id int64) error {
-	_, err := r.db.Exec(`DELETE FROM task_links WHERE id = ?`, id)
+func (r *LinkRepository) Delete(ctx context.Context, id int64) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM task_links WHERE id = ?`, id)
 	return err
 }
 
-func (r *LinkRepository) FindByURL(url string) ([]*model.Link, error) {
-	rows, err := r.db.Query(`
+func (r *LinkRepository) FindByURL(ctx context.Context, url string) ([]*model.Link, error) {
+	rows, err := r.db.QueryContext(ctx, `
 		SELECT l.id, l.task_id, l.relevance, l.url, l.title, l.notify, l.created_at
 		FROM task_links l
 		JOIN tasks t ON l.task_id = t.id

--- a/internal/store/log.go
+++ b/internal/store/log.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"time"
 
@@ -15,8 +16,8 @@ func NewLogRepository(db *sql.DB) *LogRepository {
 	return &LogRepository{db: db}
 }
 
-func (r *LogRepository) Create(log *model.Log) error {
-	result, err := r.db.Exec(`
+func (r *LogRepository) Create(ctx context.Context, log *model.Log) error {
+	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO logs (task_id, type, content, created_at)
 		VALUES (?, ?, ?, ?)
 	`, log.TaskID, log.Type, log.Content, time.Now())
@@ -27,14 +28,14 @@ func (r *LogRepository) Create(log *model.Log) error {
 	return nil
 }
 
-func (r *LogRepository) CreateBatch(logs []*model.Log) error {
-	tx, err := r.db.Begin()
+func (r *LogRepository) CreateBatch(ctx context.Context, logs []*model.Log) error {
+	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
 
-	stmt, err := tx.Prepare(`
+	stmt, err := tx.PrepareContext(ctx, `
 		INSERT INTO logs (task_id, type, content, created_at)
 		VALUES (?, ?, ?, ?)
 	`)
@@ -45,7 +46,7 @@ func (r *LogRepository) CreateBatch(logs []*model.Log) error {
 
 	now := time.Now()
 	for _, log := range logs {
-		result, err := stmt.Exec(log.TaskID, log.Type, log.Content, now)
+		result, err := stmt.ExecContext(ctx, log.TaskID, log.Type, log.Content, now)
 		if err != nil {
 			return err
 		}
@@ -55,8 +56,8 @@ func (r *LogRepository) CreateBatch(logs []*model.Log) error {
 	return tx.Commit()
 }
 
-func (r *LogRepository) ListByTask(taskID int64) ([]*model.Log, error) {
-	rows, err := r.db.Query(`
+func (r *LogRepository) ListByTask(ctx context.Context, taskID int64) ([]*model.Log, error) {
+	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, task_id, type, content, created_at
 		FROM logs WHERE task_id = ? ORDER BY created_at ASC
 	`, taskID)

--- a/internal/store/task.go
+++ b/internal/store/task.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -18,14 +19,14 @@ func NewTaskRepository(db *sql.DB) *TaskRepository {
 	return &TaskRepository{db: db}
 }
 
-func (r *TaskRepository) Create(task *model.Task) error {
+func (r *TaskRepository) Create(ctx context.Context, task *model.Task) error {
 	instructions, err := json.Marshal(task.Instructions)
 	if err != nil {
 		return err
 	}
 
 	now := time.Now()
-	result, err := r.db.Exec(`
+	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO tasks (name, parent, workspace, prompts, status, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?)
 	`, task.Name, task.Parent, task.Workspace, instructions, task.Status, now, now)
@@ -43,16 +44,16 @@ func (r *TaskRepository) Create(task *model.Task) error {
 	return nil
 }
 
-func (r *TaskRepository) Get(id int64) (*model.Task, error) {
-	row := r.db.QueryRow(`
+func (r *TaskRepository) Get(ctx context.Context, id int64) (*model.Task, error) {
+	row := r.db.QueryRowContext(ctx, `
 		SELECT id, name, parent, workspace, prompts, status, created_at, updated_at
 		FROM tasks WHERE id = ?
 	`, id)
 	return r.scanTask(row)
 }
 
-func (r *TaskRepository) List() ([]*model.Task, error) {
-	rows, err := r.db.Query(`
+func (r *TaskRepository) List(ctx context.Context) ([]*model.Task, error) {
+	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, parent, workspace, prompts, status, created_at, updated_at
 		FROM tasks WHERE status != 'archived' ORDER BY created_at DESC
 	`)
@@ -64,9 +65,9 @@ func (r *TaskRepository) List() ([]*model.Task, error) {
 	return r.scanTasks(rows)
 }
 
-func (r *TaskRepository) ListByStatuses(statuses []model.TaskStatus) ([]*model.Task, error) {
+func (r *TaskRepository) ListByStatuses(ctx context.Context, statuses []model.TaskStatus) ([]*model.Task, error) {
 	if len(statuses) == 0 {
-		return r.List()
+		return r.List(ctx)
 	}
 	placeholders := make([]string, len(statuses))
 	args := make([]any, len(statuses))
@@ -78,7 +79,7 @@ func (r *TaskRepository) ListByStatuses(statuses []model.TaskStatus) ([]*model.T
 		SELECT id, name, parent, workspace, prompts, status, created_at, updated_at
 		FROM tasks WHERE status IN (%s) ORDER BY created_at DESC
 	`, strings.Join(placeholders, ","))
-	rows, err := r.db.Query(query, args...)
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +88,8 @@ func (r *TaskRepository) ListByStatuses(statuses []model.TaskStatus) ([]*model.T
 	return r.scanTasks(rows)
 }
 
-func (r *TaskRepository) ListChildren(parentID int64) ([]*model.Task, error) {
-	rows, err := r.db.Query(`
+func (r *TaskRepository) ListChildren(ctx context.Context, parentID int64) ([]*model.Task, error) {
+	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, parent, workspace, prompts, status, created_at, updated_at
 		FROM tasks WHERE parent = ? ORDER BY created_at DESC
 	`, parentID)
@@ -100,8 +101,8 @@ func (r *TaskRepository) ListChildren(parentID int64) ([]*model.Task, error) {
 	return r.scanTasks(rows)
 }
 
-func (r *TaskRepository) ListByEvent(eventID int64) ([]*model.Task, error) {
-	rows, err := r.db.Query(`
+func (r *TaskRepository) ListByEvent(ctx context.Context, eventID int64) ([]*model.Task, error) {
+	rows, err := r.db.QueryContext(ctx, `
 		SELECT t.id, t.name, t.parent, t.workspace, t.prompts, t.status, t.created_at, t.updated_at
 		FROM tasks t
 		JOIN event_tasks et ON t.id = et.task_id
@@ -123,8 +124,8 @@ type TaskUpdate struct {
 	AddInstructions []model.Instruction
 }
 
-func (r *TaskRepository) Update(id int64, update TaskUpdate) error {
-	tx, err := r.db.Begin()
+func (r *TaskRepository) Update(ctx context.Context, id int64, update TaskUpdate) error {
+	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -132,7 +133,7 @@ func (r *TaskRepository) Update(id int64, update TaskUpdate) error {
 
 	// Add instructions if provided
 	if len(update.AddInstructions) > 0 {
-		row := tx.QueryRow(`SELECT prompts FROM tasks WHERE id = ?`, id)
+		row := tx.QueryRowContext(ctx, `SELECT prompts FROM tasks WHERE id = ?`, id)
 
 		var existing []byte
 		if err := row.Scan(&existing); err != nil {
@@ -150,7 +151,7 @@ func (r *TaskRepository) Update(id int64, update TaskUpdate) error {
 			return err
 		}
 
-		_, err = tx.Exec(`
+		_, err = tx.ExecContext(ctx, `
 			UPDATE tasks SET prompts = ?, updated_at = ? WHERE id = ?
 		`, data, time.Now(), id)
 		if err != nil {
@@ -160,7 +161,7 @@ func (r *TaskRepository) Update(id int64, update TaskUpdate) error {
 
 	// Update name if provided
 	if update.Name != "" {
-		_, err = tx.Exec(`
+		_, err = tx.ExecContext(ctx, `
 			UPDATE tasks SET name = ?, updated_at = ? WHERE id = ?
 		`, update.Name, time.Now(), id)
 		if err != nil {
@@ -170,7 +171,7 @@ func (r *TaskRepository) Update(id int64, update TaskUpdate) error {
 
 	// Update status if provided
 	if update.Status != "" {
-		_, err = tx.Exec(`
+		_, err = tx.ExecContext(ctx, `
 			UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?
 		`, update.Status, time.Now(), id)
 		if err != nil {
@@ -181,8 +182,8 @@ func (r *TaskRepository) Update(id int64, update TaskUpdate) error {
 	return tx.Commit()
 }
 
-func (r *TaskRepository) Delete(id int64) error {
-	_, err := r.db.Exec(`DELETE FROM tasks WHERE id = ?`, id)
+func (r *TaskRepository) Delete(ctx context.Context, id int64) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM tasks WHERE id = ?`, id)
 	return err
 }
 


### PR DESCRIPTION
## Summary

- Add `context.Context` as the first parameter to all repository methods in `internal/store`
- Update all database operations to use context-aware variants (`ExecContext`, `QueryContext`, `QueryRowContext`, `BeginTx`, `PrepareContext`)
- Update all callers in `internal/server/server.go` to pass the context

This enables proper request cancellation, timeout handling, and request-scoped tracing for database operations.

### Methods updated

**TaskRepository:**
- `Create`, `Get`, `List`, `ListByStatuses`, `ListChildren`, `ListByEvent`, `Update`, `Delete`

**LinkRepository:**
- `Create`, `ListByTask`, `Delete`, `FindByURL`

**LogRepository:**
- `Create`, `CreateBatch`, `ListByTask`

**EventRepository:**
- `Create`, `Get`, `List`, `FindByURL`, `Delete`, `AddTask`, `RemoveTask`, `ListTasks`, `ListByTask`

## Test plan

- [x] Build succeeds (`mise run build`)
- [x] All existing tests pass (`go test ./internal/store/... ./internal/server/...`)