### PR TITLE
Move --notify flag from runner to server

### DIFF
--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -44,10 +44,6 @@ var RunnerCommand = &cli.Command{
 			Value: 0,
 		},
 		&cli.BoolFlag{
-			Name:  "notify",
-			Usage: "Send system notification when a task finishes",
-		},
-		&cli.BoolFlag{
 			Name:  "autoprune",
 			Usage: "Automatically remove containers for archived tasks",
 			Value: true,
@@ -59,7 +55,6 @@ var RunnerCommand = &cli.Command{
 		pollInterval := cmd.Duration("poll")
 		prebuiltDir := cmd.String("prebuilt")
 		concurrency := cmd.Int("concurrency")
-		notifyFlag := cmd.Bool("notify")
 		autoprune := cmd.Bool("autoprune")
 
 		workspaces, err := workspace.LoadConfig(configPath, nil)
@@ -72,7 +67,6 @@ var RunnerCommand = &cli.Command{
 			PrebuiltDir: prebuiltDir,
 			Workspaces:  workspaces,
 			Concurrency: int(concurrency),
-			Notify:      notifyFlag,
 		})
 		if err != nil {
 			return err

--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -27,10 +27,15 @@ var ServerCommand = &cli.Command{
 			Usage:   "Database file path",
 			Value:   "data/xagent.db",
 		},
+		&cli.BoolFlag{
+			Name:  "notify",
+			Usage: "Send system notification when a task finishes",
+		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		addr := cmd.String("addr")
 		dbPath := cmd.String("db")
+		notifyFlag := cmd.Bool("notify")
 
 		db, err := store.Open(dbPath)
 		if err != nil {
@@ -47,6 +52,7 @@ var ServerCommand = &cli.Command{
 			Logs:   logs,
 			Links:  links,
 			Events: events,
+			Notify: notifyFlag,
 		})
 
 		slog.Info("starting server", "addr", addr, "db", dbPath)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/icholy/xagent/internal/agent"
 	"github.com/icholy/xagent/internal/model"
-	"github.com/icholy/xagent/internal/notify"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/workspace"
 	"github.com/icholy/xagent/internal/xagentclient"
@@ -37,7 +36,6 @@ type Runner struct {
 	prebuiltDir  string
 	workspaces   *workspace.Config
 	concurrency  int
-	notify       bool
 	runningCount atomic.Int32
 }
 
@@ -46,7 +44,6 @@ type Options struct {
 	PrebuiltDir string
 	Workspaces  *workspace.Config
 	Concurrency int
-	Notify      bool
 }
 
 func New(opts Options) (*Runner, error) {
@@ -70,7 +67,6 @@ func New(opts Options) (*Runner, error) {
 		prebuiltDir: opts.PrebuiltDir,
 		workspaces:  opts.Workspaces,
 		concurrency: opts.Concurrency,
-		notify:      opts.Notify,
 	}, nil
 }
 
@@ -86,17 +82,6 @@ func (r *Runner) submit(ctx context.Context, taskID int64, event string, version
 		},
 	})
 	return err
-}
-
-func (r *Runner) taskDisplayName(ctx context.Context, taskID int64) string {
-	resp, err := r.client.GetTask(ctx, &xagentv1.GetTaskRequest{Id: taskID})
-	if err != nil {
-		return fmt.Sprintf("Task %d", taskID)
-	}
-	if resp.Task.Name == "" {
-		return fmt.Sprintf("Task %d", taskID)
-	}
-	return fmt.Sprintf("%q", resp.Task.Name)
 }
 
 func (r *Runner) Poll(ctx context.Context) error {
@@ -489,20 +474,10 @@ func (r *Runner) Monitor(ctx context.Context) error {
 					if err := r.submit(ctx, taskID, "stopped", 0); err != nil {
 						slog.Error("failed to send stopped event", "task", taskID, "error", err)
 					}
-					if r.notify {
-						if err := notify.Send("xagent", fmt.Sprintf("%s completed", r.taskDisplayName(ctx, taskID))); err != nil {
-							slog.Error("failed to send notification", "task", taskID, "error", err)
-						}
-					}
 				} else {
 					slog.Error("container exited with error", "task", taskID, "exitCode", exitCode)
 					if err := r.submit(ctx, taskID, "failed", 0); err != nil {
 						slog.Error("failed to send failed event", "task", taskID, "error", err)
-					}
-					if r.notify {
-						if err := notify.Send("xagent", fmt.Sprintf("%s failed (exit code %s)", r.taskDisplayName(ctx, taskID), exitCode)); err != nil {
-							slog.Error("failed to send notification", "task", taskID, "error", err)
-						}
 					}
 				}
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/icholy/xagent/internal/model"
+	"github.com/icholy/xagent/internal/notify"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/proto/xagent/v1/xagentv1connect"
 	"github.com/icholy/xagent/internal/store"
@@ -26,6 +27,7 @@ type Server struct {
 	logs   *store.LogRepository
 	links  *store.LinkRepository
 	events *store.EventRepository
+	notify bool
 }
 
 type Options struct {
@@ -34,6 +36,7 @@ type Options struct {
 	Logs   *store.LogRepository
 	Links  *store.LinkRepository
 	Events *store.EventRepository
+	Notify bool
 }
 
 func New(opts Options) *Server {
@@ -47,6 +50,7 @@ func New(opts Options) *Server {
 		logs:   opts.Logs,
 		links:  opts.Links,
 		events: opts.Events,
+		notify: opts.Notify,
 	}
 }
 
@@ -503,12 +507,15 @@ func (s *Server) ProcessEvent(ctx context.Context, req *xagentv1.ProcessEventReq
 func (s *Server) SubmitRunnerEvents(ctx context.Context, req *xagentv1.SubmitRunnerEventsRequest) (*xagentv1.SubmitRunnerEventsResponse, error) {
 	for _, pbEvent := range req.Events {
 		event := model.RunnerEventFromProto(pbEvent)
+		var task *model.Task
+		var applied bool
 		err := s.tasks.WithTx(ctx, nil, func(tx *sql.Tx) error {
-			task, err := s.tasks.Get(ctx, tx, event.TaskID)
+			var err error
+			task, err = s.tasks.Get(ctx, tx, event.TaskID)
 			if err != nil {
 				return err
 			}
-			applied := task.ApplyRunnerEvent(&event)
+			applied = task.ApplyRunnerEvent(&event)
 			s.log.Info("runner event recieved",
 				"task_id", event.TaskID,
 				"event", event.Event,
@@ -531,6 +538,9 @@ func (s *Server) SubmitRunnerEvents(ctx context.Context, req *xagentv1.SubmitRun
 		})
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		if s.notify && applied {
+			s.sendNotification(task, event.Event)
 		}
 	}
 	return &xagentv1.SubmitRunnerEventsResponse{}, nil
@@ -558,5 +568,26 @@ func (s *Server) toRunnerEventLog(e model.RunnerEvent) (model.Log, bool) {
 		}, true
 	default:
 		return model.Log{}, false
+	}
+}
+
+func (s *Server) sendNotification(task *model.Task, event model.RunnerEventType) {
+	displayName := fmt.Sprintf("Task %d", task.ID)
+	if task.Name != "" {
+		displayName = fmt.Sprintf("%q", task.Name)
+	}
+
+	var message string
+	switch event {
+	case model.RunnerEventStopped:
+		message = fmt.Sprintf("%s completed", displayName)
+	case model.RunnerEventFailed:
+		message = fmt.Sprintf("%s failed", displayName)
+	default:
+		return
+	}
+
+	if err := notify.Send("xagent", message); err != nil {
+		s.log.Error("failed to send notification", "task", task.ID, "error", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Move the `--notify` CLI flag from the `runner` command to the `server` command
- System notifications for task completion/failure are now sent from the `SubmitRunnerEvents` handler instead of the runner's `Monitor` function
- Remove notification-related code from the runner (including the `taskDisplayName` helper and notify import)

## Benefits

- Server is the central point where task state changes are processed, making it the natural place for notifications
- Notifications work regardless of which runner processed the task
- Simpler runner code without notification dependencies

## Test plan

- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [ ] Manual testing: Run server with `--notify` flag and verify notifications appear when tasks complete/fail