### PR TITLE
Add date to cdl workspace branch names

### DIFF
--- a/workspaces.yaml
+++ b/workspaces.yaml
@@ -36,7 +36,7 @@ workspaces:
       - git clone --no-hardlinks -b master /repo /home/vscode/cdl
       - git -C /home/vscode/cdl remote set-url origin git@github.com:Compass-Digital-Engineering/core-eng-mono.git
       - git -C /home/vscode/cdl remote set-head origin master
-      - git -C /home/vscode/cdl switch -c task-$XAGENT_TASK_ID
+      - git -C /home/vscode/cdl switch -c task-$XAGENT_TASK_ID-$(date +%Y%m%d)
     container:
       image: containeragent
       working_dir: /home/vscode


### PR DESCRIPTION
## Summary

- Adds a date suffix (YYYYMMDD format) to branch names created for cdl workspace tasks
- Branch names will now be formatted as: `task-{ID}-{YYYYMMDD}` (e.g., `task-123-20260114`)

## Test plan

- [ ] Verify a new cdl workspace task creates a branch with the date suffix