### PR TITLE
Change default runner id to hostname

### DIFF
--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -15,6 +15,14 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+func defaultRunnerID() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "default"
+	}
+	return hostname
+}
+
 var RunnerCommand = &cli.Command{
 	Name:  "runner",
 	Usage: "Start the runner (monitors tasks, manages containers)",
@@ -61,7 +69,7 @@ var RunnerCommand = &cli.Command{
 		&cli.StringFlag{
 			Name:  "id",
 			Usage: "Unique identifier for this runner",
-			Value: "default",
+			Value: defaultRunnerID(),
 		},
 		&cli.BoolFlag{
 			Name:  "debug",


### PR DESCRIPTION
## Summary

- Changes the default value of `--id` flag for the runner command from `"default"` to the system hostname
- Uses `os.Hostname()` with a fallback to `"default"` if hostname retrieval fails
- Makes multi-runner setups work out of the box since hostnames are typically unique per machine

## Test plan

- [x] Verified the build succeeds
- [x] Verified `./xagent runner --help` shows the hostname as the default value for `--id`