### PR TITLE
Make workspace registration non-fatal in runner

### DIFF
--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -83,9 +83,9 @@ var RunnerCommand = &cli.Command{
 
 		slog.Info("runner started", "server", serverAddr, "config", configPath, "poll", pollInterval, "prebuilt", prebuiltDir, "concurrency", concurrency)
 
-		// Register workspaces with the server
+		// Register workspaces with the server (non-fatal if it fails)
 		if err := r.RegisterWorkspaces(ctx); err != nil {
-			return fmt.Errorf("failed to register workspaces: %w", err)
+			slog.Warn("failed to register workspaces", "error", err)
 		}
 
 		// Start container monitor in background


### PR DESCRIPTION
## Summary
- Change workspace registration failure from a fatal error to a warning log
- Runner continues operating even if initial workspace registration fails

## Test plan
- Start runner with server unavailable, verify it logs warning and continues
- Start runner with server available, verify normal operation