### PR TITLE
Fix command:start badge color inconsistency

### DIFF
--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -179,6 +179,7 @@ function TaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) {
 const commandStyles: Record<string, string> = {
   restart: 'bg-pink-100 text-pink-800 border-pink-200',
   stop: 'bg-orange-100 text-orange-800 border-orange-200',
+  start: 'bg-green-100 text-green-800 border-green-200',
 }
 
 function CommandBadge({ command }: { command: string }) {


### PR DESCRIPTION
## Summary

- Adds `start` command style to the `CommandBadge` component in the task list page
- The badge was appearing grey in the task list but green in the task detail page
- Now both pages show the green styling consistently for `command:start`

## Test plan

- [x] Create a new task with pending status and start command
- [ ] Verify the command:start badge appears green in the task list page
- [ ] Verify the command:start badge appears green in the task detail page
- [ ] Confirm both pages have consistent styling