### PR TITLE
Exclude archived tasks from ListWithCommand

### DIFF
--- a/internal/store/task.go
+++ b/internal/store/task.go
@@ -91,7 +91,7 @@ func (r *TaskRepository) ListChildren(ctx context.Context, tx *sql.Tx, parentID 
 func (r *TaskRepository) ListWithCommand(ctx context.Context, tx *sql.Tx) ([]*model.Task, error) {
 	rows, err := r.exec(tx).QueryContext(ctx, `
 		SELECT id, name, parent, workspace, prompts, status, command, version, created_at, updated_at
-		FROM tasks WHERE command != '' ORDER BY created_at DESC
+		FROM tasks WHERE command != '' AND status != 'archived' ORDER BY created_at DESC
 	`)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- Add `status != 'archived'` filter to `ListWithCommand` to match the behavior of `List`
- This ensures archived tasks are consistently excluded when listing tasks with commands

## Test plan
- [ ] Verify `ListWithCommand` returns only non-archived tasks with commands
- [ ] Verify existing `List` behavior is unchanged