### PR TITLE
Log tool result errors in Claude agent

### DIFF
--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -97,10 +97,13 @@ func (a *ClaudeAgent) handleStreamEvent(data []byte) bool {
 		Type    string `json:"type"`
 		Message struct {
 			Content []struct {
-				Type  string `json:"type"`
-				Text  string `json:"text"`
-				Name  string `json:"name"`
-				Input any    `json:"input"`
+				Type      string `json:"type"`
+				Text      string `json:"text"`
+				Name      string `json:"name"`
+				Input     any    `json:"input"`
+				ToolUseID string `json:"tool_use_id"`
+				Content   string `json:"content"`
+				IsError   bool   `json:"is_error"`
 			} `json:"content"`
 		} `json:"message"`
 	}
@@ -117,6 +120,16 @@ func (a *ClaudeAgent) handleStreamEvent(data []byte) bool {
 				}
 			case "tool_use":
 				a.log.Info("tool", "name", block.Name)
+			}
+		}
+	case "user":
+		for _, block := range event.Message.Content {
+			if block.Type == "tool_result" {
+				if block.IsError {
+					a.log.Error("tool_result", "tool_use_id", block.ToolUseID, "error", block.Content)
+				} else {
+					a.log.Debug("tool_result", "tool_use_id", block.ToolUseID)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

When an agent gets stuck in a loop calling tools repeatedly, it's difficult to diagnose because only tool names are logged, not the results or errors.

This PR updates the Claude agent to:
- Log tool result errors at ERROR level with the error content
- Log successful tool results at DEBUG level

## Example

Before:
```
2026/01/21 13:05:42 INFO tool name=mcp__xagent__create_link
2026/01/21 13:05:45 INFO tool name=mcp__xagent__create_link
2026/01/21 13:05:49 INFO tool name=mcp__xagent__create_link
```

After:
```
2026/01/21 13:05:42 INFO tool name=mcp__xagent__create_link
2026/01/21 13:05:42 ERROR tool_result tool_use_id=toolu_xxx error="invalid URL format"
2026/01/21 13:05:45 INFO tool name=mcp__xagent__create_link
2026/01/21 13:05:45 ERROR tool_result tool_use_id=toolu_yyy error="invalid URL format"
```

## Test plan

- [ ] Deploy and observe agent logs when tool calls fail
- [ ] Verify error content is visible in logs