### PR TITLE
Kill entire process group when context is cancelled

### DIFF
--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"syscall"
+	"time"
 )
 
 // ClaudeAgent implements Agent using Claude Code CLI.
@@ -57,6 +59,15 @@ func (a *ClaudeAgent) Prompt(ctx context.Context, prompt string, resume bool) er
 	cmd.Dir = a.cwd
 	cmd.Env = append(os.Environ(), "DISABLE_AUTOUPDATER=1")
 	cmd.Stderr = os.Stderr
+
+	// Create a new process group so we can kill all child processes.
+	// When npx spawns node, we need to kill the entire process tree.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		// Send SIGTERM to the entire process group (negative PID)
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	}
+	cmd.WaitDelay = 5 * time.Second
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"syscall"
+	"time"
 )
 
 // CopilotAgent implements Agent using GitHub Copilot CLI.
@@ -50,6 +52,14 @@ func (a *CopilotAgent) Prompt(ctx context.Context, prompt string, resume bool) e
 	cmd := exec.CommandContext(ctx, "copilot", args...)
 	cmd.Dir = a.cwd
 	cmd.Stderr = os.Stderr
+
+	// Create a new process group so we can kill all child processes
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		// Send SIGTERM to the entire process group (negative PID)
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	}
+	cmd.WaitDelay = 5 * time.Second
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/agent/cursor.go
+++ b/internal/agent/cursor.go
@@ -11,6 +11,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 )
 
 // CursorAgent implements Agent using the Cursor Agent CLI.
@@ -66,6 +68,14 @@ func (a *CursorAgent) Prompt(ctx context.Context, prompt string, resume bool) er
 	cmd.Dir = a.cwd
 	cmd.Env = os.Environ()
 	cmd.Stderr = os.Stderr
+
+	// Create a new process group so we can kill all child processes
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		// Send SIGTERM to the entire process group (negative PID)
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	}
+	cmd.WaitDelay = 5 * time.Second
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix agent subprocess not terminating when context is cancelled
- Kill entire process group instead of just the direct subprocess
- Apply fix to all agent implementations (claude, copilot, cursor)

When an agent subprocess is started (npx, copilot, cursor-agent), it may spawn additional child processes. Previously, when the context was cancelled (e.g., during a task restart), only the direct subprocess was killed, leaving child processes orphaned and continuing to run.

This fix:
- Sets `Setpgid: true` to create a new process group for the subprocess
- Uses `cmd.Cancel` to send SIGTERM to the entire process group (negative PID)
- Ensures all child processes are terminated when the agent is stopped

## Test plan

- Restart a running task and verify the container exits promptly
- Check docker logs to confirm no tool calls continue after SIGTERM is received

Fixes #163