### PR TITLE
Fix spurious notification when task is restarted

### DIFF
--- a/internal/model/task.go
+++ b/internal/model/task.go
@@ -216,7 +216,16 @@ func (t *Task) applyRunnerEventStopped() bool {
 
 func (t *Task) applyRunnerEventFailed() bool {
 	switch t.Status {
-	case TaskStatusPending, TaskStatusRestarting, TaskStatusRunning, TaskStatusCancelling:
+	case TaskStatusPending, TaskStatusRunning, TaskStatusCancelling:
+		t.Status = TaskStatusFailed
+		t.Command = ""
+		return true
+	case TaskStatusRestarting:
+		// Don't mark as failed if this is an intentional restart
+		// The container was killed by the runner as part of the restart process
+		if t.Command == TaskCommandRestart {
+			return false
+		}
 		t.Status = TaskStatusFailed
 		t.Command = ""
 		return true

--- a/internal/model/task_test.go
+++ b/internal/model/task_test.go
@@ -189,10 +189,20 @@ func TestTask_ApplyRunnerEvent(t *testing.T) {
 			changed: true,
 		},
 		{
-			name: "failed: restarting -> failed",
+			name: "failed: restarting with restart command returns false (intentional restart)",
 			before: Task{
 				Status:  TaskStatusRestarting,
 				Command: TaskCommandRestart,
+			},
+			event: RunnerEvent{
+				Event: RunnerEventFailed,
+			},
+			changed: false,
+		},
+		{
+			name: "failed: restarting without command -> failed",
+			before: Task{
+				Status: TaskStatusRestarting,
 			},
 			after: Task{
 				Status: TaskStatusFailed,


### PR DESCRIPTION
## Summary

- Fix false "task failed" notification when a task is intentionally restarted
- When the runner kills a container for restart, it exits with non-zero code (signal), triggering a "failed" event
- The state machine now ignores "failed" events for tasks in "restarting" state with "restart" command set

## Test plan

- [x] Existing task state machine tests updated and passing
- [ ] Manual test: restart a running task and verify no failure notification is sent
- [ ] Manual test: a task that genuinely fails during restart should still show as failed