### PR TITLE
WithTx: Require callback to commit transaction

### DIFF
--- a/internal/store/event.go
+++ b/internal/store/event.go
@@ -82,7 +82,7 @@ func (r *EventRepository) Delete(ctx context.Context, tx *sql.Tx, id int64) erro
 		if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE id = ?`, id); err != nil {
 			return err
 		}
-		return nil
+		return tx.Commit()
 	})
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -15,9 +15,9 @@ type Executor interface {
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
-// WithTx runs f within a transaction. If tx is non-nil, it uses that transaction
-// and the caller is responsible for committing/rolling back. If tx is nil, it
-// creates a new transaction and commits on success or rolls back on error.
+// WithTx runs f within a transaction. If tx is non-nil, it uses that transaction.
+// If tx is nil, it creates a new transaction. The callback is responsible for
+// committing the transaction. If an error is returned, the transaction is rolled back.
 func WithTx(ctx context.Context, db *sql.DB, tx *sql.Tx, f func(tx *sql.Tx) error) error {
 	if tx != nil {
 		return f(tx)
@@ -27,10 +27,7 @@ func WithTx(ctx context.Context, db *sql.DB, tx *sql.Tx, f func(tx *sql.Tx) erro
 		return err
 	}
 	defer tx.Rollback()
-	if err := f(tx); err != nil {
-		return err
-	}
-	return tx.Commit()
+	return f(tx)
 }
 
 func Open(path string) (*sql.DB, error) {

--- a/internal/store/task.go
+++ b/internal/store/task.go
@@ -181,7 +181,7 @@ func (r *TaskRepository) Update(ctx context.Context, tx *sql.Tx, id int64, updat
 			}
 		}
 
-		return nil
+		return tx.Commit()
 	})
 }
 


### PR DESCRIPTION
## Summary

- Remove auto-commit behavior from the `WithTx` helper function
- The callback is now responsible for committing the transaction
- Rollback still happens automatically via defer if the callback returns an error
- Updated existing callers (`EventRepository.Delete` and `TaskRepository.Update`) to commit the transaction at the end of their callbacks

## Test plan

- [ ] Verify that event deletion still works correctly
- [ ] Verify that task updates still work correctly
- [ ] Verify that rollback happens on error