### PR TITLE
Use Start() instead of Restart() when processing events

### DIFF
--- a/internal/server/event_test.go
+++ b/internal/server/event_test.go
@@ -380,14 +380,16 @@ func TestProcessEvent(t *testing.T) {
 	assert.Equal(t, len(events2.Events), 1)
 	assert.Equal(t, events2.Events[0].Id, eventResp.Event.Id)
 
-	// Verify both tasks were set to restarting status
+	// Verify both tasks remain running (Start() doesn't interrupt running tasks)
 	getTask1, err := srv.GetTask(ctx, &xagentv1.GetTaskRequest{Id: task1.Task.Id})
 	assert.NilError(t, err)
-	assert.Equal(t, getTask1.Task.Status, "restarting")
+	assert.Equal(t, getTask1.Task.Status, "running")
+	assert.Equal(t, getTask1.Task.Command, "start")
 
 	getTask2, err := srv.GetTask(ctx, &xagentv1.GetTaskRequest{Id: task2.Task.Id})
 	assert.NilError(t, err)
-	assert.Equal(t, getTask2.Task.Status, "restarting")
+	assert.Equal(t, getTask2.Task.Status, "running")
+	assert.Equal(t, getTask2.Task.Command, "start")
 }
 
 func TestProcessEventWithoutURL(t *testing.T) {
@@ -620,7 +622,8 @@ func TestProcessEventSkipsArchivedTasks(t *testing.T) {
 
 	getActiveTask, err := srv.GetTask(ctx, &xagentv1.GetTaskRequest{Id: activeTask.Task.Id})
 	assert.NilError(t, err)
-	assert.Equal(t, getActiveTask.Task.Status, "restarting")
+	assert.Equal(t, getActiveTask.Task.Status, "running")
+	assert.Equal(t, getActiveTask.Task.Command, "start")
 
 	// Verify archived task did NOT receive the event and remains archived
 	events2, err := srv.ListEventsByTask(ctx, &xagentv1.ListEventsByTaskRequest{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -491,14 +491,14 @@ func (s *Server) ProcessEvent(ctx context.Context, req *xagentv1.ProcessEventReq
 			if err != nil {
 				return err
 			}
-			task.Restart()
+			task.Start()
 			if err := s.tasks.Put(ctx, tx, task); err != nil {
 				return err
 			}
 			return tx.Commit()
 		})
 		if err != nil {
-			s.log.Warn("failed to restart task", "task_id", link.TaskID, "error", err)
+			s.log.Warn("failed to start task", "task_id", link.TaskID, "error", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Change `ProcessEvent` to use `task.Start()` instead of `task.Restart()` 
- Events (like `xagent:` comments on PRs) now add a start command without killing running containers
- For running tasks, container continues and will restart after the current execution finishes
- Fixes issue where leaving an `xagent:` comment on a PR resulted in a task restart instead of just adding the start command

## Test plan
- [x] Updated tests in `event_test.go` to verify new behavior
- [x] All tests pass (`go test ./...`)