### PR TITLE
Replace Task.SetStatus with dedicated Archive, Cancel, Restart methods

### DIFF
--- a/internal/model/task.go
+++ b/internal/model/task.go
@@ -225,35 +225,37 @@ func (t *Task) applyRunnerEventFailed() bool {
 	}
 }
 
-// SetStatus attempts to transition the task to the specified status.
-// Returns true if the transition is valid and was applied, false otherwise.
-// This method enforces the task state machine rules:
-//   - archived: only from completed or failed
-//   - cancelling: only from running or pending
-//   - restarting: only from running, completed, or failed
-func (t *Task) SetStatus(status TaskStatus) bool {
-	switch status {
-	case TaskStatusArchived:
-		if t.Status != TaskStatusCompleted && t.Status != TaskStatusFailed {
-			return false
-		}
-		t.Status = TaskStatusArchived
-		return true
-	case TaskStatusCancelling:
-		if t.Status != TaskStatusRunning && t.Status != TaskStatusPending {
-			return false
-		}
-		t.Status = TaskStatusCancelling
-		return true
-	case TaskStatusRestarting:
-		if t.Status != TaskStatusRunning &&
-			t.Status != TaskStatusCompleted &&
-			t.Status != TaskStatusFailed {
-			return false
-		}
-		t.Status = TaskStatusRestarting
-		return true
-	default:
+// Archive transitions the task to archived status.
+// Returns true if the transition is valid and was applied.
+// Only valid from completed or failed status.
+func (t *Task) Archive() bool {
+	if t.Status != TaskStatusCompleted && t.Status != TaskStatusFailed {
 		return false
 	}
+	t.Status = TaskStatusArchived
+	return true
+}
+
+// Cancel transitions the task to cancelling status.
+// Returns true if the transition is valid and was applied.
+// Only valid from running or pending status.
+func (t *Task) Cancel() bool {
+	if t.Status != TaskStatusRunning && t.Status != TaskStatusPending {
+		return false
+	}
+	t.Status = TaskStatusCancelling
+	return true
+}
+
+// Restart transitions the task to restarting status.
+// Returns true if the transition is valid and was applied.
+// Only valid from running, completed, or failed status.
+func (t *Task) Restart() bool {
+	if t.Status != TaskStatusRunning &&
+		t.Status != TaskStatusCompleted &&
+		t.Status != TaskStatusFailed {
+		return false
+	}
+	t.Status = TaskStatusRestarting
+	return true
 }

--- a/internal/model/task_test.go
+++ b/internal/model/task_test.go
@@ -299,230 +299,201 @@ func TestTask_ApplyRunnerEvent(t *testing.T) {
 	}
 }
 
-func TestTask_SetStatus(t *testing.T) {
+func TestTask_Archive(t *testing.T) {
 	tests := []struct {
-		name      string
-		before    TaskStatus
-		newStatus TaskStatus
-		want      bool
-		after     TaskStatus
+		name   string
+		before TaskStatus
+		want   bool
+		after  TaskStatus
 	}{
-		// Archive transitions (only from completed or failed)
 		{
-			name:      "archive from completed succeeds",
-			before:    TaskStatusCompleted,
-			newStatus: TaskStatusArchived,
-			want:      true,
-			after:     TaskStatusArchived,
+			name:   "from completed succeeds",
+			before: TaskStatusCompleted,
+			want:   true,
+			after:  TaskStatusArchived,
 		},
 		{
-			name:      "archive from failed succeeds",
-			before:    TaskStatusFailed,
-			newStatus: TaskStatusArchived,
-			want:      true,
-			after:     TaskStatusArchived,
+			name:   "from failed succeeds",
+			before: TaskStatusFailed,
+			want:   true,
+			after:  TaskStatusArchived,
 		},
 		{
-			name:      "archive from pending fails",
-			before:    TaskStatusPending,
-			newStatus: TaskStatusArchived,
-			want:      false,
-			after:     TaskStatusPending,
+			name:   "from pending fails",
+			before: TaskStatusPending,
+			want:   false,
+			after:  TaskStatusPending,
 		},
 		{
-			name:      "archive from running fails",
-			before:    TaskStatusRunning,
-			newStatus: TaskStatusArchived,
-			want:      false,
-			after:     TaskStatusRunning,
+			name:   "from running fails",
+			before: TaskStatusRunning,
+			want:   false,
+			after:  TaskStatusRunning,
 		},
 		{
-			name:      "archive from restarting fails",
-			before:    TaskStatusRestarting,
-			newStatus: TaskStatusArchived,
-			want:      false,
-			after:     TaskStatusRestarting,
+			name:   "from restarting fails",
+			before: TaskStatusRestarting,
+			want:   false,
+			after:  TaskStatusRestarting,
 		},
 		{
-			name:      "archive from cancelling fails",
-			before:    TaskStatusCancelling,
-			newStatus: TaskStatusArchived,
-			want:      false,
-			after:     TaskStatusCancelling,
+			name:   "from cancelling fails",
+			before: TaskStatusCancelling,
+			want:   false,
+			after:  TaskStatusCancelling,
 		},
 		{
-			name:      "archive from cancelled fails",
-			before:    TaskStatusCancelled,
-			newStatus: TaskStatusArchived,
-			want:      false,
-			after:     TaskStatusCancelled,
+			name:   "from cancelled fails",
+			before: TaskStatusCancelled,
+			want:   false,
+			after:  TaskStatusCancelled,
 		},
 		{
-			name:      "archive from archived fails",
-			before:    TaskStatusArchived,
-			newStatus: TaskStatusArchived,
-			want:      false,
-			after:     TaskStatusArchived,
-		},
-
-		// Cancel transitions (only from running or pending)
-		{
-			name:      "cancel from running succeeds",
-			before:    TaskStatusRunning,
-			newStatus: TaskStatusCancelling,
-			want:      true,
-			after:     TaskStatusCancelling,
-		},
-		{
-			name:      "cancel from pending succeeds",
-			before:    TaskStatusPending,
-			newStatus: TaskStatusCancelling,
-			want:      true,
-			after:     TaskStatusCancelling,
-		},
-		{
-			name:      "cancel from completed fails",
-			before:    TaskStatusCompleted,
-			newStatus: TaskStatusCancelling,
-			want:      false,
-			after:     TaskStatusCompleted,
-		},
-		{
-			name:      "cancel from failed fails",
-			before:    TaskStatusFailed,
-			newStatus: TaskStatusCancelling,
-			want:      false,
-			after:     TaskStatusFailed,
-		},
-		{
-			name:      "cancel from restarting fails",
-			before:    TaskStatusRestarting,
-			newStatus: TaskStatusCancelling,
-			want:      false,
-			after:     TaskStatusRestarting,
-		},
-		{
-			name:      "cancel from cancelling fails",
-			before:    TaskStatusCancelling,
-			newStatus: TaskStatusCancelling,
-			want:      false,
-			after:     TaskStatusCancelling,
-		},
-		{
-			name:      "cancel from cancelled fails",
-			before:    TaskStatusCancelled,
-			newStatus: TaskStatusCancelling,
-			want:      false,
-			after:     TaskStatusCancelled,
-		},
-		{
-			name:      "cancel from archived fails",
-			before:    TaskStatusArchived,
-			newStatus: TaskStatusCancelling,
-			want:      false,
-			after:     TaskStatusArchived,
-		},
-
-		// Restart transitions (only from running, completed, or failed)
-		{
-			name:      "restart from running succeeds",
-			before:    TaskStatusRunning,
-			newStatus: TaskStatusRestarting,
-			want:      true,
-			after:     TaskStatusRestarting,
-		},
-		{
-			name:      "restart from completed succeeds",
-			before:    TaskStatusCompleted,
-			newStatus: TaskStatusRestarting,
-			want:      true,
-			after:     TaskStatusRestarting,
-		},
-		{
-			name:      "restart from failed succeeds",
-			before:    TaskStatusFailed,
-			newStatus: TaskStatusRestarting,
-			want:      true,
-			after:     TaskStatusRestarting,
-		},
-		{
-			name:      "restart from pending fails",
-			before:    TaskStatusPending,
-			newStatus: TaskStatusRestarting,
-			want:      false,
-			after:     TaskStatusPending,
-		},
-		{
-			name:      "restart from restarting fails",
-			before:    TaskStatusRestarting,
-			newStatus: TaskStatusRestarting,
-			want:      false,
-			after:     TaskStatusRestarting,
-		},
-		{
-			name:      "restart from cancelling fails",
-			before:    TaskStatusCancelling,
-			newStatus: TaskStatusRestarting,
-			want:      false,
-			after:     TaskStatusCancelling,
-		},
-		{
-			name:      "restart from cancelled fails",
-			before:    TaskStatusCancelled,
-			newStatus: TaskStatusRestarting,
-			want:      false,
-			after:     TaskStatusCancelled,
-		},
-		{
-			name:      "restart from archived fails",
-			before:    TaskStatusArchived,
-			newStatus: TaskStatusRestarting,
-			want:      false,
-			after:     TaskStatusArchived,
-		},
-
-		// Unsupported target status values
-		{
-			name:      "setting to running fails",
-			before:    TaskStatusPending,
-			newStatus: TaskStatusRunning,
-			want:      false,
-			after:     TaskStatusPending,
-		},
-		{
-			name:      "setting to completed fails",
-			before:    TaskStatusRunning,
-			newStatus: TaskStatusCompleted,
-			want:      false,
-			after:     TaskStatusRunning,
-		},
-		{
-			name:      "setting to failed fails",
-			before:    TaskStatusRunning,
-			newStatus: TaskStatusFailed,
-			want:      false,
-			after:     TaskStatusRunning,
-		},
-		{
-			name:      "setting to cancelled fails",
-			before:    TaskStatusCancelling,
-			newStatus: TaskStatusCancelled,
-			want:      false,
-			after:     TaskStatusCancelling,
-		},
-		{
-			name:      "setting to pending fails",
-			before:    TaskStatusRunning,
-			newStatus: TaskStatusPending,
-			want:      false,
-			after:     TaskStatusRunning,
+			name:   "from archived fails",
+			before: TaskStatusArchived,
+			want:   false,
+			after:  TaskStatusArchived,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			task := Task{Status: tt.before}
-			got := task.SetStatus(tt.newStatus)
+			got := task.Archive()
+			assert.Equal(t, got, tt.want)
+			assert.Equal(t, task.Status, tt.after)
+		})
+	}
+}
+
+func TestTask_Cancel(t *testing.T) {
+	tests := []struct {
+		name   string
+		before TaskStatus
+		want   bool
+		after  TaskStatus
+	}{
+		{
+			name:   "from running succeeds",
+			before: TaskStatusRunning,
+			want:   true,
+			after:  TaskStatusCancelling,
+		},
+		{
+			name:   "from pending succeeds",
+			before: TaskStatusPending,
+			want:   true,
+			after:  TaskStatusCancelling,
+		},
+		{
+			name:   "from completed fails",
+			before: TaskStatusCompleted,
+			want:   false,
+			after:  TaskStatusCompleted,
+		},
+		{
+			name:   "from failed fails",
+			before: TaskStatusFailed,
+			want:   false,
+			after:  TaskStatusFailed,
+		},
+		{
+			name:   "from restarting fails",
+			before: TaskStatusRestarting,
+			want:   false,
+			after:  TaskStatusRestarting,
+		},
+		{
+			name:   "from cancelling fails",
+			before: TaskStatusCancelling,
+			want:   false,
+			after:  TaskStatusCancelling,
+		},
+		{
+			name:   "from cancelled fails",
+			before: TaskStatusCancelled,
+			want:   false,
+			after:  TaskStatusCancelled,
+		},
+		{
+			name:   "from archived fails",
+			before: TaskStatusArchived,
+			want:   false,
+			after:  TaskStatusArchived,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := Task{Status: tt.before}
+			got := task.Cancel()
+			assert.Equal(t, got, tt.want)
+			assert.Equal(t, task.Status, tt.after)
+		})
+	}
+}
+
+func TestTask_Restart(t *testing.T) {
+	tests := []struct {
+		name   string
+		before TaskStatus
+		want   bool
+		after  TaskStatus
+	}{
+		{
+			name:   "from running succeeds",
+			before: TaskStatusRunning,
+			want:   true,
+			after:  TaskStatusRestarting,
+		},
+		{
+			name:   "from completed succeeds",
+			before: TaskStatusCompleted,
+			want:   true,
+			after:  TaskStatusRestarting,
+		},
+		{
+			name:   "from failed succeeds",
+			before: TaskStatusFailed,
+			want:   true,
+			after:  TaskStatusRestarting,
+		},
+		{
+			name:   "from pending fails",
+			before: TaskStatusPending,
+			want:   false,
+			after:  TaskStatusPending,
+		},
+		{
+			name:   "from restarting fails",
+			before: TaskStatusRestarting,
+			want:   false,
+			after:  TaskStatusRestarting,
+		},
+		{
+			name:   "from cancelling fails",
+			before: TaskStatusCancelling,
+			want:   false,
+			after:  TaskStatusCancelling,
+		},
+		{
+			name:   "from cancelled fails",
+			before: TaskStatusCancelled,
+			want:   false,
+			after:  TaskStatusCancelled,
+		},
+		{
+			name:   "from archived fails",
+			before: TaskStatusArchived,
+			want:   false,
+			after:  TaskStatusArchived,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := Task{Status: tt.before}
+			got := task.Restart()
 			assert.Equal(t, got, tt.want)
 			assert.Equal(t, task.Status, tt.after)
 		})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -206,7 +206,7 @@ func (s *Server) ArchiveTask(ctx context.Context, req *xagentv1.ArchiveTaskReque
 		if err != nil {
 			return err
 		}
-		if !task.SetStatus(model.TaskStatusArchived) {
+		if !task.Archive() {
 			return fmt.Errorf("cannot archive task with status %s", task.Status)
 		}
 		if err := s.tasks.Put(ctx, tx, task); err != nil {
@@ -228,7 +228,7 @@ func (s *Server) CancelTask(ctx context.Context, req *xagentv1.CancelTaskRequest
 		if err != nil {
 			return err
 		}
-		if !task.SetStatus(model.TaskStatusCancelling) {
+		if !task.Cancel() {
 			return fmt.Errorf("cannot cancel task with status %s", task.Status)
 		}
 		if err := s.tasks.Put(ctx, tx, task); err != nil {
@@ -250,7 +250,7 @@ func (s *Server) RestartTask(ctx context.Context, req *xagentv1.RestartTaskReque
 		if err != nil {
 			return err
 		}
-		if !task.SetStatus(model.TaskStatusRestarting) {
+		if !task.Restart() {
 			return fmt.Errorf("cannot restart task with status %s", task.Status)
 		}
 		if err := s.tasks.Put(ctx, tx, task); err != nil {


### PR DESCRIPTION
## Summary

- Replace the generic `SetStatus` method with three dedicated methods that provide clearer intent and type safety:
  - `Task.Archive()` - transitions to archived status (only from completed/failed)
  - `Task.Cancel()` - transitions to cancelling status (only from running/pending)
  - `Task.Restart()` - transitions to restarting status (only from running/completed/failed)
- Each method returns `bool` indicating if the transition was valid
- Update server.go to use the new methods
- Update tests to cover each method individually

## Test plan

- [x] All model tests pass
- [x] Tests cover valid and invalid transitions for each method