### PR TITLE
Display task command badge in web UI

### DIFF
--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -59,6 +59,22 @@ function StatusBadge({ status }: { status: string }) {
   )
 }
 
+const commandStyles: Record<string, string> = {
+  restart: 'bg-pink-100 text-pink-800 border-pink-200',
+  stop: 'bg-orange-100 text-orange-800 border-orange-200',
+}
+
+function CommandBadge({ command }: { command: string }) {
+  return (
+    <Badge
+      variant="outline"
+      className={commandStyles[command] ?? 'bg-gray-100 text-gray-600'}
+    >
+      {command}
+    </Badge>
+  )
+}
+
 
 function TaskDetail() {
   const { id } = Route.useParams()
@@ -209,8 +225,9 @@ function TaskDetail() {
 
         <div>
           <h2 className="text-sm font-medium text-muted-foreground">Status</h2>
-          <p className="mt-1">
+          <p className="mt-1 flex items-center gap-2">
             <StatusBadge status={task.status} />
+            {task.command && <CommandBadge command={task.command} />}
           </p>
         </div>
 

--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -132,7 +132,10 @@ function TaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) {
       </TableCell>
       <TableCell>{task.workspace}</TableCell>
       <TableCell>
-        <StatusBadge status={task.status} />
+        <span className="flex items-center gap-2">
+          <StatusBadge status={task.status} />
+          {task.command && <CommandBadge command={task.command} />}
+        </span>
       </TableCell>
       <TableCell className="text-muted-foreground">
         {task.createdAt ? <RelativeTime date={timestampDate(task.createdAt)} /> : '-'}
@@ -171,6 +174,22 @@ function StatusBadge({ status }: { status: string }) {
       className={statusStyles[status] ?? 'bg-gray-100 text-gray-600'}
     >
       {status}
+    </Badge>
+  )
+}
+
+const commandStyles: Record<string, string> = {
+  restart: 'bg-pink-100 text-pink-800 border-pink-200',
+  stop: 'bg-orange-100 text-orange-800 border-orange-200',
+}
+
+function CommandBadge({ command }: { command: string }) {
+  return (
+    <Badge
+      variant="outline"
+      className={commandStyles[command] ?? 'bg-gray-100 text-gray-600'}
+    >
+      {command}
     </Badge>
   )
 }


### PR DESCRIPTION
## Summary
- Show the task command (restart/stop) as a badge next to the status in both the task list and task detail pages
- Uses distinct colors (pink for restart, orange for stop) to visually differentiate pending commands from the task status
- Command badge only appears when a command is pending on the task

## Test plan
- [ ] Navigate to task list and verify command badge appears next to status for tasks with pending commands
- [ ] Navigate to task detail page and verify command badge appears next to status
- [ ] Verify restart command shows pink badge
- [ ] Verify stop command shows orange badge
- [ ] Verify no command badge appears when task has no pending command