### PR TITLE
Skip notification when task has pending command

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -542,7 +542,7 @@ func (s *Server) SubmitRunnerEvents(ctx context.Context, req *xagentv1.SubmitRun
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, err)
 		}
-		if s.notify && applied {
+		if s.notify && applied && task.Command == "" {
 			s.sendNotification(task, event.Event)
 		}
 	}


### PR DESCRIPTION
## Summary
- Don't send notifications when a task has a pending start or restart command
- Fixes confusing "completed" notifications when a task is about to restart

## Problem
When a task stopped but had a pending `start` command (set via the Start action while the task was running), users would receive a "completed" notification even though the task was transitioning back to `pending` status to be restarted by the runner.

## Solution
Add a condition to only send notifications when `task.Command == ""`. This ensures notifications are only sent when the task has truly completed/failed/cancelled with no pending commands waiting to be processed.

## Test plan
- [ ] Start a task, then issue a Start command while it's running. When the task finishes, it should restart without sending a notification
- [ ] Verify normal task completion still sends notifications
- [ ] Verify failed tasks still send notifications