### PR TITLE
Add task status utility functions

### DIFF
--- a/webui/src/lib/task.ts
+++ b/webui/src/lib/task.ts
@@ -1,0 +1,24 @@
+import type { Task } from '@/gen/xagent/v1/xagent_pb'
+
+type TaskLike = Pick<Task, 'status'>
+type TaskWithParent = Pick<Task, 'parent'>
+
+export function isChildTask(task: TaskWithParent): boolean {
+  return task.parent !== 0n
+}
+
+export function canArchiveTask(task: TaskLike): boolean {
+  return task.status === 'completed' || task.status === 'failed'
+}
+
+export function canCancelTask(task: TaskLike): boolean {
+  return task.status === 'running' || task.status === 'pending'
+}
+
+export function canRestartTask(task: TaskLike): boolean {
+  return task.status === 'running' || task.status === 'completed' || task.status === 'failed'
+}
+
+export function isArchivedTask(task: TaskLike): boolean {
+  return task.status === 'archived'
+}

--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -12,6 +12,7 @@ import {
 import type { Task, TaskLink, Event, LogEntry } from '@/gen/xagent/v1/xagent_pb'
 import { timestampDate } from '@bufbuild/protobuf/wkt'
 import { useState } from 'react'
+import { canArchiveTask, canCancelTask, canRestartTask, isArchivedTask } from '@/lib/task'
 import {
   Table,
   TableBody,
@@ -143,13 +144,6 @@ function TaskDetail() {
     )
   }
 
-  const isArchived = task.status === 'archived'
-  const canCancel = task.status === 'running' || task.status === 'pending'
-  const canRestart =
-    task.status === 'running' ||
-    task.status === 'completed' ||
-    task.status === 'failed'
-  const canArchive = task.status === 'completed' || task.status === 'failed'
   const isMutating = archiveMutation.isPending || cancelMutation.isPending || restartMutation.isPending
 
   return (
@@ -157,7 +151,7 @@ function TaskDetail() {
       <div className="flex justify-between items-start mb-6">
         <h1 className="text-2xl font-bold">{task.name || `Unnamed - ${id}`}</h1>
         <div className="flex gap-2">
-          {canCancel && (
+          {canCancelTask(task) && (
             <Button
               variant="destructive"
               size="sm"
@@ -167,7 +161,7 @@ function TaskDetail() {
               Cancel
             </Button>
           )}
-          {canRestart && (
+          {canRestartTask(task) && (
             <Button
               variant="outline"
               size="sm"
@@ -177,7 +171,7 @@ function TaskDetail() {
               Restart
             </Button>
           )}
-          {canArchive && (
+          {canArchiveTask(task) && (
             <Button
               variant="outline"
               size="sm"
@@ -256,7 +250,7 @@ function TaskDetail() {
             ))}
           </div>
         )}
-        {!isArchived && (
+        {!isArchivedTask(task) && (
           <form onSubmit={handleAddInstruction} className="space-y-4 pt-4 mt-4 border-t">
             <Textarea
               placeholder="Enter a new instruction..."
@@ -382,7 +376,6 @@ function ChildTasksTable({ tasks, onUpdate }: { tasks: Task[]; onUpdate: () => v
 
 function ChildTaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) {
   const archiveMutation = useMutation(archiveTask)
-  const canArchive = task.status === 'completed' || task.status === 'failed'
 
   const handleArchive = async () => {
     await archiveMutation.mutateAsync({ id: task.id })
@@ -408,7 +401,7 @@ function ChildTaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) 
         {task.createdAt ? <RelativeTime date={timestampDate(task.createdAt)} /> : '-'}
       </TableCell>
       <TableCell>
-        {canArchive && (
+        {canArchiveTask(task) && (
           <Button
             variant="outline"
             size="sm"

--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation } from '@connectrpc/connect-query'
 import { listTasks, archiveTask } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
 import type { Task } from '@/gen/xagent/v1/xagent_pb'
 import { timestampDate } from '@bufbuild/protobuf/wkt'
+import { canArchiveTask, isChildTask } from '@/lib/task'
 import {
   Table,
   TableBody,
@@ -111,9 +112,7 @@ function TasksPage() {
 }
 
 function TaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) {
-  const isChild = task.parent !== 0n
   const archiveMutation = useMutation(archiveTask)
-  const canArchive = task.status === 'completed' || task.status === 'failed'
 
   const handleArchive = async () => {
     await archiveMutation.mutateAsync({ id: task.id })
@@ -121,7 +120,7 @@ function TaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) {
   }
 
   return (
-    <TableRow className={cn(isChild && 'bg-muted/30')}>
+    <TableRow className={cn(isChildTask(task) && 'bg-muted/30')}>
       <TableCell>
         <Link
           to="/tasks/$id"
@@ -139,7 +138,7 @@ function TaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) {
         {task.createdAt ? <RelativeTime date={timestampDate(task.createdAt)} /> : '-'}
       </TableCell>
       <TableCell>
-        {canArchive && (
+        {canArchiveTask(task) && (
           <Button
             variant="outline"
             size="sm"
@@ -174,4 +173,3 @@ function StatusBadge({ status }: { status: string }) {
     </Badge>
   )
 }
-


### PR DESCRIPTION
## Summary

- Extract duplicated task status checks into a new `webui/src/lib/task.ts` utility module
- Add `canArchiveTask()`, `canCancelTask()`, `canRestartTask()`, and `isArchivedTask()` functions
- Update `tasks.$id.tsx` and `tasks.index.tsx` to use these utility functions

This removes the duplication of `task.status === 'completed' || task.status === 'failed'` checks that were scattered across multiple components.

## Test plan

- [ ] Verify archive button appears for completed and failed tasks
- [ ] Verify cancel button works for running and pending tasks
- [ ] Verify restart button works appropriately
- [ ] Run `npm run build` in webui/ to verify no type errors