### PR TITLE
Replace TaskRepository.Update with Put and use server-owned transactions

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"cmp"
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -161,16 +162,25 @@ func (s *Server) GetTaskDetails(ctx context.Context, req *xagentv1.GetTaskDetail
 }
 
 func (s *Server) UpdateTask(ctx context.Context, req *xagentv1.UpdateTaskRequest) (*xagentv1.UpdateTaskResponse, error) {
-	instructions := make([]model.Instruction, len(req.AddInstructions))
-	for i, inst := range req.AddInstructions {
-		instructions[i] = model.InstructionFromProto(inst)
-	}
+	err := s.tasks.WithTx(ctx, nil, func(tx *sql.Tx) error {
+		task, err := s.tasks.Get(ctx, tx, req.Id)
+		if err != nil {
+			return err
+		}
 
-	if err := s.tasks.Update(ctx, nil, req.Id, store.TaskUpdate{
-		Name:            req.Name,
-		Status:          model.TaskStatus(req.Status),
-		AddInstructions: instructions,
-	}); err != nil {
+		if req.Name != "" {
+			task.Name = req.Name
+		}
+		if req.Status != "" {
+			task.Status = model.TaskStatus(req.Status)
+		}
+		for _, inst := range req.AddInstructions {
+			task.Instructions = append(task.Instructions, model.InstructionFromProto(inst))
+		}
+
+		return s.tasks.Put(ctx, tx, task)
+	})
+	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
@@ -384,7 +394,8 @@ func (s *Server) ProcessEvent(ctx context.Context, req *xagentv1.ProcessEventReq
 		if err := s.events.AddTask(ctx, nil, req.Id, link.TaskID); err != nil {
 			s.log.Warn("failed to add event task", "event_id", req.Id, "task_id", link.TaskID, "error", err)
 		}
-		if err := s.tasks.Update(ctx, nil, link.TaskID, store.TaskUpdate{Status: model.TaskStatusRestarting}); err != nil {
+		task.Status = model.TaskStatusRestarting
+		if err := s.tasks.Put(ctx, nil, task); err != nil {
 			s.log.Warn("failed to restart task", "task_id", link.TaskID, "error", err)
 		}
 	}

--- a/internal/store/task.go
+++ b/internal/store/task.go
@@ -131,65 +131,18 @@ func (r *TaskRepository) ListByEvent(ctx context.Context, tx *sql.Tx, eventID in
 	return r.scanTasks(rows)
 }
 
-// TaskUpdate contains fields that can be updated on a task.
-type TaskUpdate struct {
-	Name            string
-	Status          model.TaskStatus
-	AddInstructions []model.Instruction
-}
-
-func (r *TaskRepository) Update(ctx context.Context, tx *sql.Tx, id int64, update TaskUpdate) error {
-	exec := r.exec(tx)
-
-	// Add instructions if provided
-	if len(update.AddInstructions) > 0 {
-		row := exec.QueryRowContext(ctx, `SELECT prompts FROM tasks WHERE id = ?`, id)
-
-		var existing []byte
-		if err := row.Scan(&existing); err != nil {
-			return err
-		}
-
-		var all []model.Instruction
-		if err := json.Unmarshal(existing, &all); err != nil {
-			return err
-		}
-
-		all = append(all, update.AddInstructions...)
-		data, err := json.Marshal(all)
-		if err != nil {
-			return err
-		}
-
-		_, err = exec.ExecContext(ctx, `
-			UPDATE tasks SET prompts = ?, updated_at = ? WHERE id = ?
-		`, data, time.Now(), id)
-		if err != nil {
-			return err
-		}
+// Put updates an existing task with all mutable fields.
+func (r *TaskRepository) Put(ctx context.Context, tx *sql.Tx, task *model.Task) error {
+	instructions, err := json.Marshal(task.Instructions)
+	if err != nil {
+		return err
 	}
 
-	// Update name if provided
-	if update.Name != "" {
-		_, err := exec.ExecContext(ctx, `
-			UPDATE tasks SET name = ?, updated_at = ? WHERE id = ?
-		`, update.Name, time.Now(), id)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Update status if provided
-	if update.Status != "" {
-		_, err := exec.ExecContext(ctx, `
-			UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?
-		`, update.Status, time.Now(), id)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	task.UpdatedAt = time.Now()
+	_, err = r.exec(tx).ExecContext(ctx, `
+		UPDATE tasks SET name = ?, prompts = ?, status = ?, updated_at = ? WHERE id = ?
+	`, task.Name, instructions, task.Status, task.UpdatedAt, task.ID)
+	return err
 }
 
 func (r *TaskRepository) Delete(ctx context.Context, tx *sql.Tx, id int64) error {


### PR DESCRIPTION
## Summary

- Add `TaskRepository.WithTx` method for server-controlled transactions
- Add `TaskRepository.Put` method that updates all mutable task fields
- Remove `TaskRepository.Update` method and `TaskUpdate` struct
- Update server to use Get + Put pattern inside transactions

## Changes

The server now owns the read-modify-write transaction for task updates:
1. `UpdateTask` uses `WithTx` to wrap Get + modify + Put in a transaction
2. `ProcessEvent` reuses the task from Get and calls Put directly

This makes the data flow more explicit and consistent.

## Test plan

- [x] All existing server tests pass
- [x] Build succeeds