### PR TITLE
Refactor StatusBadge and CommandBadge to take Task as input

### DIFF
--- a/webui/src/components/command-badge.tsx
+++ b/webui/src/components/command-badge.tsx
@@ -1,4 +1,5 @@
 import { Badge } from '@/components/ui/badge'
+import type { Task } from '@/gen/xagent/v1/xagent_pb'
 
 const commandStyles: Record<string, string> = {
   restart: 'bg-pink-100 text-pink-800 border-pink-200',
@@ -6,13 +7,16 @@ const commandStyles: Record<string, string> = {
   start: 'bg-green-100 text-green-800 border-green-200',
 }
 
-export function CommandBadge({ command }: { command: string }) {
+export function CommandBadge({ task }: { task: Task }) {
+  if (!task.command) {
+    return null
+  }
   return (
     <Badge
       variant="outline"
-      className={commandStyles[command] ?? 'bg-gray-100 text-gray-600'}
+      className={commandStyles[task.command] ?? 'bg-gray-100 text-gray-600'}
     >
-      command:{command}
+      command:{task.command}
     </Badge>
   )
 }

--- a/webui/src/components/status-badge.tsx
+++ b/webui/src/components/status-badge.tsx
@@ -1,5 +1,6 @@
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
+import type { Task } from '@/gen/xagent/v1/xagent_pb'
 
 const statusStyles: Record<string, string> = {
   pending: 'bg-amber-100 text-amber-800 border-amber-200',
@@ -14,13 +15,13 @@ const statusStyles: Record<string, string> = {
 
 const activeStatuses = new Set(['running', 'restarting', 'cancelling'])
 
-export function StatusBadge({ status }: { status: string }) {
-  const isActive = activeStatuses.has(status)
+export function StatusBadge({ task }: { task: Task }) {
+  const isActive = activeStatuses.has(task.status)
 
   return (
     <Badge
       variant="outline"
-      className={cn(statusStyles[status] ?? 'bg-gray-100 text-gray-600')}
+      className={cn(statusStyles[task.status] ?? 'bg-gray-100 text-gray-600')}
     >
       {isActive && (
         <span className="relative flex h-2 w-2 mr-1">
@@ -28,7 +29,7 @@ export function StatusBadge({ status }: { status: string }) {
           <span className="relative inline-flex rounded-full h-2 w-2 bg-current"></span>
         </span>
       )}
-      {status}
+      {task.status}
     </Badge>
   )
 }

--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -186,8 +186,8 @@ function TaskDetail() {
           )}
           <div className="flex items-center gap-2">
             <span className="text-muted-foreground">Status:</span>
-            <StatusBadge status={task.status} />
-            {task.command && <CommandBadge command={task.command} />}
+            <StatusBadge task={task} />
+            <CommandBadge task={task} />
           </div>
           <div className="flex items-center gap-2">
             <span className="text-muted-foreground">Created:</span>
@@ -365,7 +365,10 @@ function ChildTaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) 
       </TableCell>
       <TableCell>{task.workspace}</TableCell>
       <TableCell>
-        <StatusBadge status={task.status} />
+        <span className="flex items-center gap-2">
+          <StatusBadge task={task} />
+          <CommandBadge task={task} />
+        </span>
       </TableCell>
       <TableCell className="text-muted-foreground">
         {task.createdAt ? <RelativeTime date={timestampDate(task.createdAt)} /> : '-'}

--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -153,8 +153,8 @@ function TaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) {
       <TableCell>{task.workspace}</TableCell>
       <TableCell>
         <span className="flex items-center gap-2">
-          <StatusBadge status={task.status} />
-          {task.command && <CommandBadge command={task.command} />}
+          <StatusBadge task={task} />
+          <CommandBadge task={task} />
         </span>
       </TableCell>
       <TableCell className="text-muted-foreground">


### PR DESCRIPTION
## Summary
- Update `StatusBadge` to accept a `Task` object instead of a `status` string
- Update `CommandBadge` to accept a `Task` object instead of a `command` string
- `CommandBadge` now handles the null check internally, returning `null` when `task.command` is empty

## Test plan
- [ ] Verify task list page displays status and command badges correctly
- [ ] Verify task detail page displays status and command badges correctly
- [ ] Verify child tasks table displays badges correctly