### PR TITLE
Remove Create Task link from navbar

### DIFF
--- a/webui/src/routes/__root.tsx
+++ b/webui/src/routes/__root.tsx
@@ -50,12 +50,6 @@ function RootComponent() {
             >
               Events
             </Link>
-            <Link
-              to="/tasks/new"
-              className="text-muted-foreground hover:text-foreground transition-colors [&.active]:text-foreground"
-            >
-              Create Task
-            </Link>
           </div>
         </div>
       </nav>


### PR DESCRIPTION
## Summary

- Removes the "Create Task" link from the main navigation bar

## Test plan

- Verify the navigation bar no longer shows the "Create Task" link
- Verify the `/tasks/new` route still works when accessed directly