### PR TITLE
Run claude CLI directly instead of using npx

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ XAGENT is an async agent orchestrator using a botnet-style C2 (command & control
 
 - **C2 Server** (`internal/server/`) - Connect RPC API + Web UI, stores tasks and logs in SQLite
 - **Runner** (`internal/runner/`) - Polls for pending tasks, manages Docker container lifecycle, creates Unix socket proxy for container-to-server communication
-- **Agent** (`internal/agent/`) - Runs inside containers, executes Claude Code CLI (`npx @anthropic-ai/claude-code --print`)
+- **Agent** (`internal/agent/`) - Runs inside containers, executes Claude Code CLI (`claude --print`)
 - **Store** (`internal/store/`) - SQLite persistence layer with WAL mode
 
 ### Key Concepts

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Containers communicate with the C2 server via a Unix socket proxy:
 - **Cancellation**: Kills containers for cancelled tasks
 
 ### Agent
-- Runs Claude Code via CLI (`npx @anthropic-ai/claude-code --print`)
+- Runs Claude Code via CLI (`claude --print`)
 - Executes tasks with `--continue` flag for resumption
 - Stores local state in `~/.xagent/{task-id}.json`
 - Accesses injected `xagent` MCP server for task communication tools
@@ -259,7 +259,7 @@ Stored in `~/.xagent/{task-id}.json` with session status (`started`) and prompt 
 5. Agent runs setup commands from workspace config
 6. Agent calls `GetTask` to get task details (including prompts)
 7. Agent creates Claude session, stores state locally in `~/.xagent/{task-id}.json`
-8. Agent executes `prompts[prompt_index]` via `npx @anthropic-ai/claude-code --print`
+8. Agent executes `prompts[prompt_index]` via `claude --print`
 9. Agent increments local `prompt_index`, sets `started: true`
 10. Agent polls `GetTask` for new prompts
 11. When done, agent exits (exit code 0 = completed, non-zero = failed)

--- a/diagrams/dataflow.d2
+++ b/diagrams/dataflow.d2
@@ -21,7 +21,7 @@ c2 -> agent: Task details
 
 agent -> agent: Run setup commands
 
-agent -> claude: npx claude-code --print "prompt"
+agent -> claude: claude --print "prompt"
 claude -> claude: Run tools
 claude -> mcp: create_link / report
 mcp -> c2: CreateLink / UploadLogs

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -28,7 +28,6 @@ func (a *ClaudeAgent) Prompt(ctx context.Context, prompt string, resume bool) er
 	}
 
 	args := []string{
-		"@anthropic-ai/claude-code",
 		"--dangerously-skip-permissions",
 		"--verbose",
 		"--output-format", "stream-json",
@@ -53,9 +52,8 @@ func (a *ClaudeAgent) Prompt(ctx context.Context, prompt string, resume bool) er
 
 	args = append(args, "--print", prompt)
 
-	cmd := exec.CommandContext(ctx, "npx", args...)
+	cmd := exec.CommandContext(ctx, "claude", args...)
 	cmd.Dir = a.cwd
-	cmd.Env = append(os.Environ(), "DISABLE_AUTOUPDATER=1")
 	cmd.Stderr = os.Stderr
 
 	stdout, err := cmd.StdoutPipe()


### PR DESCRIPTION
## Summary
- Changed `ClaudeAgent` to invoke `claude` directly instead of using `npx @anthropic-ai/claude-code`
- Removed the `DISABLE_AUTOUPDATER=1` environment variable (no longer needed)
- Updated documentation in CLAUDE.md, README.md, and diagrams/dataflow.d2

## Test plan
- [ ] Verify Claude Code CLI is installed as `claude` in the container image
- [ ] Run a task and confirm the agent successfully invokes Claude