### PR TITLE
Sync FE task status labels with BE model

### DIFF
--- a/webui/src/lib/task.ts
+++ b/webui/src/lib/task.ts
@@ -8,15 +8,15 @@ export function isChildTask(task: TaskWithParent): boolean {
 }
 
 export function canArchiveTask(task: TaskLike): boolean {
-  return task.status === 'completed' || task.status === 'failed'
+  return task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled'
 }
 
 export function canCancelTask(task: TaskLike): boolean {
-  return task.status === 'running' || task.status === 'pending'
+  return task.status === 'pending' || task.status === 'running' || task.status === 'restarting'
 }
 
 export function canRestartTask(task: TaskLike): boolean {
-  return task.status === 'running' || task.status === 'completed' || task.status === 'failed'
+  return task.status === 'running' || task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled'
 }
 
 export function isArchivedTask(task: TaskLike): boolean {

--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -34,10 +34,11 @@ export const Route = createFileRoute('/tasks/$id')({
 const statusStyles: Record<string, string> = {
   pending: 'bg-amber-100 text-amber-800 border-amber-200',
   running: 'bg-blue-100 text-blue-800 border-blue-200',
+  restarting: 'bg-pink-100 text-pink-800 border-pink-200',
+  cancelling: 'bg-orange-100 text-orange-800 border-orange-200',
   completed: 'bg-green-100 text-green-800 border-green-200',
   failed: 'bg-red-100 text-red-800 border-red-200',
   cancelled: 'bg-amber-100 text-amber-800 border-amber-200',
-  restarting: 'bg-pink-100 text-pink-800 border-pink-200',
   archived: 'bg-gray-100 text-gray-600 border-gray-200',
 }
 

--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -157,10 +157,11 @@ function StatusBadge({ status }: { status: string }) {
   const statusStyles: Record<string, string> = {
     pending: 'bg-amber-100 text-amber-800 border-amber-200',
     running: 'bg-blue-100 text-blue-800 border-blue-200',
+    restarting: 'bg-pink-100 text-pink-800 border-pink-200',
+    cancelling: 'bg-orange-100 text-orange-800 border-orange-200',
     completed: 'bg-green-100 text-green-800 border-green-200',
     failed: 'bg-red-100 text-red-800 border-red-200',
     cancelled: 'bg-amber-100 text-amber-800 border-amber-200',
-    restarting: 'bg-pink-100 text-pink-800 border-pink-200',
     archived: 'bg-gray-100 text-gray-600 border-gray-200',
   }
 


### PR DESCRIPTION
## Summary

- Add missing `cancelling` status style to StatusBadge components in both task list and detail views
- Update `canArchiveTask` to include `cancelled` status (matches BE's `Archive()` method)
- Update `canCancelTask` to include `restarting` status (matches BE's `Cancel()` method)
- Update `canRestartTask` to include `cancelled` status (matches BE's `Restart()` method)
- Reorder status styles to match BE `TaskStatus` constant order for consistency

## Changes

**BE Status Values** (`internal/model/task.go`):
- pending, running, restarting, cancelling, completed, failed, cancelled, archived

**FE Status Styles** (before this PR):
- Missing `cancelling` status

**FE Task Functions** (before this PR):
- `canArchiveTask`: missing `cancelled`
- `canCancelTask`: missing `restarting`  
- `canRestartTask`: missing `cancelled`

## Test Plan

- [x] Build succeeds (`npm run build`)
- [ ] Verify `cancelling` status displays with orange badge
- [ ] Verify Archive button appears for cancelled tasks
- [ ] Verify Cancel button appears for restarting tasks
- [ ] Verify Restart button appears for cancelled tasks