### PR TITLE
Remove redundant 'restarting' task status

### DIFF
--- a/internal/model/task.go
+++ b/internal/model/task.go
@@ -13,7 +13,6 @@ type TaskStatus string
 const (
 	TaskStatusPending    TaskStatus = "pending"
 	TaskStatusRunning    TaskStatus = "running"
-	TaskStatusRestarting TaskStatus = "restarting"
 	TaskStatusCancelling TaskStatus = "cancelling"
 	TaskStatusCompleted  TaskStatus = "completed"
 	TaskStatusFailed     TaskStatus = "failed"
@@ -178,7 +177,7 @@ func (t *Task) ApplyRunnerEvent(e *RunnerEvent) bool {
 
 func (t *Task) applyRunnerEventStarted() bool {
 	switch t.Status {
-	case TaskStatusPending, TaskStatusRestarting, TaskStatusRunning:
+	case TaskStatusPending, TaskStatusRunning:
 		if t.Command == TaskCommandRestart || t.Command == TaskCommandStart {
 			t.Status = TaskStatusRunning
 			t.Command = ""
@@ -224,7 +223,7 @@ func (t *Task) applyRunnerEventStopped() bool {
 
 func (t *Task) applyRunnerEventFailed() bool {
 	switch t.Status {
-	case TaskStatusPending, TaskStatusRestarting, TaskStatusRunning, TaskStatusCancelling:
+	case TaskStatusPending, TaskStatusRunning, TaskStatusCancelling:
 		t.Status = TaskStatusFailed
 		t.Command = ""
 		return true
@@ -248,11 +247,11 @@ func (t *Task) Archive() bool {
 
 // Cancel transitions the task to cancelling/cancelled status and sets the stop command.
 // Returns true if the transition is valid and was applied.
-// For running or restarting tasks: sets status to cancelling, command to stop, increments version.
+// For running tasks: sets status to cancelling, command to stop, increments version.
 // For pending tasks: sets status to cancelled directly (no runner action needed).
 func (t *Task) Cancel() bool {
 	switch t.Status {
-	case TaskStatusRunning, TaskStatusRestarting:
+	case TaskStatusRunning:
 		t.Status = TaskStatusCancelling
 		t.Command = TaskCommandStop
 		t.Version++
@@ -265,14 +264,14 @@ func (t *Task) Cancel() bool {
 	}
 }
 
-// Restart transitions the task to pending/restarting status and sets the restart command.
+// Restart transitions the task to pending status and sets the restart command.
 // Returns true if the transition is valid and was applied.
-// For running tasks: sets status to restarting, command to restart, increments version.
+// For running tasks: keeps status as running, sets command to restart, increments version.
 // For completed, failed, or cancelled tasks: sets status to pending, command to restart, increments version.
 func (t *Task) Restart() bool {
 	switch t.Status {
 	case TaskStatusRunning:
-		t.Status = TaskStatusRestarting
+		// Keep status as running - the restart command tells the runner to kill and restart
 		t.Command = TaskCommandRestart
 		t.Version++
 		return true

--- a/internal/model/task_test.go
+++ b/internal/model/task_test.go
@@ -61,20 +61,6 @@ func TestTask_ApplyRunnerEvent(t *testing.T) {
 			changed: true,
 		},
 		{
-			name: "started: restarting with restart -> running",
-			before: Task{
-				Status:  TaskStatusRestarting,
-				Command: TaskCommandRestart,
-			},
-			after: Task{
-				Status: TaskStatusRunning,
-			},
-			event: RunnerEvent{
-				Event: RunnerEventStarted,
-			},
-			changed: true,
-		},
-		{
 			name: "started: running with restart -> running (SIGHUP case)",
 			before: Task{
 				Status:  TaskStatusRunning,
@@ -234,20 +220,6 @@ func TestTask_ApplyRunnerEvent(t *testing.T) {
 			changed: true,
 		},
 		{
-			name: "failed: restarting -> failed",
-			before: Task{
-				Status:  TaskStatusRestarting,
-				Command: TaskCommandRestart,
-			},
-			after: Task{
-				Status: TaskStatusFailed,
-			},
-			event: RunnerEvent{
-				Event: RunnerEventFailed,
-			},
-			changed: true,
-		},
-		{
 			name: "failed: running -> failed",
 			before: Task{
 				Status: TaskStatusRunning,
@@ -376,12 +348,6 @@ func TestTask_Archive(t *testing.T) {
 			want:   false,
 		},
 		{
-			name:   "from restarting fails",
-			before: Task{Status: TaskStatusRestarting},
-			after:  Task{Status: TaskStatusRestarting},
-			want:   false,
-		},
-		{
 			name:   "from cancelling fails",
 			before: Task{Status: TaskStatusCancelling},
 			after:  Task{Status: TaskStatusCancelling},
@@ -443,12 +409,6 @@ func TestTask_Cancel(t *testing.T) {
 			want:   false,
 		},
 		{
-			name:   "from restarting succeeds",
-			before: Task{Status: TaskStatusRestarting},
-			after:  Task{Status: TaskStatusCancelling, Command: TaskCommandStop, Version: 1},
-			want:   true,
-		},
-		{
 			name:   "from cancelling fails",
 			before: Task{Status: TaskStatusCancelling},
 			after:  Task{Status: TaskStatusCancelling},
@@ -486,9 +446,9 @@ func TestTask_Restart(t *testing.T) {
 		want   bool
 	}{
 		{
-			name:   "from running succeeds",
+			name:   "from running succeeds without changing status",
 			before: Task{Status: TaskStatusRunning},
-			after:  Task{Status: TaskStatusRestarting, Command: TaskCommandRestart, Version: 1},
+			after:  Task{Status: TaskStatusRunning, Command: TaskCommandRestart, Version: 1},
 			want:   true,
 		},
 		{
@@ -507,12 +467,6 @@ func TestTask_Restart(t *testing.T) {
 			name:   "from pending fails",
 			before: Task{Status: TaskStatusPending},
 			after:  Task{Status: TaskStatusPending},
-			want:   false,
-		},
-		{
-			name:   "from restarting fails",
-			before: Task{Status: TaskStatusRestarting},
-			after:  Task{Status: TaskStatusRestarting},
 			want:   false,
 		},
 		{
@@ -574,12 +528,6 @@ func TestTask_Start(t *testing.T) {
 			name:   "from pending fails",
 			before: Task{Status: TaskStatusPending},
 			after:  Task{Status: TaskStatusPending},
-			want:   false,
-		},
-		{
-			name:   "from restarting fails",
-			before: Task{Status: TaskStatusRestarting},
-			after:  Task{Status: TaskStatusRestarting},
 			want:   false,
 		},
 		{

--- a/internal/server/event_test.go
+++ b/internal/server/event_test.go
@@ -613,7 +613,7 @@ func TestProcessEventSkipsArchivedTasks(t *testing.T) {
 	assert.Equal(t, len(processResp.TaskIds), 1)
 	assert.Equal(t, processResp.TaskIds[0], activeTask.Task.Id)
 
-	// Verify active task received the event and was set to restarting
+	// Verify active task received the event and was set to start
 	events1, err := srv.ListEventsByTask(ctx, &xagentv1.ListEventsByTaskRequest{
 		TaskId: activeTask.Task.Id,
 	})

--- a/webui/src/components/status-badge.tsx
+++ b/webui/src/components/status-badge.tsx
@@ -5,7 +5,6 @@ import type { Task } from '@/gen/xagent/v1/xagent_pb'
 const statusStyles: Record<string, string> = {
   pending: 'bg-amber-100 text-amber-800 border-amber-200',
   running: 'bg-blue-100 text-blue-800 border-blue-200',
-  restarting: 'bg-pink-100 text-pink-800 border-pink-200',
   cancelling: 'bg-orange-100 text-orange-800 border-orange-200',
   completed: 'bg-green-100 text-green-800 border-green-200',
   failed: 'bg-red-100 text-red-800 border-red-200',
@@ -13,7 +12,7 @@ const statusStyles: Record<string, string> = {
   archived: 'bg-gray-100 text-gray-600 border-gray-200',
 }
 
-const activeStatuses = new Set(['running', 'restarting', 'cancelling'])
+const activeStatuses = new Set(['running', 'cancelling'])
 
 export function StatusBadge({ task }: { task: Task }) {
   const isActive = activeStatuses.has(task.status)

--- a/webui/src/lib/task.ts
+++ b/webui/src/lib/task.ts
@@ -12,7 +12,7 @@ export function canArchiveTask(task: TaskLike): boolean {
 }
 
 export function canCancelTask(task: TaskLike): boolean {
-  return task.status === 'pending' || task.status === 'running' || task.status === 'restarting'
+  return task.status === 'pending' || task.status === 'running'
 }
 
 export function canRestartTask(task: TaskLike): boolean {


### PR DESCRIPTION
## Summary
- Remove the redundant `restarting` task status that was set when RestartTask is called on a running task
- Make `Restart()` behave like `Start()` - keep status as `running` but set command to `restart`
- The runner handles the restart command by killing the container and starting a new one

## Rationale
The `restarting` status was redundant because:
- For running tasks, the restart command tells the runner what to do (kill and start)
- The status only served to indicate "this task is in the process of restarting" but functionally behaved identically to `running` with a `restart` command
- Once the new container starts, it transitions to `running` anyway

## Changes
- Remove `TaskStatusRestarting` constant from model
- Update `Restart()` to keep status as `running` for running tasks
- Update `Cancel()` to only handle `running` status (not `restarting`)
- Update `ApplyRunnerEvent` handlers to remove `restarting` references  
- Update webui to remove restarting status styling and logic
- Update tests to reflect new behavior

## Test plan
- [x] All existing tests pass
- [x] Model tests updated to reflect new behavior
- [x] Build succeeds