### PR TITLE
Add Task.SetStatus method with validation

### DIFF
--- a/internal/model/task.go
+++ b/internal/model/task.go
@@ -224,3 +224,36 @@ func (t *Task) applyRunnerEventFailed() bool {
 		return false
 	}
 }
+
+// SetStatus attempts to transition the task to the specified status.
+// Returns true if the transition is valid and was applied, false otherwise.
+// This method enforces the task state machine rules:
+//   - archived: only from completed or failed
+//   - cancelling: only from running or pending
+//   - restarting: only from running, completed, or failed
+func (t *Task) SetStatus(status TaskStatus) bool {
+	switch status {
+	case TaskStatusArchived:
+		if t.Status != TaskStatusCompleted && t.Status != TaskStatusFailed {
+			return false
+		}
+		t.Status = TaskStatusArchived
+		return true
+	case TaskStatusCancelling:
+		if t.Status != TaskStatusRunning && t.Status != TaskStatusPending {
+			return false
+		}
+		t.Status = TaskStatusCancelling
+		return true
+	case TaskStatusRestarting:
+		if t.Status != TaskStatusRunning &&
+			t.Status != TaskStatusCompleted &&
+			t.Status != TaskStatusFailed {
+			return false
+		}
+		t.Status = TaskStatusRestarting
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/model/task_test.go
+++ b/internal/model/task_test.go
@@ -298,3 +298,233 @@ func TestTask_ApplyRunnerEvent(t *testing.T) {
 		})
 	}
 }
+
+func TestTask_SetStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		before    TaskStatus
+		newStatus TaskStatus
+		want      bool
+		after     TaskStatus
+	}{
+		// Archive transitions (only from completed or failed)
+		{
+			name:      "archive from completed succeeds",
+			before:    TaskStatusCompleted,
+			newStatus: TaskStatusArchived,
+			want:      true,
+			after:     TaskStatusArchived,
+		},
+		{
+			name:      "archive from failed succeeds",
+			before:    TaskStatusFailed,
+			newStatus: TaskStatusArchived,
+			want:      true,
+			after:     TaskStatusArchived,
+		},
+		{
+			name:      "archive from pending fails",
+			before:    TaskStatusPending,
+			newStatus: TaskStatusArchived,
+			want:      false,
+			after:     TaskStatusPending,
+		},
+		{
+			name:      "archive from running fails",
+			before:    TaskStatusRunning,
+			newStatus: TaskStatusArchived,
+			want:      false,
+			after:     TaskStatusRunning,
+		},
+		{
+			name:      "archive from restarting fails",
+			before:    TaskStatusRestarting,
+			newStatus: TaskStatusArchived,
+			want:      false,
+			after:     TaskStatusRestarting,
+		},
+		{
+			name:      "archive from cancelling fails",
+			before:    TaskStatusCancelling,
+			newStatus: TaskStatusArchived,
+			want:      false,
+			after:     TaskStatusCancelling,
+		},
+		{
+			name:      "archive from cancelled fails",
+			before:    TaskStatusCancelled,
+			newStatus: TaskStatusArchived,
+			want:      false,
+			after:     TaskStatusCancelled,
+		},
+		{
+			name:      "archive from archived fails",
+			before:    TaskStatusArchived,
+			newStatus: TaskStatusArchived,
+			want:      false,
+			after:     TaskStatusArchived,
+		},
+
+		// Cancel transitions (only from running or pending)
+		{
+			name:      "cancel from running succeeds",
+			before:    TaskStatusRunning,
+			newStatus: TaskStatusCancelling,
+			want:      true,
+			after:     TaskStatusCancelling,
+		},
+		{
+			name:      "cancel from pending succeeds",
+			before:    TaskStatusPending,
+			newStatus: TaskStatusCancelling,
+			want:      true,
+			after:     TaskStatusCancelling,
+		},
+		{
+			name:      "cancel from completed fails",
+			before:    TaskStatusCompleted,
+			newStatus: TaskStatusCancelling,
+			want:      false,
+			after:     TaskStatusCompleted,
+		},
+		{
+			name:      "cancel from failed fails",
+			before:    TaskStatusFailed,
+			newStatus: TaskStatusCancelling,
+			want:      false,
+			after:     TaskStatusFailed,
+		},
+		{
+			name:      "cancel from restarting fails",
+			before:    TaskStatusRestarting,
+			newStatus: TaskStatusCancelling,
+			want:      false,
+			after:     TaskStatusRestarting,
+		},
+		{
+			name:      "cancel from cancelling fails",
+			before:    TaskStatusCancelling,
+			newStatus: TaskStatusCancelling,
+			want:      false,
+			after:     TaskStatusCancelling,
+		},
+		{
+			name:      "cancel from cancelled fails",
+			before:    TaskStatusCancelled,
+			newStatus: TaskStatusCancelling,
+			want:      false,
+			after:     TaskStatusCancelled,
+		},
+		{
+			name:      "cancel from archived fails",
+			before:    TaskStatusArchived,
+			newStatus: TaskStatusCancelling,
+			want:      false,
+			after:     TaskStatusArchived,
+		},
+
+		// Restart transitions (only from running, completed, or failed)
+		{
+			name:      "restart from running succeeds",
+			before:    TaskStatusRunning,
+			newStatus: TaskStatusRestarting,
+			want:      true,
+			after:     TaskStatusRestarting,
+		},
+		{
+			name:      "restart from completed succeeds",
+			before:    TaskStatusCompleted,
+			newStatus: TaskStatusRestarting,
+			want:      true,
+			after:     TaskStatusRestarting,
+		},
+		{
+			name:      "restart from failed succeeds",
+			before:    TaskStatusFailed,
+			newStatus: TaskStatusRestarting,
+			want:      true,
+			after:     TaskStatusRestarting,
+		},
+		{
+			name:      "restart from pending fails",
+			before:    TaskStatusPending,
+			newStatus: TaskStatusRestarting,
+			want:      false,
+			after:     TaskStatusPending,
+		},
+		{
+			name:      "restart from restarting fails",
+			before:    TaskStatusRestarting,
+			newStatus: TaskStatusRestarting,
+			want:      false,
+			after:     TaskStatusRestarting,
+		},
+		{
+			name:      "restart from cancelling fails",
+			before:    TaskStatusCancelling,
+			newStatus: TaskStatusRestarting,
+			want:      false,
+			after:     TaskStatusCancelling,
+		},
+		{
+			name:      "restart from cancelled fails",
+			before:    TaskStatusCancelled,
+			newStatus: TaskStatusRestarting,
+			want:      false,
+			after:     TaskStatusCancelled,
+		},
+		{
+			name:      "restart from archived fails",
+			before:    TaskStatusArchived,
+			newStatus: TaskStatusRestarting,
+			want:      false,
+			after:     TaskStatusArchived,
+		},
+
+		// Unsupported target status values
+		{
+			name:      "setting to running fails",
+			before:    TaskStatusPending,
+			newStatus: TaskStatusRunning,
+			want:      false,
+			after:     TaskStatusPending,
+		},
+		{
+			name:      "setting to completed fails",
+			before:    TaskStatusRunning,
+			newStatus: TaskStatusCompleted,
+			want:      false,
+			after:     TaskStatusRunning,
+		},
+		{
+			name:      "setting to failed fails",
+			before:    TaskStatusRunning,
+			newStatus: TaskStatusFailed,
+			want:      false,
+			after:     TaskStatusRunning,
+		},
+		{
+			name:      "setting to cancelled fails",
+			before:    TaskStatusCancelling,
+			newStatus: TaskStatusCancelled,
+			want:      false,
+			after:     TaskStatusCancelling,
+		},
+		{
+			name:      "setting to pending fails",
+			before:    TaskStatusRunning,
+			newStatus: TaskStatusPending,
+			want:      false,
+			after:     TaskStatusRunning,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := Task{Status: tt.before}
+			got := task.SetStatus(tt.newStatus)
+			assert.Equal(t, got, tt.want)
+			assert.Equal(t, task.Status, tt.after)
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -206,10 +206,9 @@ func (s *Server) ArchiveTask(ctx context.Context, req *xagentv1.ArchiveTaskReque
 		if err != nil {
 			return err
 		}
-		if task.Status != model.TaskStatusCompleted && task.Status != model.TaskStatusFailed {
+		if !task.SetStatus(model.TaskStatusArchived) {
 			return fmt.Errorf("cannot archive task with status %s", task.Status)
 		}
-		task.Status = model.TaskStatusArchived
 		if err := s.tasks.Put(ctx, tx, task); err != nil {
 			return err
 		}
@@ -229,10 +228,9 @@ func (s *Server) CancelTask(ctx context.Context, req *xagentv1.CancelTaskRequest
 		if err != nil {
 			return err
 		}
-		if task.Status != model.TaskStatusRunning && task.Status != model.TaskStatusPending {
+		if !task.SetStatus(model.TaskStatusCancelling) {
 			return fmt.Errorf("cannot cancel task with status %s", task.Status)
 		}
-		task.Status = model.TaskStatusCancelling
 		if err := s.tasks.Put(ctx, tx, task); err != nil {
 			return err
 		}
@@ -252,12 +250,9 @@ func (s *Server) RestartTask(ctx context.Context, req *xagentv1.RestartTaskReque
 		if err != nil {
 			return err
 		}
-		if task.Status != model.TaskStatusRunning &&
-			task.Status != model.TaskStatusCompleted &&
-			task.Status != model.TaskStatusFailed {
+		if !task.SetStatus(model.TaskStatusRestarting) {
 			return fmt.Errorf("cannot restart task with status %s", task.Status)
 		}
-		task.Status = model.TaskStatusRestarting
 		if err := s.tasks.Put(ctx, tx, task); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- Add `Task.SetStatus(status)` method that encapsulates status transition validation logic
- Method returns `false` if the transition is not allowed from the current status
- Update `ArchiveTask`, `CancelTask`, and `RestartTask` server methods to use the new method
- Add comprehensive unit tests for all valid and invalid status transitions

## Test plan
- [x] Unit tests pass for all status transitions (archive, cancel, restart)
- [x] Tests verify invalid transitions return false and don't modify status
- [x] Tests verify unsupported target status values return false
- [x] Server methods continue to work correctly with the new implementation