### PR TITLE
Show grey command:start badge when task is running

### DIFF
--- a/webui/src/components/command-badge.tsx
+++ b/webui/src/components/command-badge.tsx
@@ -7,15 +7,20 @@ const commandStyles: Record<string, string> = {
   start: 'bg-green-100 text-green-800 border-green-200',
 }
 
+function getCommandStyle(task: Task): string {
+  // When task is running with start command, show grey instead of green
+  if (task.command === 'start' && task.status === 'running') {
+    return 'bg-gray-100 text-gray-600 border-gray-200'
+  }
+  return commandStyles[task.command!] ?? 'bg-gray-100 text-gray-600'
+}
+
 export function CommandBadge({ task }: { task: Task }) {
   if (!task.command) {
     return null
   }
   return (
-    <Badge
-      variant="outline"
-      className={commandStyles[task.command] ?? 'bg-gray-100 text-gray-600'}
-    >
+    <Badge variant="outline" className={getCommandStyle(task)}>
       command:{task.command}
     </Badge>
   )


### PR DESCRIPTION
## Summary
- Changed the `command:start` badge to display in grey when the task status is `running`
- Pending start commands still show in green, making them visually distinct from running tasks

## Changes
The `CommandBadge` component now checks if `task.command === 'start'` and `task.status === 'running'`, and if so, uses grey styling instead of green.

## Test plan
- [ ] Verify pending tasks with `command:start` show green badge
- [ ] Verify running tasks with `command:start` show grey badge
- [ ] Verify other command badges remain unchanged