### PR TITLE
Enable autoprune by default in runner

### DIFF
--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -50,6 +50,7 @@ var RunnerCommand = &cli.Command{
 		&cli.BoolFlag{
 			Name:  "autoprune",
 			Usage: "Automatically remove containers for archived tasks",
+			Value: true,
 		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {


### PR DESCRIPTION
## Summary
- Set the `autoprune` flag default value to `true` so containers for archived tasks are automatically removed without requiring the `--autoprune` flag.

## Test plan
- Verify runner starts with autoprune enabled by default
- Confirm `--autoprune=false` can still be used to disable the feature