### PR TITLE
Move --notify flag from runner to server

### DIFF
--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -44,10 +44,6 @@ var RunnerCommand = &cli.Command{
 			Value: 0,
 		},
 		&cli.BoolFlag{
-			Name:  "notify",
-			Usage: "Send system notification when a task finishes",
-		},
-		&cli.BoolFlag{
 			Name:  "autoprune",
 			Usage: "Automatically remove containers for archived tasks",
 			Value: true,
@@ -59,7 +55,6 @@ var RunnerCommand = &cli.Command{
 		pollInterval := cmd.Duration("poll")
 		prebuiltDir := cmd.String("prebuilt")
 		concurrency := cmd.Int("concurrency")
-		notifyFlag := cmd.Bool("notify")
 		autoprune := cmd.Bool("autoprune")
 
 		workspaces, err := workspace.LoadConfig(configPath, nil)
@@ -72,7 +67,6 @@ var RunnerCommand = &cli.Command{
 			PrebuiltDir: prebuiltDir,
 			Workspaces:  workspaces,
 			Concurrency: int(concurrency),
-			Notify:      notifyFlag,
 		})
 		if err != nil {
 			return err

--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -27,10 +27,15 @@ var ServerCommand = &cli.Command{
 			Usage:   "Database file path",
 			Value:   "data/xagent.db",
 		},
+		&cli.BoolFlag{
+			Name:  "notify",
+			Usage: "Send system notification when a task finishes",
+		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		addr := cmd.String("addr")
 		dbPath := cmd.String("db")
+		notifyFlag := cmd.Bool("notify")
 
 		db, err := store.Open(dbPath)
 		if err != nil {
@@ -47,6 +52,7 @@ var ServerCommand = &cli.Command{
 			Logs:   logs,
 			Links:  links,
 			Events: events,
+			Notify: notifyFlag,
 		})
 
 		slog.Info("starting server", "addr", addr, "db", dbPath)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -19,7 +19,6 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
 	"github.com/icholy/xagent/internal/agent"
-	"github.com/icholy/xagent/internal/notify"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/workspace"
 	"github.com/icholy/xagent/internal/xagentclient"
@@ -34,7 +33,6 @@ type Runner struct {
 	prebuiltDir  string
 	workspaces   *workspace.Config
 	concurrency  int
-	notify       bool
 	runningCount atomic.Int32
 }
 
@@ -43,7 +41,6 @@ type Options struct {
 	PrebuiltDir string
 	Workspaces  *workspace.Config
 	Concurrency int
-	Notify      bool
 }
 
 func New(opts Options) (*Runner, error) {
@@ -67,7 +64,6 @@ func New(opts Options) (*Runner, error) {
 		prebuiltDir: opts.PrebuiltDir,
 		workspaces:  opts.Workspaces,
 		concurrency: opts.Concurrency,
-		notify:      opts.Notify,
 	}, nil
 }
 
@@ -86,17 +82,6 @@ func (r *Runner) log(ctx context.Context, taskID int64, typ, content string) {
 	if err != nil {
 		slog.Error("failed to upload log", "task", taskID, "error", err)
 	}
-}
-
-func (r *Runner) taskDisplayName(ctx context.Context, taskID int64) string {
-	resp, err := r.client.GetTask(ctx, &xagentv1.GetTaskRequest{Id: taskID})
-	if err != nil {
-		return fmt.Sprintf("Task %d", taskID)
-	}
-	if resp.Task.Name == "" {
-		return fmt.Sprintf("Task %d", taskID)
-	}
-	return fmt.Sprintf("%q", resp.Task.Name)
 }
 
 func (r *Runner) Poll(ctx context.Context) error {
@@ -493,21 +478,11 @@ func (r *Runner) Monitor(ctx context.Context) error {
 				if _, err := r.client.UpdateTask(ctx, &xagentv1.UpdateTaskRequest{Id: taskID, Status: "completed"}); err != nil {
 					slog.Error("failed to update task status", "task", taskID, "error", err)
 				}
-				if r.notify {
-					if err := notify.Send("xagent", fmt.Sprintf("%s completed", r.taskDisplayName(ctx, taskID))); err != nil {
-						slog.Error("failed to send notification", "task", taskID, "error", err)
-					}
-				}
 			} else {
 				slog.Error("container exited with error", "task", taskID, "exitCode", exitCode)
 				r.log(ctx, taskID, "error", fmt.Sprintf("container exited with code %s", exitCode))
 				if _, err := r.client.UpdateTask(ctx, &xagentv1.UpdateTaskRequest{Id: taskID, Status: "failed"}); err != nil {
 					slog.Error("failed to update task status", "task", taskID, "error", err)
-				}
-				if r.notify {
-					if err := notify.Send("xagent", fmt.Sprintf("%s failed (exit code %s)", r.taskDisplayName(ctx, taskID), exitCode)); err != nil {
-						slog.Error("failed to send notification", "task", taskID, "error", err)
-					}
 				}
 			}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/icholy/xagent/internal/model"
+	"github.com/icholy/xagent/internal/notify"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/proto/xagent/v1/xagentv1connect"
 	"github.com/icholy/xagent/internal/store"
@@ -25,6 +26,7 @@ type Server struct {
 	logs   *store.LogRepository
 	links  *store.LinkRepository
 	events *store.EventRepository
+	notify bool
 }
 
 type Options struct {
@@ -33,6 +35,7 @@ type Options struct {
 	Logs   *store.LogRepository
 	Links  *store.LinkRepository
 	Events *store.EventRepository
+	Notify bool
 }
 
 func New(opts Options) *Server {
@@ -46,6 +49,7 @@ func New(opts Options) *Server {
 		logs:   opts.Logs,
 		links:  opts.Links,
 		events: opts.Events,
+		notify: opts.Notify,
 	}
 }
 
@@ -487,8 +491,10 @@ func (s *Server) ProcessEvent(ctx context.Context, req *xagentv1.ProcessEventReq
 func (s *Server) SubmitRunnerEvents(ctx context.Context, req *xagentv1.SubmitRunnerEventsRequest) (*xagentv1.SubmitRunnerEventsResponse, error) {
 	for _, pbEvent := range req.Events {
 		event := model.RunnerEventFromProto(pbEvent)
+		var task *model.Task
 		err := s.tasks.WithTx(ctx, nil, func(tx *sql.Tx) error {
-			task, err := s.tasks.Get(ctx, tx, event.TaskID)
+			var err error
+			task, err = s.tasks.Get(ctx, tx, event.TaskID)
 			if err != nil {
 				return err
 			}
@@ -507,6 +513,32 @@ func (s *Server) SubmitRunnerEvents(ctx context.Context, req *xagentv1.SubmitRun
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, err)
 		}
+		// Send notification after successful transaction
+		if s.notify && task != nil {
+			s.notifyTaskStatus(task)
+		}
 	}
 	return &xagentv1.SubmitRunnerEventsResponse{}, nil
+}
+
+func (s *Server) taskDisplayName(task *model.Task) string {
+	if task.Name != "" {
+		return fmt.Sprintf("Task %d (%s)", task.ID, task.Name)
+	}
+	return fmt.Sprintf("Task %d", task.ID)
+}
+
+func (s *Server) notifyTaskStatus(task *model.Task) {
+	var message string
+	switch task.Status {
+	case model.TaskStatusCompleted:
+		message = fmt.Sprintf("%s completed", s.taskDisplayName(task))
+	case model.TaskStatusFailed:
+		message = fmt.Sprintf("%s failed", s.taskDisplayName(task))
+	default:
+		return
+	}
+	if err := notify.Send("xagent", message); err != nil {
+		s.log.Error("failed to send notification", "task", task.ID, "error", err)
+	}
 }


### PR DESCRIPTION
## Summary

- Moved the `--notify` flag from the runner command to the server command
- Notifications are now sent when the server receives runner events that cause a task to transition to completed or failed status
- Exit codes are no longer included in notifications since the server doesn't have access to them (only knows about completed/failed status)

## Changes

- Added `--notify` flag to `server` command
- Added `Notify` option to server `Options` struct and `Server` struct
- Added notification logic in `SubmitRunnerEvents` method
- Removed `--notify` flag, `Notify` option, and notification logic from runner
- Removed unused `taskDisplayName` method from runner

## Test plan

- [x] Tests pass
- [ ] Manually test with `xagent server --notify` to verify notifications work when tasks complete/fail