### PR TITLE
Change default port from 8080 to 6464

### DIFF
--- a/.claude/skills/grpc/SKILL.md
+++ b/.claude/skills/grpc/SKILL.md
@@ -106,7 +106,7 @@ connect.CodePermissionDenied // Authorization failure
 import "github.com/icholy/xagent/internal/xagentclient"
 
 // HTTP client
-client := xagentclient.New("http://localhost:8080")
+client := xagentclient.New("http://localhost:6464")
 
 // Unix socket client (used inside containers)
 client := xagentclient.New("unix:///var/run/xagent.sock")
@@ -208,12 +208,12 @@ Connect RPC endpoints are accessible via HTTP POST with JSON:
 
 ```bash
 # List tasks
-curl -X POST http://localhost:8080/xagent.v1.XAgentService/ListTasks \
+curl -X POST http://localhost:6464/xagent.v1.XAgentService/ListTasks \
   -H "Content-Type: application/json" \
   -d '{"statuses": ["pending", "running"]}'
 
 # Get task
-curl -X POST http://localhost:8080/xagent.v1.XAgentService/GetTask \
+curl -X POST http://localhost:6464/xagent.v1.XAgentService/GetTask \
   -H "Content-Type: application/json" \
   -d '{"id": 123}'
 ```

--- a/README.md
+++ b/README.md
@@ -72,16 +72,16 @@ Containers communicate with the C2 server via a Unix socket proxy:
 
 ```bash
 # Start server
-xagent server --addr :8080
+xagent server --addr :6464
 
 # Start runner (separate terminal)
-xagent runner --server http://localhost:8080
+xagent runner --server http://localhost:6464
 
 # Create a task
 xagent task create --workspace myworkspace --prompt "Implement feature X"
 
 # Monitor via Web UI
-open http://localhost:8080
+open http://localhost:6464
 ```
 
 For detailed CLI reference, see [CLAUDE.md](CLAUDE.md).

--- a/diagrams/networking.d2
+++ b/diagrams/networking.d2
@@ -10,7 +10,7 @@ host: Host Machine {
     }
   }
 
-  c2: C2 Server\n(:8080) {
+  c2: C2 Server\n(:6464) {
     style.fill: "#2ecc71"
     style.font-color: "#fff"
   }

--- a/docs/WEBHOOK_SETUP.md
+++ b/docs/WEBHOOK_SETUP.md
@@ -131,7 +131,7 @@ export AWS_REGION="us-east-1"
 xagent subscribe \
   --queue-url "$SQS_QUEUE_URL" \
   --workspace <your-workspace> \
-  --server http://localhost:8080
+  --server http://localhost:6464
 ```
 
 Or using environment variables:
@@ -147,7 +147,7 @@ xagent subscribe -w <your-workspace>
 
 - `--queue-url, -q`: SQS queue URL (or env: `SQS_QUEUE_URL`)
 - `--workspace, -ws`: Workspace for new tasks (required)
-- `--server, -s`: xagent server URL (default: `http://localhost:8080`)
+- `--server, -s`: xagent server URL (default: `http://localhost:6464`)
 - `--max-messages, -m`: Max messages per poll (default: 10)
 - `--wait-time, -w`: Long polling wait time in seconds (default: 20)
 - `--poll-interval`: Interval between polls when queue is empty (default: 5s)

--- a/internal/command/mcp.go
+++ b/internal/command/mcp.go
@@ -24,7 +24,7 @@ var McpCommand = &cli.Command{
 			Name:    "server",
 			Aliases: []string{"s"},
 			Usage:   "C2 server URL",
-			Value:   "http://localhost:8080",
+			Value:   "http://localhost:6464",
 		},
 		&cli.Int64Flag{
 			Name:    "task",

--- a/internal/command/prune.go
+++ b/internal/command/prune.go
@@ -21,7 +21,7 @@ var PruneCommand = &cli.Command{
 			Name:    "server",
 			Aliases: []string{"s"},
 			Usage:   "C2 server URL",
-			Value:   "http://localhost:8080",
+			Value:   "http://localhost:6464",
 		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -22,7 +22,7 @@ var RunCommand = &cli.Command{
 			Name:    "server",
 			Aliases: []string{"s"},
 			Usage:   "C2 server URL",
-			Value:   "http://localhost:8080",
+			Value:   "http://localhost:6464",
 		},
 		&cli.StringFlag{
 			Name:     "task",

--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -21,7 +21,7 @@ var RunnerCommand = &cli.Command{
 			Name:    "server",
 			Aliases: []string{"s"},
 			Usage:   "C2 server URL",
-			Value:   "http://localhost:8080",
+			Value:   "http://localhost:6464",
 		},
 		&cli.StringFlag{
 			Name:    "config",

--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -19,7 +19,7 @@ var ServerCommand = &cli.Command{
 			Name:    "addr",
 			Aliases: []string{"a"},
 			Usage:   "Address to listen on",
-			Value:   ":8080",
+			Value:   ":6464",
 		},
 		&cli.StringFlag{
 			Name:    "db",

--- a/internal/command/subscribe.go
+++ b/internal/command/subscribe.go
@@ -46,7 +46,7 @@ var SubscribeCommand = &cli.Command{
 			Name:    "server",
 			Aliases: []string{"s"},
 			Usage:   "xagent server URL",
-			Value:   "http://localhost:8080",
+			Value:   "http://localhost:6464",
 		},
 		&cli.StringFlag{
 			Name:    "region",

--- a/internal/command/task_create.go
+++ b/internal/command/task_create.go
@@ -19,7 +19,7 @@ var TaskCreateCommand = &cli.Command{
 			Name:    "server",
 			Aliases: []string{"s"},
 			Usage:   "C2 server URL",
-			Value:   "http://localhost:8080",
+			Value:   "http://localhost:6464",
 		},
 		&cli.StringFlag{
 			Name:    "name",

--- a/internal/command/task_delete.go
+++ b/internal/command/task_delete.go
@@ -19,7 +19,7 @@ var TaskDeleteCommand = &cli.Command{
 			Name:    "server",
 			Aliases: []string{"s"},
 			Usage:   "C2 server URL",
-			Value:   "http://localhost:8080",
+			Value:   "http://localhost:6464",
 		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {

--- a/internal/command/task_list.go
+++ b/internal/command/task_list.go
@@ -20,7 +20,7 @@ var TaskListCommand = &cli.Command{
 			Name:    "server",
 			Aliases: []string{"s"},
 			Usage:   "C2 server URL",
-			Value:   "http://localhost:8080",
+			Value:   "http://localhost:6464",
 		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {

--- a/internal/command/task_update.go
+++ b/internal/command/task_update.go
@@ -19,7 +19,7 @@ var TaskUpdateCommand = &cli.Command{
 			Name:    "server",
 			Aliases: []string{"s"},
 			Usage:   "C2 server URL",
-			Value:   "http://localhost:8080",
+			Value:   "http://localhost:6464",
 		},
 		&cli.StringFlag{
 			Name:    "name",

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     proxy: {
       // Proxy Connect RPC requests to the backend server
       "/xagent.v1.XAgentService": {
-        target: "http://localhost:8080",
+        target: "http://localhost:6464",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

- Change the default server port from 8080 to 6464
- Update all CLI commands that connect to the server
- Update documentation and diagrams
- Update Vite dev proxy configuration

## Rationale

Port 8080 is commonly used by:
- HTTP proxies
- Alternative web servers
- Development servers (Spring Boot, Jetty, etc.)
- Many other applications

Port 6464 is:
- Easy to remember (doubled 64s)
- Not commonly used by popular software
- Higher than typical well-known ports
- Reduces conflicts with other development tools

## Changes

- `internal/command/server.go`: `:6464` as default listen address
- All client commands: `http://localhost:6464` as default server URL
- `README.md`: Updated examples
- `docs/WEBHOOK_SETUP.md`: Updated documentation
- `.claude/skills/grpc/SKILL.md`: Updated curl examples
- `webui/vite.config.ts`: Updated dev proxy target
- `diagrams/networking.d2`: Updated diagram source

## Test plan

- [ ] Start server with `xagent server` (should bind to :6464)
- [ ] Start runner with `xagent runner` (should connect to localhost:6464)
- [ ] Access Web UI at http://localhost:6464