### PR TITLE
Add sleep option to DummyAgent

### DIFF
--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	Claude     *ClaudeOptions       `json:"claude,omitempty"`
 	Copilot    *CopilotOptions      `json:"copilot,omitempty"`
 	Cursor     *CursorOptions       `json:"cursor,omitempty"`
+	Dummy      *DummyOptions        `json:"dummy,omitempty"`
 
 	// Agent-managed state
 	Setup   bool `json:"setup,omitempty"`

--- a/internal/agent/dummy.go
+++ b/internal/agent/dummy.go
@@ -3,16 +3,37 @@ package agent
 import (
 	"context"
 	"log/slog"
+	"time"
 )
 
 // DummyAgent is a no-op agent implementation for testing.
 type DummyAgent struct {
-	log *slog.Logger
+	log     *slog.Logger
+	options *DummyOptions
 }
 
-// Prompt does nothing and returns nil.
+// Prompt handles the prompt based on the configured options.
+// If Sleep is set to -1, it sleeps forever (until context cancellation).
+// If Sleep is set to a positive value, it sleeps for that many seconds.
+// Otherwise, it does nothing and returns nil.
 func (a *DummyAgent) Prompt(ctx context.Context, prompt string, resume bool) error {
 	a.log.Info("dummy agent received prompt", "text", prompt, "resume", resume)
+
+	if a.options != nil && a.options.Sleep != 0 {
+		if a.options.Sleep == -1 {
+			a.log.Info("dummy agent sleeping forever")
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		duration := time.Duration(a.options.Sleep) * time.Second
+		a.log.Info("dummy agent sleeping", "duration", duration)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(duration):
+		}
+	}
+
 	return nil
 }
 

--- a/internal/agent/interface.go
+++ b/internal/agent/interface.go
@@ -49,6 +49,7 @@ type Options struct {
 	Claude     *ClaudeOptions
 	Copilot    *CopilotOptions
 	Cursor     *CursorOptions
+	Dummy      *DummyOptions
 }
 
 // ClaudeOptions contains Claude-specific agent options.
@@ -64,6 +65,12 @@ type CopilotOptions struct {
 // CursorOptions contains Cursor-specific agent options.
 type CursorOptions struct {
 	Model string
+}
+
+// DummyOptions contains Dummy-specific agent options.
+type DummyOptions struct {
+	// Sleep duration in seconds. If -1, sleeps forever.
+	Sleep int
 }
 
 // NewAgent creates an Agent based on the type specified in options.
@@ -94,7 +101,7 @@ func NewAgent(opts Options) (Agent, error) {
 			options:    opts.Cursor,
 		}, nil
 	case TypeDummy:
-		return &DummyAgent{log: log}, nil
+		return &DummyAgent{log: log, options: opts.Dummy}, nil
 	default:
 		return nil, fmt.Errorf("unknown agent type: %s", opts.Type)
 	}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -85,6 +85,7 @@ var RunCommand = &cli.Command{
 			Claude:     cfg.Claude,
 			Copilot:    cfg.Copilot,
 			Cursor:     cfg.Cursor,
+			Dummy:      cfg.Dummy,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create agent: %w", err)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -417,6 +417,11 @@ func (r *Runner) copyConfig(ctx context.Context, containerID string, task *model
 			Model: ws.Agent.Cursor.Model,
 		}
 	}
+	if ws.Agent.Dummy != nil {
+		cfg.Dummy = &agent.DummyOptions{
+			Sleep: ws.Agent.Dummy.Sleep,
+		}
+	}
 
 	// Inject xagent MCP server for link creation
 	cfg.McpServers["xagent"] = agent.McpServer{

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -41,6 +41,7 @@ type Agent struct {
 	Claude     *ClaudeConfig              `yaml:"claude,omitempty"`
 	Copilot    *CopilotConfig             `yaml:"copilot,omitempty"`
 	Cursor     *CursorConfig              `yaml:"cursor,omitempty"`
+	Dummy      *DummyConfig               `yaml:"dummy,omitempty"`
 }
 
 // ClaudeConfig contains Claude-specific agent configuration.
@@ -56,6 +57,12 @@ type CopilotConfig struct {
 // CursorConfig contains Cursor-specific agent configuration.
 type CursorConfig struct {
 	Model string `yaml:"model"`
+}
+
+// DummyConfig contains Dummy-specific agent configuration.
+type DummyConfig struct {
+	// Sleep duration in seconds. If -1, sleeps forever.
+	Sleep int `yaml:"sleep"`
 }
 
 func (w *Workspace) Validate() error {


### PR DESCRIPTION
## Summary
- Add `Sleep` option to `DummyOptions` that controls how long the DummyAgent sleeps
- When `Sleep` is `-1`, the agent sleeps forever (until context cancellation)
- When `Sleep` is a positive number, the agent sleeps for that many seconds
- Wire up the option through workspace config for YAML configuration

## Example Usage
```yaml
workspaces:
  test:
    agent:
      type: dummy
      dummy:
        sleep: -1  # Sleep forever
```

## Test plan
- [ ] Configure a workspace with dummy agent and `sleep: 5`
- [ ] Verify agent sleeps for 5 seconds before completing
- [ ] Configure with `sleep: -1`
- [ ] Verify agent sleeps until killed/cancelled