### PR TITLE
Add SleepContext helper to reduce poll loop boilerplate

### DIFF
--- a/internal/agent/dummy.go
+++ b/internal/agent/dummy.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"time"
+
+	"github.com/icholy/xagent/internal/common"
 )
 
 // DummyAgent is a no-op agent implementation for testing.
@@ -27,10 +29,8 @@ func (a *DummyAgent) Prompt(ctx context.Context, prompt string, resume bool) err
 		}
 		duration := time.Duration(a.options.Sleep) * time.Second
 		a.log.Info("dummy agent sleeping", "duration", duration)
-		select {
-		case <-ctx.Done():
+		if !common.SleepContext(ctx, duration) {
 			return ctx.Err()
-		case <-time.After(duration):
 		}
 	}
 

--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/icholy/xagent/internal/common"
 	"github.com/icholy/xagent/internal/runner"
 	"github.com/icholy/xagent/internal/workspace"
 	"github.com/urfave/cli/v3"
@@ -83,21 +84,18 @@ var RunnerCommand = &cli.Command{
 					break
 				}
 				slog.Error("monitor error, restarting", "error", err)
-				time.Sleep(time.Second)
+				if !common.SleepContext(ctx, time.Second) {
+					break
+				}
 			}
 		}()
 
 		// Start autoprune goroutine if enabled
 		if autoprune {
 			go func() {
-				for {
-					select {
-					case <-ctx.Done():
-						return
-					case <-time.After(pollInterval):
-						if err := r.Prune(ctx); err != nil {
-							slog.Error("failed to prune containers", "error", err)
-						}
+				for common.SleepContext(ctx, pollInterval) {
+					if err := r.Prune(ctx); err != nil {
+						slog.Error("failed to prune containers", "error", err)
 					}
 				}
 			}()
@@ -112,7 +110,9 @@ var RunnerCommand = &cli.Command{
 			if err := r.Poll(ctx); err != nil {
 				slog.Error("failed to poll tasks", "error", err)
 			}
-			time.Sleep(pollInterval)
+			if !common.SleepContext(ctx, pollInterval) {
+				return nil
+			}
 		}
 	},
 }

--- a/internal/common/sleep.go
+++ b/internal/common/sleep.go
@@ -1,0 +1,17 @@
+package common
+
+import (
+	"context"
+	"time"
+)
+
+// SleepContext sleeps for the specified duration or until the context is canceled.
+// Returns true if the sleep completed, false if the context was canceled.
+func SleepContext(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
+	}
+}

--- a/internal/webhook/subscriber.go
+++ b/internal/webhook/subscriber.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/icholy/xagent/internal/common"
 )
 
 // EventHandler processes webhook events.
@@ -52,7 +53,9 @@ func (s *SQSSubscriber) Run(ctx context.Context) error {
 		})
 		if err != nil {
 			slog.Error("failed to receive messages from SQS", "error", err)
-			time.Sleep(s.config.PollInterval)
+			if !common.SleepContext(ctx, s.config.PollInterval) {
+				return ctx.Err()
+			}
 			continue
 		}
 


### PR DESCRIPTION
## Summary

- Adds `common.SleepContext(ctx, duration)` function that sleeps for the specified duration or until the context is canceled
- Returns `true` if the sleep completed normally, `false` if the context was canceled
- Updates poll loops in runner, webhook subscriber, and dummy agent to use this helper

## Test plan

- [x] Build succeeds
- [x] All tests pass