### PR TITLE
Use Log.Proto() and LogFromProto in server methods

### DIFF
--- a/internal/model/log.go
+++ b/internal/model/log.go
@@ -22,3 +22,13 @@ func (l *Log) Proto() *xagentv1.LogEntry {
 		Content: l.Content,
 	}
 }
+
+// LogFromProto converts a protobuf LogEntry to a model Log.
+// Note: ID, TaskID, and CreatedAt must be set separately as they are not
+// part of the LogEntry protobuf message.
+func LogFromProto(pb *xagentv1.LogEntry) Log {
+	return Log{
+		Type:    pb.Type,
+		Content: pb.Content,
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -189,12 +189,9 @@ func (s *Server) DeleteTask(ctx context.Context, req *xagentv1.DeleteTaskRequest
 
 func (s *Server) UploadLogs(ctx context.Context, req *xagentv1.UploadLogsRequest) (*xagentv1.UploadLogsResponse, error) {
 	for _, entry := range req.Entries {
-		log := &model.Log{
-			TaskID:  req.TaskId,
-			Type:    entry.Type,
-			Content: entry.Content,
-		}
-		if err := s.logs.Create(ctx, log); err != nil {
+		log := model.LogFromProto(entry)
+		log.TaskID = req.TaskId
+		if err := s.logs.Create(ctx, &log); err != nil {
 			return nil, connect.NewError(connect.CodeInternal, err)
 		}
 	}
@@ -210,10 +207,7 @@ func (s *Server) ListLogs(ctx context.Context, req *xagentv1.ListLogsRequest) (*
 		Entries: make([]*xagentv1.LogEntry, len(logs)),
 	}
 	for i, l := range logs {
-		resp.Entries[i] = &xagentv1.LogEntry{
-			Type:    l.Type,
-			Content: l.Content,
-		}
+		resp.Entries[i] = l.Proto()
 	}
 	return resp, nil
 }


### PR DESCRIPTION
## Summary
- Add `LogFromProto` function to `internal/model/log.go` for converting protobuf `LogEntry` to model `Log`
- Update `UploadLogs` server method to use `LogFromProto` instead of manual struct construction
- Update `ListLogs` server method to use `Log.Proto()` instead of manual protobuf construction

## Test plan
- [x] Build passes with `mise run build`