### PR TITLE
Add command field to UpdateTaskRequest

### DIFF
--- a/internal/proto/xagent/v1/xagent.pb.go
+++ b/internal/proto/xagent/v1/xagent.pb.go
@@ -752,6 +752,7 @@ type UpdateTaskRequest struct {
 	Name            string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	Status          string                 `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
 	AddInstructions []*Instruction         `protobuf:"bytes,4,rep,name=add_instructions,json=addInstructions,proto3" json:"add_instructions,omitempty"`
+	Command         string                 `protobuf:"bytes,5,opt,name=command,proto3" json:"command,omitempty"` // "restart", "stop", or empty to clear
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -812,6 +813,13 @@ func (x *UpdateTaskRequest) GetAddInstructions() []*Instruction {
 		return x.AddInstructions
 	}
 	return nil
+}
+
+func (x *UpdateTaskRequest) GetCommand() string {
+	if x != nil {
+		return x.Command
+	}
+	return ""
 }
 
 type UpdateTaskResponse struct {
@@ -2625,12 +2633,13 @@ const file_xagent_v1_xagent_proto_rawDesc = "" +
 	"\x04task\x18\x01 \x01(\v2\x0f.xagent.v1.TaskR\x04task\x12+\n" +
 	"\bchildren\x18\x02 \x03(\v2\x0f.xagent.v1.TaskR\bchildren\x12(\n" +
 	"\x06events\x18\x03 \x03(\v2\x10.xagent.v1.EventR\x06events\x12)\n" +
-	"\x05links\x18\x04 \x03(\v2\x13.xagent.v1.TaskLinkR\x05links\"\x92\x01\n" +
+	"\x05links\x18\x04 \x03(\v2\x13.xagent.v1.TaskLinkR\x05links\"\xac\x01\n" +
 	"\x11UpdateTaskRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x16\n" +
 	"\x06status\x18\x03 \x01(\tR\x06status\x12A\n" +
-	"\x10add_instructions\x18\x04 \x03(\v2\x16.xagent.v1.InstructionR\x0faddInstructions\"\x14\n" +
+	"\x10add_instructions\x18\x04 \x03(\v2\x16.xagent.v1.InstructionR\x0faddInstructions\x12\x18\n" +
+	"\acommand\x18\x05 \x01(\tR\acommand\"\x14\n" +
 	"\x12UpdateTaskResponse\"#\n" +
 	"\x11DeleteTaskRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\"\x14\n" +

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -177,6 +177,10 @@ func (s *Server) UpdateTask(ctx context.Context, req *xagentv1.UpdateTaskRequest
 		for _, inst := range req.AddInstructions {
 			task.Instructions = append(task.Instructions, model.InstructionFromProto(inst))
 		}
+		if req.Command != "" {
+			task.Command = model.TaskCommand(req.Command)
+			task.Version++
+		}
 
 		if err := s.tasks.Put(ctx, tx, task); err != nil {
 			return err
@@ -187,7 +191,7 @@ func (s *Server) UpdateTask(ctx context.Context, req *xagentv1.UpdateTaskRequest
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	s.log.Info("task updated", "id", req.Id, "name", req.Name, "status", req.Status, "instructions_added", len(req.AddInstructions))
+	s.log.Info("task updated", "id", req.Id, "name", req.Name, "status", req.Status, "instructions_added", len(req.AddInstructions), "command", req.Command)
 	return &xagentv1.UpdateTaskResponse{}, nil
 }
 

--- a/proto/xagent/v1/xagent.proto
+++ b/proto/xagent/v1/xagent.proto
@@ -107,6 +107,7 @@ message UpdateTaskRequest {
   string name = 2;
   string status = 3;
   repeated Instruction add_instructions = 4;
+  string command = 5;  // "restart", "stop", or empty to clear
 }
 
 message UpdateTaskResponse {}


### PR DESCRIPTION
## Summary
- Add `command` field to `UpdateTaskRequest` proto message
- Update server's `UpdateTask` handler to process the command field
- Increment task version when command is set (per existing convention)

## Test plan
- [x] Tests pass (`go test ./...`)
- [x] Build succeeds (`mise run build`)