### PR TITLE
Add frontend proto generation to mise generate task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -20,6 +20,7 @@ run = [
 description = "Generate code from proto files"
 run = [
 	"go tool buf generate",
+	"cd webui && pnpm install --frozen-lockfile && pnpm run generate",
 	"go generate ./..."
 ]
 


### PR DESCRIPTION
## Summary

- Updates the `mise run generate` task to also run the frontend protobuf code generation
- Runs `pnpm install --frozen-lockfile && pnpm run generate` in the webui directory
- Ensures both backend (`go tool buf generate`) and frontend proto code are generated together in one command

## Test Plan

- [x] Verified `mise run generate` completes successfully
- [x] Verified frontend proto files are generated in webui directory