### PR TITLE
store: add command and version columns to task repository

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -53,6 +53,8 @@ func migrate(db *sql.DB) error {
 			workspace     TEXT NOT NULL,
 			prompts       TEXT NOT NULL,
 			status        TEXT NOT NULL,
+			command       TEXT NOT NULL DEFAULT '',
+			version       INTEGER NOT NULL DEFAULT 0,
 			created_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
 			updated_at    DATETIME DEFAULT CURRENT_TIMESTAMP
 		);
@@ -96,5 +98,29 @@ func migrate(db *sql.DB) error {
 		);
 		CREATE INDEX IF NOT EXISTS idx_event_tasks_task_id ON event_tasks(task_id);
 	`)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Migrations: Add columns to existing tables
+	// These use "IF NOT EXISTS" logic by checking for errors and ignoring "duplicate column" errors
+	migrations := []string{
+		`ALTER TABLE tasks ADD COLUMN command TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE tasks ADD COLUMN version INTEGER NOT NULL DEFAULT 0`,
+	}
+	for _, m := range migrations {
+		if _, err := db.Exec(m); err != nil {
+			// Ignore "duplicate column name" errors (column already exists)
+			if !isDuplicateColumnError(err) {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func isDuplicateColumnError(err error) bool {
+	return err != nil && (err.Error() == "duplicate column name: command" ||
+		err.Error() == "duplicate column name: version")
 }

--- a/internal/store/task.go
+++ b/internal/store/task.go
@@ -38,9 +38,9 @@ func (r *TaskRepository) Create(ctx context.Context, tx *sql.Tx, task *model.Tas
 
 	now := time.Now()
 	result, err := r.exec(tx).ExecContext(ctx, `
-		INSERT INTO tasks (name, parent, workspace, prompts, status, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
-	`, task.Name, task.Parent, task.Workspace, instructions, task.Status, now, now)
+		INSERT INTO tasks (name, parent, workspace, prompts, status, command, version, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, task.Name, task.Parent, task.Workspace, instructions, task.Status, task.Command, task.Version, now, now)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func (r *TaskRepository) Create(ctx context.Context, tx *sql.Tx, task *model.Tas
 
 func (r *TaskRepository) Get(ctx context.Context, tx *sql.Tx, id int64) (*model.Task, error) {
 	row := r.exec(tx).QueryRowContext(ctx, `
-		SELECT id, name, parent, workspace, prompts, status, created_at, updated_at
+		SELECT id, name, parent, workspace, prompts, status, command, version, created_at, updated_at
 		FROM tasks WHERE id = ?
 	`, id)
 	return r.scanTask(row)
@@ -65,7 +65,7 @@ func (r *TaskRepository) Get(ctx context.Context, tx *sql.Tx, id int64) (*model.
 
 func (r *TaskRepository) List(ctx context.Context, tx *sql.Tx) ([]*model.Task, error) {
 	rows, err := r.exec(tx).QueryContext(ctx, `
-		SELECT id, name, parent, workspace, prompts, status, created_at, updated_at
+		SELECT id, name, parent, workspace, prompts, status, command, version, created_at, updated_at
 		FROM tasks WHERE status != 'archived' ORDER BY created_at DESC
 	`)
 	if err != nil {
@@ -87,7 +87,7 @@ func (r *TaskRepository) ListByStatuses(ctx context.Context, tx *sql.Tx, statuse
 		args[i] = s
 	}
 	query := fmt.Sprintf(`
-		SELECT id, name, parent, workspace, prompts, status, created_at, updated_at
+		SELECT id, name, parent, workspace, prompts, status, command, version, created_at, updated_at
 		FROM tasks WHERE status IN (%s) ORDER BY created_at DESC
 	`, strings.Join(placeholders, ","))
 	rows, err := r.exec(tx).QueryContext(ctx, query, args...)
@@ -101,7 +101,7 @@ func (r *TaskRepository) ListByStatuses(ctx context.Context, tx *sql.Tx, statuse
 
 func (r *TaskRepository) ListChildren(ctx context.Context, tx *sql.Tx, parentID int64) ([]*model.Task, error) {
 	rows, err := r.exec(tx).QueryContext(ctx, `
-		SELECT id, name, parent, workspace, prompts, status, created_at, updated_at
+		SELECT id, name, parent, workspace, prompts, status, command, version, created_at, updated_at
 		FROM tasks WHERE parent = ? ORDER BY created_at DESC
 	`, parentID)
 	if err != nil {
@@ -114,7 +114,7 @@ func (r *TaskRepository) ListChildren(ctx context.Context, tx *sql.Tx, parentID 
 
 func (r *TaskRepository) ListByEvent(ctx context.Context, tx *sql.Tx, eventID int64) ([]*model.Task, error) {
 	rows, err := r.exec(tx).QueryContext(ctx, `
-		SELECT t.id, t.name, t.parent, t.workspace, t.prompts, t.status, t.created_at, t.updated_at
+		SELECT t.id, t.name, t.parent, t.workspace, t.prompts, t.status, t.command, t.version, t.created_at, t.updated_at
 		FROM tasks t
 		JOIN event_tasks et ON t.id = et.task_id
 		WHERE et.event_id = ?
@@ -136,9 +136,9 @@ func (r *TaskRepository) Put(ctx context.Context, tx *sql.Tx, task *model.Task) 
 
 	task.UpdatedAt = time.Now()
 	_, err = r.exec(tx).ExecContext(ctx, `
-		UPDATE tasks SET name = ?, parent = ?, workspace = ?, prompts = ?, status = ?, updated_at = ?
+		UPDATE tasks SET name = ?, parent = ?, workspace = ?, prompts = ?, status = ?, command = ?, version = ?, updated_at = ?
 		WHERE id = ?
-	`, task.Name, task.Parent, task.Workspace, instructions, task.Status, task.UpdatedAt, task.ID)
+	`, task.Name, task.Parent, task.Workspace, instructions, task.Status, task.Command, task.Version, task.UpdatedAt, task.ID)
 	return err
 }
 
@@ -158,6 +158,8 @@ func (r *TaskRepository) scanTask(row *sql.Row) (*model.Task, error) {
 		&task.Workspace,
 		&instructions,
 		&task.Status,
+		&task.Command,
+		&task.Version,
 		&task.CreatedAt,
 		&task.UpdatedAt,
 	)
@@ -185,6 +187,8 @@ func (r *TaskRepository) scanTasks(rows *sql.Rows) ([]*model.Task, error) {
 			&task.Workspace,
 			&instructions,
 			&task.Status,
+			&task.Command,
+			&task.Version,
 			&task.CreatedAt,
 			&task.UpdatedAt,
 		)


### PR DESCRIPTION
## Summary
- Add `command` (TEXT) and `version` (INTEGER) columns to the tasks database table schema
- Add ALTER TABLE migration to handle existing databases
- Update TaskRepository methods (Create, Get, Put, List, ListByStatuses, ListChildren, ListByEvent) to include the new columns
- Update scan functions to populate the Command and Version fields in Task model

## Test plan
- [x] Build passes (`mise run build`)
- [x] All existing tests pass (`go test ./...`)