### PR TITLE
Use runner concurrency as errgroup limit

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -92,7 +92,7 @@ func (r *Runner) Poll(ctx context.Context) error {
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(3)
+	g.SetLimit(r.concurrency)
 
 	for _, pbTask := range resp.Tasks {
 		task := model.TaskFromProto(pbTask)


### PR DESCRIPTION
## Summary

- Use the runner's configured concurrency value as the errgroup limit in `Poll()` instead of hardcoding it to 3
- When concurrency is 0 (unlimited), the errgroup will also have no limit

## Changes

Previously `g.SetLimit(3)` was hardcoded. Now it uses `g.SetLimit(r.concurrency)` to match the runner's configured maximum parallel containers.