### PR TITLE
Remove unused ListByStatuses functionality

### DIFF
--- a/internal/command/task_list.go
+++ b/internal/command/task_list.go
@@ -22,17 +22,11 @@ var TaskListCommand = &cli.Command{
 			Usage:   "C2 server URL",
 			Value:   "http://localhost:8080",
 		},
-		&cli.StringSliceFlag{
-			Name:  "status",
-			Usage: "Filter by status (pending, running, completed, failed)",
-		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		client := xagentclient.New(cmd.String("server"))
 
-		resp, err := client.ListTasks(ctx, &xagentv1.ListTasksRequest{
-			Statuses: cmd.StringSlice("status"),
-		})
+		resp, err := client.ListTasks(ctx, &xagentv1.ListTasksRequest{})
 		if err != nil {
 			return fmt.Errorf("failed to list tasks: %w", err)
 		}

--- a/internal/proto/xagent/v1/xagent.pb.go
+++ b/internal/proto/xagent/v1/xagent.pb.go
@@ -260,8 +260,7 @@ func (x *McpServer) GetEnv() map[string]string {
 
 type ListTasksRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Statuses      []string               `protobuf:"bytes,1,rep,name=statuses,proto3" json:"statuses,omitempty"`
-	HasCommand    bool                   `protobuf:"varint,2,opt,name=has_command,json=hasCommand,proto3" json:"has_command,omitempty"` // If true, only return tasks with non-empty command
+	HasCommand    bool                   `protobuf:"varint,1,opt,name=has_command,json=hasCommand,proto3" json:"has_command,omitempty"` // If true, only return tasks with non-empty command
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -294,13 +293,6 @@ func (x *ListTasksRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ListTasksRequest.ProtoReflect.Descriptor instead.
 func (*ListTasksRequest) Descriptor() ([]byte, []int) {
 	return file_xagent_v1_xagent_proto_rawDescGZIP(), []int{3}
-}
-
-func (x *ListTasksRequest) GetStatuses() []string {
-	if x != nil {
-		return x.Statuses
-	}
-	return nil
 }
 
 func (x *ListTasksRequest) GetHasCommand() bool {
@@ -2847,10 +2839,9 @@ const file_xagent_v1_xagent_proto_rawDesc = "" +
 	"\x03env\x18\x04 \x03(\v2\x1d.xagent.v1.McpServer.EnvEntryR\x03env\x1a6\n" +
 	"\bEnvEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"O\n" +
-	"\x10ListTasksRequest\x12\x1a\n" +
-	"\bstatuses\x18\x01 \x03(\tR\bstatuses\x12\x1f\n" +
-	"\vhas_command\x18\x02 \x01(\bR\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"3\n" +
+	"\x10ListTasksRequest\x12\x1f\n" +
+	"\vhas_command\x18\x01 \x01(\bR\n" +
 	"hasCommand\":\n" +
 	"\x11ListTasksResponse\x12%\n" +
 	"\x05tasks\x18\x01 \x03(\v2\x0f.xagent.v1.TaskR\x05tasks\"4\n" +

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -69,11 +69,7 @@ func (s *Server) ListTasks(ctx context.Context, req *xagentv1.ListTasksRequest) 
 	if req.HasCommand {
 		tasks, err = s.tasks.ListWithCommand(ctx, nil)
 	} else {
-		statuses := make([]model.TaskStatus, len(req.Statuses))
-		for i, s := range req.Statuses {
-			statuses[i] = model.TaskStatus(s)
-		}
-		tasks, err = s.tasks.ListByStatuses(ctx, nil, statuses)
+		tasks, err = s.tasks.List(ctx, nil)
 	}
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)

--- a/internal/store/task.go
+++ b/internal/store/task.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/icholy/xagent/internal/model"
@@ -76,28 +74,6 @@ func (r *TaskRepository) List(ctx context.Context, tx *sql.Tx) ([]*model.Task, e
 	return r.scanTasks(rows)
 }
 
-func (r *TaskRepository) ListByStatuses(ctx context.Context, tx *sql.Tx, statuses []model.TaskStatus) ([]*model.Task, error) {
-	if len(statuses) == 0 {
-		return r.List(ctx, tx)
-	}
-	placeholders := make([]string, len(statuses))
-	args := make([]any, len(statuses))
-	for i, s := range statuses {
-		placeholders[i] = "?"
-		args[i] = s
-	}
-	query := fmt.Sprintf(`
-		SELECT id, name, parent, workspace, prompts, status, command, version, created_at, updated_at
-		FROM tasks WHERE status IN (%s) ORDER BY created_at DESC
-	`, strings.Join(placeholders, ","))
-	rows, err := r.exec(tx).QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	return r.scanTasks(rows)
-}
 
 func (r *TaskRepository) ListChildren(ctx context.Context, tx *sql.Tx, parentID int64) ([]*model.Task, error) {
 	rows, err := r.exec(tx).QueryContext(ctx, `

--- a/proto/xagent/v1/xagent.proto
+++ b/proto/xagent/v1/xagent.proto
@@ -60,8 +60,7 @@ message McpServer {
 }
 
 message ListTasksRequest {
-  repeated string statuses = 1;
-  bool has_command = 2;  // If true, only return tasks with non-empty command
+  bool has_command = 1;  // If true, only return tasks with non-empty command
 }
 
 message ListTasksResponse {


### PR DESCRIPTION
## Summary
- Remove unused `ListByStatuses` method from `TaskRepository`
- Remove `statuses` field from `ListTasksRequest` proto
- Remove `--status` flag from CLI `task list` command

The status filtering was only used by the CLI `--status` flag, which had no tests and wasn't actively used by the Web UI or runner. This simplifies the API by removing the dead code.

## Test plan
- [x] Verified build succeeds
- [x] Verified tests pass
- [x] Verified proto regeneration