### PR TITLE
Add timeout to ContainerKill to prevent runner from hanging

### DIFF
--- a/internal/dockerx/container_test.go
+++ b/internal/dockerx/container_test.go
@@ -124,3 +124,4 @@ func TestContainerKill_OtherError(t *testing.T) {
 		t.Error("expected non-ErrNotRunning error")
 	}
 }
+

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/docker/docker/api/types/container"
@@ -313,13 +314,28 @@ func (r *Runner) kill(ctx context.Context, task *model.Task) error {
 		return nil
 	}
 	r.log.Info("killing container", "task", task.ID)
-	if err := dockerx.ContainerKill(ctx, r.docker, c.ID, "SIGTERM"); err != nil {
-		if errors.Is(err, dockerx.ErrNotRunning) {
-			return nil
-		}
-		return err
+
+	// Try SIGTERM first with a timeout
+	killCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	err = dockerx.ContainerKill(killCtx, r.docker, c.ID, "SIGTERM")
+	if err == nil || errors.Is(err, dockerx.ErrNotRunning) {
+		return nil
 	}
-	return nil
+
+	// If SIGTERM timed out, send SIGKILL
+	if errors.Is(err, context.DeadlineExceeded) {
+		r.log.Warn("SIGTERM timed out, sending SIGKILL", "task", task.ID)
+		if err := dockerx.ContainerKill(ctx, r.docker, c.ID, "SIGKILL"); err != nil {
+			if errors.Is(err, dockerx.ErrNotRunning) {
+				return nil
+			}
+			return err
+		}
+		return nil
+	}
+
+	return err
 }
 
 func (r *Runner) create(ctx context.Context, task *model.Task) (string, error) {


### PR DESCRIPTION
## Summary

When killing a container, the runner now uses a 30-second timeout for SIGTERM. If the container doesn't stop within that time, it sends SIGKILL as a fallback to force termination.

This was reported when a user cancelled a task and the runner showed "killing container" but then stopped processing other tasks because the container wasn't responding to SIGTERM.

## Changes

- Added timeout logic to `Runner.kill()` in `internal/runner/runner.go`
- After SIGTERM times out (30 seconds), SIGKILL is sent to force container termination
- Reverted the timeout from `dockerx.ContainerKill` (moved the logic to the appropriate layer)

## Test plan

- [x] All existing tests pass
- [ ] Manual test: cancel a container that ignores SIGTERM - should be force killed after 30s