### PR TITLE
Improve link creation reminder in agent bootstrap prompt

### DIFF
--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -109,12 +109,12 @@ var RunCommand = &cli.Command{
 				"When creating links with xagent:create_link, ALWAYS set notify=true for resources you create (PRs, issues, comments), even if the task is complete. Others may respond and you'll need to handle those responses. Only use notify=false for reference links to external resources you didn't create.",
 				"Use xagent:update_child_task to delegate work to child tasks.",
 				"",
-				"When done, use xagent:create_link for any URLs you created (PRs, issues, etc).",
-				"Always use web URLs that users can visit, not API URLs.",
 				"Use xagent:report to log important observations.",
 				"Only use xagent:create_child_task when explicitly instructed to create a new task.",
 				"",
 				"Your text responses are NOT visible to users - only tool calls matter.",
+				"",
+				"IMPORTANT: Before finishing any task, you MUST call xagent:create_link for EVERY URL you created (PRs, issues, comments, etc). Always use web URLs that users can visit, not API URLs. This is critical for task tracking.",
 			}, "\n")
 		}
 		if cfg.Prompt != "" {


### PR DESCRIPTION
## Summary

Agents sometimes forget to create links for resources they create (PRs, issues, comments). This PR improves the agent bootstrap prompt to make the link creation instruction more prominent and harder to miss.

## Changes

- Consolidated duplicate link creation instructions into a single, prominent reminder
- Added "IMPORTANT:" prefix and changed "use" to "MUST" for stronger emphasis
- Moved the reminder to the end of the prompt so it's the last instruction agents see before starting work
- Changed wording to emphasize "EVERY URL" to ensure completeness

## Before

The link creation reminder was buried in the middle of the prompt:
```
"When done, use xagent:create_link for any URLs you created (PRs, issues, etc).",
"Always use web URLs that users can visit, not API URLs.",
```

## After

The reminder is now at the end with stronger emphasis:
```
"IMPORTANT: Before finishing any task, you MUST call xagent:create_link for EVERY URL you created (PRs, issues, comments, etc). Always use web URLs that users can visit, not API URLs. This is critical for task tracking.",
```

## Test plan

- [ ] Verify the bootstrap prompt is correctly formatted
- [ ] Test that agents receive the improved prompt when starting tasks
- [ ] Monitor agent behavior to confirm improved link creation compliance