### PR TITLE
Replace status field with command+version in runner events

### DIFF
--- a/internal/model/task.go
+++ b/internal/model/task.go
@@ -127,7 +127,6 @@ type RunnerEvent struct {
 	Event     RunnerEventType
 	Version   int64
 	Reconcile bool
-	Status    TaskStatus // Optional: direct status update (bypasses state machine)
 }
 
 // Proto converts a RunnerEvent to its protobuf representation.
@@ -137,7 +136,6 @@ func (r *RunnerEvent) Proto() *xagentv1.RunnerEvent {
 		Event:     string(r.Event),
 		Version:   r.Version,
 		Reconcile: r.Reconcile,
-		Status:    string(r.Status),
 	}
 }
 
@@ -148,7 +146,6 @@ func RunnerEventFromProto(pb *xagentv1.RunnerEvent) RunnerEvent {
 		Event:     RunnerEventType(pb.Event),
 		Version:   pb.Version,
 		Reconcile: pb.Reconcile,
-		Status:    TaskStatus(pb.Status),
 	}
 }
 
@@ -230,35 +227,53 @@ func (t *Task) applyRunnerEventFailed() bool {
 
 // Archive transitions the task to archived status.
 // Returns true if the transition is valid and was applied.
-// Only valid from completed or failed status.
+// Only valid from completed, failed, or cancelled status.
 func (t *Task) Archive() bool {
-	if t.Status != TaskStatusCompleted && t.Status != TaskStatusFailed {
+	switch t.Status {
+	case TaskStatusCompleted, TaskStatusFailed, TaskStatusCancelled:
+		t.Status = TaskStatusArchived
+		return true
+	default:
 		return false
 	}
-	t.Status = TaskStatusArchived
-	return true
 }
 
-// Cancel transitions the task to cancelling status.
+// Cancel transitions the task to cancelling/cancelled status and sets the stop command.
 // Returns true if the transition is valid and was applied.
-// Only valid from running or pending status.
+// For running or restarting tasks: sets status to cancelling, command to stop, increments version.
+// For pending tasks: sets status to cancelled directly (no runner action needed).
 func (t *Task) Cancel() bool {
-	if t.Status != TaskStatusRunning && t.Status != TaskStatusPending {
+	switch t.Status {
+	case TaskStatusRunning, TaskStatusRestarting:
+		t.Status = TaskStatusCancelling
+		t.Command = TaskCommandStop
+		t.Version++
+		return true
+	case TaskStatusPending:
+		t.Status = TaskStatusCancelled
+		return true
+	default:
 		return false
 	}
-	t.Status = TaskStatusCancelling
-	return true
 }
 
-// Restart transitions the task to restarting status.
+// Restart transitions the task to pending/restarting status and sets the restart command.
 // Returns true if the transition is valid and was applied.
-// Only valid from running, completed, or failed status.
+// For running tasks: sets status to restarting, command to restart, increments version.
+// For completed, failed, or cancelled tasks: sets status to pending, command to restart, increments version.
 func (t *Task) Restart() bool {
-	if t.Status != TaskStatusRunning &&
-		t.Status != TaskStatusCompleted &&
-		t.Status != TaskStatusFailed {
+	switch t.Status {
+	case TaskStatusRunning:
+		t.Status = TaskStatusRestarting
+		t.Command = TaskCommandRestart
+		t.Version++
+		return true
+	case TaskStatusCompleted, TaskStatusFailed, TaskStatusCancelled:
+		t.Status = TaskStatusPending
+		t.Command = TaskCommandRestart
+		t.Version++
+		return true
+	default:
 		return false
 	}
-	t.Status = TaskStatusRestarting
-	return true
 }

--- a/internal/model/task_test.go
+++ b/internal/model/task_test.go
@@ -302,66 +302,66 @@ func TestTask_ApplyRunnerEvent(t *testing.T) {
 func TestTask_Archive(t *testing.T) {
 	tests := []struct {
 		name   string
-		before TaskStatus
+		before Task
+		after  Task
 		want   bool
-		after  TaskStatus
 	}{
 		{
 			name:   "from completed succeeds",
-			before: TaskStatusCompleted,
+			before: Task{Status: TaskStatusCompleted},
+			after:  Task{Status: TaskStatusArchived},
 			want:   true,
-			after:  TaskStatusArchived,
 		},
 		{
 			name:   "from failed succeeds",
-			before: TaskStatusFailed,
+			before: Task{Status: TaskStatusFailed},
+			after:  Task{Status: TaskStatusArchived},
 			want:   true,
-			after:  TaskStatusArchived,
 		},
 		{
 			name:   "from pending fails",
-			before: TaskStatusPending,
+			before: Task{Status: TaskStatusPending},
+			after:  Task{Status: TaskStatusPending},
 			want:   false,
-			after:  TaskStatusPending,
 		},
 		{
 			name:   "from running fails",
-			before: TaskStatusRunning,
+			before: Task{Status: TaskStatusRunning},
+			after:  Task{Status: TaskStatusRunning},
 			want:   false,
-			after:  TaskStatusRunning,
 		},
 		{
 			name:   "from restarting fails",
-			before: TaskStatusRestarting,
+			before: Task{Status: TaskStatusRestarting},
+			after:  Task{Status: TaskStatusRestarting},
 			want:   false,
-			after:  TaskStatusRestarting,
 		},
 		{
 			name:   "from cancelling fails",
-			before: TaskStatusCancelling,
+			before: Task{Status: TaskStatusCancelling},
+			after:  Task{Status: TaskStatusCancelling},
 			want:   false,
-			after:  TaskStatusCancelling,
 		},
 		{
-			name:   "from cancelled fails",
-			before: TaskStatusCancelled,
-			want:   false,
-			after:  TaskStatusCancelled,
+			name:   "from cancelled succeeds",
+			before: Task{Status: TaskStatusCancelled},
+			after:  Task{Status: TaskStatusArchived},
+			want:   true,
 		},
 		{
 			name:   "from archived fails",
-			before: TaskStatusArchived,
+			before: Task{Status: TaskStatusArchived},
+			after:  Task{Status: TaskStatusArchived},
 			want:   false,
-			after:  TaskStatusArchived,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			task := Task{Status: tt.before}
+			task := tt.before
 			got := task.Archive()
 			assert.Equal(t, got, tt.want)
-			assert.Equal(t, task.Status, tt.after)
+			assert.DeepEqual(t, task, tt.after)
 		})
 	}
 }
@@ -369,66 +369,66 @@ func TestTask_Archive(t *testing.T) {
 func TestTask_Cancel(t *testing.T) {
 	tests := []struct {
 		name   string
-		before TaskStatus
+		before Task
+		after  Task
 		want   bool
-		after  TaskStatus
 	}{
 		{
 			name:   "from running succeeds",
-			before: TaskStatusRunning,
+			before: Task{Status: TaskStatusRunning},
+			after:  Task{Status: TaskStatusCancelling, Command: TaskCommandStop, Version: 1},
 			want:   true,
-			after:  TaskStatusCancelling,
 		},
 		{
-			name:   "from pending succeeds",
-			before: TaskStatusPending,
+			name:   "from pending succeeds with cancelled status",
+			before: Task{Status: TaskStatusPending},
+			after:  Task{Status: TaskStatusCancelled},
 			want:   true,
-			after:  TaskStatusCancelling,
 		},
 		{
 			name:   "from completed fails",
-			before: TaskStatusCompleted,
+			before: Task{Status: TaskStatusCompleted},
+			after:  Task{Status: TaskStatusCompleted},
 			want:   false,
-			after:  TaskStatusCompleted,
 		},
 		{
 			name:   "from failed fails",
-			before: TaskStatusFailed,
+			before: Task{Status: TaskStatusFailed},
+			after:  Task{Status: TaskStatusFailed},
 			want:   false,
-			after:  TaskStatusFailed,
 		},
 		{
-			name:   "from restarting fails",
-			before: TaskStatusRestarting,
-			want:   false,
-			after:  TaskStatusRestarting,
+			name:   "from restarting succeeds",
+			before: Task{Status: TaskStatusRestarting},
+			after:  Task{Status: TaskStatusCancelling, Command: TaskCommandStop, Version: 1},
+			want:   true,
 		},
 		{
 			name:   "from cancelling fails",
-			before: TaskStatusCancelling,
+			before: Task{Status: TaskStatusCancelling},
+			after:  Task{Status: TaskStatusCancelling},
 			want:   false,
-			after:  TaskStatusCancelling,
 		},
 		{
 			name:   "from cancelled fails",
-			before: TaskStatusCancelled,
+			before: Task{Status: TaskStatusCancelled},
+			after:  Task{Status: TaskStatusCancelled},
 			want:   false,
-			after:  TaskStatusCancelled,
 		},
 		{
 			name:   "from archived fails",
-			before: TaskStatusArchived,
+			before: Task{Status: TaskStatusArchived},
+			after:  Task{Status: TaskStatusArchived},
 			want:   false,
-			after:  TaskStatusArchived,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			task := Task{Status: tt.before}
+			task := tt.before
 			got := task.Cancel()
 			assert.Equal(t, got, tt.want)
-			assert.Equal(t, task.Status, tt.after)
+			assert.DeepEqual(t, task, tt.after)
 		})
 	}
 }
@@ -436,66 +436,66 @@ func TestTask_Cancel(t *testing.T) {
 func TestTask_Restart(t *testing.T) {
 	tests := []struct {
 		name   string
-		before TaskStatus
+		before Task
+		after  Task
 		want   bool
-		after  TaskStatus
 	}{
 		{
 			name:   "from running succeeds",
-			before: TaskStatusRunning,
+			before: Task{Status: TaskStatusRunning},
+			after:  Task{Status: TaskStatusRestarting, Command: TaskCommandRestart, Version: 1},
 			want:   true,
-			after:  TaskStatusRestarting,
 		},
 		{
 			name:   "from completed succeeds",
-			before: TaskStatusCompleted,
+			before: Task{Status: TaskStatusCompleted},
+			after:  Task{Status: TaskStatusPending, Command: TaskCommandRestart, Version: 1},
 			want:   true,
-			after:  TaskStatusRestarting,
 		},
 		{
 			name:   "from failed succeeds",
-			before: TaskStatusFailed,
+			before: Task{Status: TaskStatusFailed},
+			after:  Task{Status: TaskStatusPending, Command: TaskCommandRestart, Version: 1},
 			want:   true,
-			after:  TaskStatusRestarting,
 		},
 		{
 			name:   "from pending fails",
-			before: TaskStatusPending,
+			before: Task{Status: TaskStatusPending},
+			after:  Task{Status: TaskStatusPending},
 			want:   false,
-			after:  TaskStatusPending,
 		},
 		{
 			name:   "from restarting fails",
-			before: TaskStatusRestarting,
+			before: Task{Status: TaskStatusRestarting},
+			after:  Task{Status: TaskStatusRestarting},
 			want:   false,
-			after:  TaskStatusRestarting,
 		},
 		{
 			name:   "from cancelling fails",
-			before: TaskStatusCancelling,
+			before: Task{Status: TaskStatusCancelling},
+			after:  Task{Status: TaskStatusCancelling},
 			want:   false,
-			after:  TaskStatusCancelling,
 		},
 		{
-			name:   "from cancelled fails",
-			before: TaskStatusCancelled,
-			want:   false,
-			after:  TaskStatusCancelled,
+			name:   "from cancelled succeeds",
+			before: Task{Status: TaskStatusCancelled},
+			after:  Task{Status: TaskStatusPending, Command: TaskCommandRestart, Version: 1},
+			want:   true,
 		},
 		{
 			name:   "from archived fails",
-			before: TaskStatusArchived,
+			before: Task{Status: TaskStatusArchived},
+			after:  Task{Status: TaskStatusArchived},
 			want:   false,
-			after:  TaskStatusArchived,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			task := Task{Status: tt.before}
+			task := tt.before
 			got := task.Restart()
 			assert.Equal(t, got, tt.want)
-			assert.Equal(t, task.Status, tt.after)
+			assert.DeepEqual(t, task, tt.after)
 		})
 	}
 }

--- a/internal/proto/xagent/v1/xagent.pb.go
+++ b/internal/proto/xagent/v1/xagent.pb.go
@@ -261,6 +261,7 @@ func (x *McpServer) GetEnv() map[string]string {
 type ListTasksRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Statuses      []string               `protobuf:"bytes,1,rep,name=statuses,proto3" json:"statuses,omitempty"`
+	HasCommand    bool                   `protobuf:"varint,2,opt,name=has_command,json=hasCommand,proto3" json:"has_command,omitempty"` // If true, only return tasks with non-empty command
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -300,6 +301,13 @@ func (x *ListTasksRequest) GetStatuses() []string {
 		return x.Statuses
 	}
 	return nil
+}
+
+func (x *ListTasksRequest) GetHasCommand() bool {
+	if x != nil {
+		return x.HasCommand
+	}
+	return false
 }
 
 type ListTasksResponse struct {
@@ -2668,7 +2676,6 @@ type RunnerEvent struct {
 	Event         string                 `protobuf:"bytes,2,opt,name=event,proto3" json:"event,omitempty"`          // "started", "stopped", "failed"
 	Version       int64                  `protobuf:"varint,3,opt,name=version,proto3" json:"version,omitempty"`     // Current version, or 0 for bypass
 	Reconcile     bool                   `protobuf:"varint,4,opt,name=reconcile,proto3" json:"reconcile,omitempty"` // True if from reconciliation, not real-time
-	Status        string                 `protobuf:"bytes,5,opt,name=status,proto3" json:"status,omitempty"`        // Optional: direct status update (bypasses state machine)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2729,13 +2736,6 @@ func (x *RunnerEvent) GetReconcile() bool {
 		return x.Reconcile
 	}
 	return false
-}
-
-func (x *RunnerEvent) GetStatus() string {
-	if x != nil {
-		return x.Status
-	}
-	return ""
 }
 
 type SubmitRunnerEventsRequest struct {
@@ -2847,9 +2847,11 @@ const file_xagent_v1_xagent_proto_rawDesc = "" +
 	"\x03env\x18\x04 \x03(\v2\x1d.xagent.v1.McpServer.EnvEntryR\x03env\x1a6\n" +
 	"\bEnvEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\".\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"O\n" +
 	"\x10ListTasksRequest\x12\x1a\n" +
-	"\bstatuses\x18\x01 \x03(\tR\bstatuses\":\n" +
+	"\bstatuses\x18\x01 \x03(\tR\bstatuses\x12\x1f\n" +
+	"\vhas_command\x18\x02 \x01(\bR\n" +
+	"hasCommand\":\n" +
 	"\x11ListTasksResponse\x12%\n" +
 	"\x05tasks\x18\x01 \x03(\v2\x0f.xagent.v1.TaskR\x05tasks\"4\n" +
 	"\x15ListChildTasksRequest\x12\x1b\n" +
@@ -2971,13 +2973,12 @@ const file_xagent_v1_xagent_proto_rawDesc = "" +
 	"\x13ProcessEventRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\"1\n" +
 	"\x14ProcessEventResponse\x12\x19\n" +
-	"\btask_ids\x18\x01 \x03(\x03R\ataskIds\"\x8c\x01\n" +
+	"\btask_ids\x18\x01 \x03(\x03R\ataskIds\"t\n" +
 	"\vRunnerEvent\x12\x17\n" +
 	"\atask_id\x18\x01 \x01(\x03R\x06taskId\x12\x14\n" +
 	"\x05event\x18\x02 \x01(\tR\x05event\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\x03R\aversion\x12\x1c\n" +
-	"\treconcile\x18\x04 \x01(\bR\treconcile\x12\x16\n" +
-	"\x06status\x18\x05 \x01(\tR\x06status\"K\n" +
+	"\treconcile\x18\x04 \x01(\bR\treconcile\"K\n" +
 	"\x19SubmitRunnerEventsRequest\x12.\n" +
 	"\x06events\x18\x01 \x03(\v2\x16.xagent.v1.RunnerEventR\x06events\"\x1c\n" +
 	"\x1aSubmitRunnerEventsResponse2\xc8\x0f\n" +

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
 	"github.com/icholy/xagent/internal/agent"
+	"github.com/icholy/xagent/internal/model"
 	"github.com/icholy/xagent/internal/notify"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/workspace"
@@ -76,10 +77,10 @@ func (r *Runner) Close() error {
 	return r.docker.Close()
 }
 
-func (r *Runner) updateStatus(ctx context.Context, taskID int64, status string) error {
+func (r *Runner) submit(ctx context.Context, taskID int64, event string, version int64) error {
 	_, err := r.client.SubmitRunnerEvents(ctx, &xagentv1.SubmitRunnerEventsRequest{
 		Events: []*xagentv1.RunnerEvent{
-			{TaskId: taskID, Status: status},
+			{TaskId: taskID, Event: event, Version: version},
 		},
 	})
 	return err
@@ -97,52 +98,39 @@ func (r *Runner) taskDisplayName(ctx context.Context, taskID int64) string {
 }
 
 func (r *Runner) Poll(ctx context.Context) error {
-	resp, err := r.client.ListTasks(ctx, &xagentv1.ListTasksRequest{Statuses: []string{"pending", "cancelled", "restarting"}})
+	resp, err := r.client.ListTasks(ctx, &xagentv1.ListTasksRequest{HasCommand: true})
 	if err != nil {
 		return err
 	}
 
-	for _, task := range resp.Tasks {
-		switch task.Status {
-		case "cancelled":
-			if err := r.killTask(ctx, task, "SIGKILL"); err != nil {
-				slog.Error("failed to cancel task", "task", task.Id, "error", err)
+	for _, pbTask := range resp.Tasks {
+		task := model.TaskFromProto(pbTask)
+		switch task.Command {
+		case model.TaskCommandStop:
+			if err := r.killTask(ctx, pbTask, "SIGTERM"); err != nil {
+				slog.Error("failed to stop task", "task", task.ID, "error", err)
 			}
-			if err := r.updateStatus(ctx, task.Id, "failed"); err != nil {
-				slog.Error("failed to update cancelled task", "task", task.Id, "error", err)
+			if err := r.submit(ctx, task.ID, "stopped", task.Version); err != nil {
+				slog.Error("failed to send stopped event", "task", task.ID, "error", err)
 			}
-		case "restarting":
-			if err := r.killTask(ctx, task, "SIGTERM"); err != nil {
-				slog.Error("failed to kill task for restart", "task", task.Id, "error", err)
+		case model.TaskCommandRestart:
+			// Kill existing container if running
+			if err := r.killTask(ctx, pbTask, "SIGTERM"); err != nil {
+				slog.Error("failed to kill task for restart", "task", task.ID, "error", err)
 			}
 			if r.concurrency > 0 && int(r.runningCount.Load()) >= r.concurrency {
-				slog.Debug("concurrency limit reached, skipping restarting task", "task", task.Id, "running", r.runningCount.Load(), "limit", r.concurrency)
+				slog.Debug("concurrency limit reached, skipping task", "task", task.ID, "running", r.runningCount.Load(), "limit", r.concurrency)
 				continue
 			}
-			if err := r.startTask(ctx, task); err != nil {
-				slog.Error("failed to restart task", "task", task.Id, "error", err)
-				if err := r.updateStatus(ctx, task.Id, "failed"); err != nil {
-					slog.Error("failed to update task status", "task", task.Id, "error", err)
+			if err := r.startTask(ctx, pbTask); err != nil {
+				slog.Error("failed to start task", "task", task.ID, "error", err)
+				if err := r.submit(ctx, task.ID, "failed", task.Version); err != nil {
+					slog.Error("failed to send failed event", "task", task.ID, "error", err)
 				}
 				continue
 			}
-			if err := r.updateStatus(ctx, task.Id, "running"); err != nil {
-				slog.Error("failed to update task status", "task", task.Id, "error", err)
-			}
-		case "pending":
-			if r.concurrency > 0 && int(r.runningCount.Load()) >= r.concurrency {
-				slog.Debug("concurrency limit reached, skipping pending task", "task", task.Id, "running", r.runningCount.Load(), "limit", r.concurrency)
-				continue
-			}
-			if err := r.startTask(ctx, task); err != nil {
-				slog.Error("failed to start container", "task", task.Id, "error", err)
-				if err := r.updateStatus(ctx, task.Id, "failed"); err != nil {
-					slog.Error("failed to update task status", "task", task.Id, "error", err)
-				}
-				continue
-			}
-			if err := r.updateStatus(ctx, task.Id, "running"); err != nil {
-				slog.Error("failed to update task status", "task", task.Id, "error", err)
+			if err := r.submit(ctx, task.ID, "started", task.Version); err != nil {
+				slog.Error("failed to send started event", "task", task.ID, "error", err)
 			}
 		}
 	}
@@ -201,16 +189,17 @@ func (r *Runner) Reconcile(ctx context.Context) error {
 			continue
 		}
 
+		// Use version 0 to bypass version check (spontaneous events)
 		exitCode := info.State.ExitCode
 		if exitCode == 0 {
 			slog.Info("reconcile: container exited successfully", "task", taskID)
-			if err := r.updateStatus(ctx, taskID, "completed"); err != nil {
-				slog.Error("failed to update task status", "task", taskID, "error", err)
+			if err := r.submit(ctx, taskID, "stopped", 0); err != nil {
+				slog.Error("failed to send stopped event", "task", taskID, "error", err)
 			}
 		} else {
 			slog.Error("reconcile: container exited with error", "task", taskID, "exitCode", exitCode)
-			if err := r.updateStatus(ctx, taskID, "failed"); err != nil {
-				slog.Error("failed to update task status", "task", taskID, "error", err)
+			if err := r.submit(ctx, taskID, "failed", 0); err != nil {
+				slog.Error("failed to send failed event", "task", taskID, "error", err)
 			}
 		}
 	}
@@ -455,7 +444,7 @@ func (r *Runner) copyConfig(ctx context.Context, containerID string, task *xagen
 	return r.docker.CopyToContainer(ctx, containerID, "/", bytes.NewReader(data), container.CopyToContainerOptions{})
 }
 
-// Monitor watches for container exits and updates task status accordingly.
+// Monitor watches for container exits and sends runner events accordingly.
 func (r *Runner) Monitor(ctx context.Context) error {
 	eventCh, errCh := r.docker.Events(ctx, events.ListOptions{
 		Filters: filters.NewArgs(
@@ -475,11 +464,12 @@ func (r *Runner) Monitor(ctx context.Context) error {
 				slog.Error("invalid task ID in container event", "task", taskIDStr, "error", err)
 				continue
 			}
+			// Use version 0 to bypass version check (spontaneous events)
 			exitCode := event.Actor.Attributes["exitCode"]
 			if exitCode == "0" {
 				slog.Info("container exited successfully", "task", taskID)
-				if err := r.updateStatus(ctx, taskID, "completed"); err != nil {
-					slog.Error("failed to update task status", "task", taskID, "error", err)
+				if err := r.submit(ctx, taskID, "stopped", 0); err != nil {
+					slog.Error("failed to send stopped event", "task", taskID, "error", err)
 				}
 				if r.notify {
 					if err := notify.Send("xagent", fmt.Sprintf("%s completed", r.taskDisplayName(ctx, taskID))); err != nil {
@@ -488,8 +478,8 @@ func (r *Runner) Monitor(ctx context.Context) error {
 				}
 			} else {
 				slog.Error("container exited with error", "task", taskID, "exitCode", exitCode)
-				if err := r.updateStatus(ctx, taskID, "failed"); err != nil {
-					slog.Error("failed to update task status", "task", taskID, "error", err)
+				if err := r.submit(ctx, taskID, "failed", 0); err != nil {
+					slog.Error("failed to send failed event", "task", taskID, "error", err)
 				}
 				if r.notify {
 					if err := notify.Send("xagent", fmt.Sprintf("%s failed (exit code %s)", r.taskDisplayName(ctx, taskID), exitCode)); err != nil {

--- a/internal/server/event_test.go
+++ b/internal/server/event_test.go
@@ -544,10 +544,18 @@ func TestProcessEventSkipsArchivedTasks(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	// Set task to completed first (archive only works from completed/failed)
+	// First, send started event to transition pending -> running
 	_, err = srv.SubmitRunnerEvents(ctx, &xagentv1.SubmitRunnerEventsRequest{
 		Events: []*xagentv1.RunnerEvent{
-			{TaskId: archivedTask.Task.Id, Status: "completed"},
+			{TaskId: archivedTask.Task.Id, Event: "started", Version: archivedTask.Task.Version},
+		},
+	})
+	assert.NilError(t, err)
+
+	// Then send stopped event to transition running -> completed
+	_, err = srv.SubmitRunnerEvents(ctx, &xagentv1.SubmitRunnerEventsRequest{
+		Events: []*xagentv1.RunnerEvent{
+			{TaskId: archivedTask.Task.Id, Event: "stopped", Version: 0},
 		},
 	})
 	assert.NilError(t, err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -65,11 +65,16 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) ListTasks(ctx context.Context, req *xagentv1.ListTasksRequest) (*xagentv1.ListTasksResponse, error) {
 	var tasks []*model.Task
 	var err error
-	statuses := make([]model.TaskStatus, len(req.Statuses))
-	for i, s := range req.Statuses {
-		statuses[i] = model.TaskStatus(s)
+
+	if req.HasCommand {
+		tasks, err = s.tasks.ListWithCommand(ctx, nil)
+	} else {
+		statuses := make([]model.TaskStatus, len(req.Statuses))
+		for i, s := range req.Statuses {
+			statuses[i] = model.TaskStatus(s)
+		}
+		tasks, err = s.tasks.ListByStatuses(ctx, nil, statuses)
 	}
-	tasks, err = s.tasks.ListByStatuses(ctx, nil, statuses)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -110,6 +115,8 @@ func (s *Server) CreateTask(ctx context.Context, req *xagentv1.CreateTaskRequest
 		Workspace:    req.Workspace,
 		Instructions: instructions,
 		Status:       model.TaskStatusPending,
+		Command:      model.TaskCommandRestart,
+		Version:      1,
 	}
 
 	if err := s.tasks.Create(ctx, nil, task); err != nil {
@@ -495,17 +502,7 @@ func (s *Server) SubmitRunnerEvents(ctx context.Context, req *xagentv1.SubmitRun
 				return err
 			}
 
-			var updated bool
-			if event.Status != "" {
-				// Direct status update (bypasses state machine)
-				task.Status = event.Status
-				updated = true
-			} else {
-				// Use state machine
-				updated = task.ApplyRunnerEvent(&event)
-			}
-
-			if updated {
+			if task.ApplyRunnerEvent(&event) {
 				newStatus = task.Status
 				if err := s.tasks.Put(ctx, tx, task); err != nil {
 					return err
@@ -513,7 +510,7 @@ func (s *Server) SubmitRunnerEvents(ctx context.Context, req *xagentv1.SubmitRun
 				s.log.Info("runner event applied",
 					"task_id", event.TaskID,
 					"event", event.Event,
-					"status", event.Status,
+					"version", event.Version,
 					"new_status", task.Status,
 				)
 			}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -88,6 +88,8 @@ func TestGetTask(t *testing.T) {
 			},
 		},
 		Status:    "pending",
+		Command:   "restart",
+		Version:   1,
 		CreatedAt: getResp.Task.CreatedAt, // Copy timestamps since we can't predict them
 		UpdatedAt: getResp.Task.UpdatedAt,
 	}
@@ -126,6 +128,8 @@ func TestCreateTask(t *testing.T) {
 			},
 		},
 		Status:    "pending",
+		Command:   "restart",
+		Version:   1,
 		CreatedAt: resp.Task.CreatedAt,
 		UpdatedAt: resp.Task.UpdatedAt,
 	}
@@ -259,7 +263,7 @@ func TestSubmitRunnerEvents(t *testing.T) {
 	srv := setupTestServer(t)
 	ctx := context.Background()
 
-	// Create a task
+	// Create a task (starts as pending with restart command)
 	createResp, err := srv.CreateTask(ctx, &xagentv1.CreateTaskRequest{
 		Name:      "Test Task",
 		Workspace: "test-workspace",
@@ -267,34 +271,45 @@ func TestSubmitRunnerEvents(t *testing.T) {
 	assert.NilError(t, err)
 	taskID := createResp.Task.Id
 
-	// Use direct status update (like the runner does) to set to running
-	_, err = srv.SubmitRunnerEvents(ctx, &xagentv1.SubmitRunnerEventsRequest{
-		Events: []*xagentv1.RunnerEvent{
-			{
-				TaskId: taskID,
-				Status: "running",
-			},
-		},
-	})
-	assert.NilError(t, err)
-
-	// Verify task is running
+	// Verify initial state
 	getResp, err := srv.GetTask(ctx, &xagentv1.GetTaskRequest{Id: taskID})
 	assert.NilError(t, err)
-	assert.Equal(t, getResp.Task.Status, "running")
+	assert.Equal(t, getResp.Task.Status, "pending")
+	assert.Equal(t, getResp.Task.Command, "restart")
+	assert.Equal(t, getResp.Task.Version, int64(1))
 
-	// Use direct status update to set to completed
+	// Send started event (simulating container start)
 	_, err = srv.SubmitRunnerEvents(ctx, &xagentv1.SubmitRunnerEventsRequest{
 		Events: []*xagentv1.RunnerEvent{
 			{
-				TaskId: taskID,
-				Status: "completed",
+				TaskId:  taskID,
+				Event:   "started",
+				Version: 1,
 			},
 		},
 	})
 	assert.NilError(t, err)
 
-	// Verify task status was updated
+	// Verify task is running and command is cleared
+	getResp, err = srv.GetTask(ctx, &xagentv1.GetTaskRequest{Id: taskID})
+	assert.NilError(t, err)
+	assert.Equal(t, getResp.Task.Status, "running")
+	assert.Equal(t, getResp.Task.Command, "")
+
+	// Send stopped event (simulating container exit with code 0)
+	// Use version 0 to bypass version check (spontaneous event)
+	_, err = srv.SubmitRunnerEvents(ctx, &xagentv1.SubmitRunnerEventsRequest{
+		Events: []*xagentv1.RunnerEvent{
+			{
+				TaskId:  taskID,
+				Event:   "stopped",
+				Version: 0,
+			},
+		},
+	})
+	assert.NilError(t, err)
+
+	// Verify task status was updated to completed
 	getResp, err = srv.GetTask(ctx, &xagentv1.GetTaskRequest{Id: taskID})
 	assert.NilError(t, err)
 	assert.Equal(t, getResp.Task.Status, "completed")

--- a/internal/store/task.go
+++ b/internal/store/task.go
@@ -112,6 +112,19 @@ func (r *TaskRepository) ListChildren(ctx context.Context, tx *sql.Tx, parentID 
 	return r.scanTasks(rows)
 }
 
+func (r *TaskRepository) ListWithCommand(ctx context.Context, tx *sql.Tx) ([]*model.Task, error) {
+	rows, err := r.exec(tx).QueryContext(ctx, `
+		SELECT id, name, parent, workspace, prompts, status, command, version, created_at, updated_at
+		FROM tasks WHERE command != '' ORDER BY created_at DESC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return r.scanTasks(rows)
+}
+
 func (r *TaskRepository) ListByEvent(ctx context.Context, tx *sql.Tx, eventID int64) ([]*model.Task, error) {
 	rows, err := r.exec(tx).QueryContext(ctx, `
 		SELECT t.id, t.name, t.parent, t.workspace, t.prompts, t.status, t.command, t.version, t.created_at, t.updated_at

--- a/proto/xagent/v1/xagent.proto
+++ b/proto/xagent/v1/xagent.proto
@@ -61,6 +61,7 @@ message McpServer {
 
 message ListTasksRequest {
   repeated string statuses = 1;
+  bool has_command = 2;  // If true, only return tasks with non-empty command
 }
 
 message ListTasksResponse {
@@ -279,7 +280,6 @@ message RunnerEvent {
   string event = 2;     // "started", "stopped", "failed"
   int64 version = 3;    // Current version, or 0 for bypass
   bool reconcile = 4;   // True if from reconciliation, not real-time
-  string status = 5;    // Optional: direct status update (bypasses state machine)
 }
 
 message SubmitRunnerEventsRequest {


### PR DESCRIPTION
## Summary

- Implements task lifecycle state machine with command/version model as specified in #149
- Runner now uses event+version instead of direct status updates  
- Removes status field from RunnerEvent proto
- Updates runner polling to use has_command filter
- Task methods (Cancel, Restart) now set command and increment version

## Test plan

- [x] All existing tests pass
- [ ] Manual testing: Create task and verify it starts
- [ ] Manual testing: Cancel running task and verify it stops
- [ ] Manual testing: Restart completed task and verify it restarts

Closes #149