### PR TITLE
Hide events card when task has no events

### DIFF
--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -286,18 +286,16 @@ function TaskDetail() {
       )}
 
       {/* Events */}
-      <div className="rounded-lg border p-6">
-        <h2 className="text-lg font-semibold mb-4">Events</h2>
-        {events.length === 0 ? (
-          <p className="text-muted-foreground">No events linked to this task.</p>
-        ) : (
+      {events.length > 0 && (
+        <div className="rounded-lg border p-6">
+          <h2 className="text-lg font-semibold mb-4">Events</h2>
           <EventsTable
             events={events}
             onUnlink={handleUnlinkEvent}
             isUnlinking={removeEventMutation.isPending}
           />
-        )}
-      </div>
+        </div>
+      )}
 
       {/* Logs */}
       <div className="rounded-lg border p-6">


### PR DESCRIPTION
The events card on the task detail page is now hidden when there are no events, matching the behavior of the Links and Child Tasks sections.

This provides a cleaner UI by not showing empty sections.