### PR TITLE
Add client-side search filter for tasks

### DIFF
--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -62,7 +62,7 @@ function TasksPage() {
   const allTasks = data?.tasks ?? []
   const search = searchQuery.trim().toLowerCase()
   const tasks = allTasks.filter((task) => {
-    if (!showChildTasks && task.parent !== 0n) {
+    if (!showChildTasks && isChildTask(task)) {
       return false
     }
     if (search && !(task.name || `Unnamed - ${task.id}`).toLowerCase().includes(search)) {
@@ -70,7 +70,7 @@ function TasksPage() {
     }
     return true
   })
-  const hiddenCount = allTasks.filter((task) => task.parent !== 0n).length
+  const hiddenCount = allTasks.filter(isChildTask).length
 
   return (
     <div className="container mx-auto py-8 px-4">


### PR DESCRIPTION
## Summary
- Adds a search input field to the tasks list page header
- Filters tasks by name using case-insensitive matching
- Search filter is applied after the parent/child task filter

## Test plan
- [ ] Navigate to the tasks list page
- [ ] Enter a search term in the search input
- [ ] Verify that only tasks matching the search term are displayed
- [ ] Verify the search is case-insensitive
- [ ] Toggle the "Show child tasks" switch and verify search still works
- [ ] Clear the search input and verify all tasks are displayed again