### PR TITLE
Rename 'Initial Instruction' to 'Instructions' on new task page

### DIFF
--- a/webui/src/routes/tasks.new.tsx
+++ b/webui/src/routes/tasks.new.tsx
@@ -87,7 +87,7 @@ function NewTaskPage() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="instruction">Initial Instruction</Label>
+              <Label htmlFor="instruction">Instructions</Label>
               <Textarea
                 id="instruction"
                 placeholder="Enter the initial instruction for the task..."


### PR DESCRIPTION
## Summary
- Rename the label from "Initial Instruction" to "Instructions" on the new task creation page

## Test plan
- Navigate to the new task page and verify the field label shows "Instructions" instead of "Initial Instruction"