### PR TITLE
Remove LogRepository.CreateBatch method

### DIFF
--- a/.claude/skills/grpc/SKILL.md
+++ b/.claude/skills/grpc/SKILL.md
@@ -287,16 +287,15 @@ if err != nil {
 ### Batch operations
 ```go
 func (s *Server) UploadLogs(ctx context.Context, req *xagentv1.UploadLogsRequest) (*xagentv1.UploadLogsResponse, error) {
-    logs := make([]*store.Log, len(req.Entries))
-    for i, entry := range req.Entries {
-        logs[i] = &store.Log{
+    for _, entry := range req.Entries {
+        log := &model.Log{
             TaskID:  req.TaskId,
             Type:    entry.Type,
             Content: entry.Content,
         }
-    }
-    if err := s.logs.CreateBatch(logs); err != nil {
-        return nil, connect.NewError(connect.CodeInternal, err)
+        if err := s.logs.Create(ctx, log); err != nil {
+            return nil, connect.NewError(connect.CodeInternal, err)
+        }
     }
     return &xagentv1.UploadLogsResponse{}, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -188,16 +188,15 @@ func (s *Server) DeleteTask(ctx context.Context, req *xagentv1.DeleteTaskRequest
 }
 
 func (s *Server) UploadLogs(ctx context.Context, req *xagentv1.UploadLogsRequest) (*xagentv1.UploadLogsResponse, error) {
-	logs := make([]*model.Log, len(req.Entries))
-	for i, entry := range req.Entries {
-		logs[i] = &model.Log{
+	for _, entry := range req.Entries {
+		log := &model.Log{
 			TaskID:  req.TaskId,
 			Type:    entry.Type,
 			Content: entry.Content,
 		}
-	}
-	if err := s.logs.CreateBatch(ctx, logs); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		if err := s.logs.Create(ctx, log); err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
 	}
 	return &xagentv1.UploadLogsResponse{}, nil
 }

--- a/internal/store/log.go
+++ b/internal/store/log.go
@@ -28,34 +28,6 @@ func (r *LogRepository) Create(ctx context.Context, log *model.Log) error {
 	return nil
 }
 
-func (r *LogRepository) CreateBatch(ctx context.Context, logs []*model.Log) error {
-	tx, err := r.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-
-	stmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO logs (task_id, type, content, created_at)
-		VALUES (?, ?, ?, ?)
-	`)
-	if err != nil {
-		return err
-	}
-	defer stmt.Close()
-
-	now := time.Now()
-	for _, log := range logs {
-		result, err := stmt.ExecContext(ctx, log.TaskID, log.Type, log.Content, now)
-		if err != nil {
-			return err
-		}
-		log.ID, _ = result.LastInsertId()
-	}
-
-	return tx.Commit()
-}
-
 func (r *LogRepository) ListByTask(ctx context.Context, taskID int64) ([]*model.Log, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, task_id, type, content, created_at


### PR DESCRIPTION
## Summary
- Remove the `CreateBatch` method from `LogRepository`
- Update `UploadLogs` handler to use individual `Create` calls
- Update documentation in SKILL.md

## Test plan
- [x] Go code builds successfully
- [x] Store package passes vet