### PR TITLE
Add ClearWorkspaces RPC and Clear button in workspaces page

### DIFF
--- a/internal/proto/xagent/v1/xagent.pb.go
+++ b/internal/proto/xagent/v1/xagent.pb.go
@@ -3150,6 +3150,78 @@ func (x *ListWorkspacesResponse) GetWorkspaces() []*RegisteredWorkspace {
 	return nil
 }
 
+type ClearWorkspacesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClearWorkspacesRequest) Reset() {
+	*x = ClearWorkspacesRequest{}
+	mi := &file_xagent_v1_xagent_proto_msgTypes[64]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClearWorkspacesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClearWorkspacesRequest) ProtoMessage() {}
+
+func (x *ClearWorkspacesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_xagent_v1_xagent_proto_msgTypes[64]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClearWorkspacesRequest.ProtoReflect.Descriptor instead.
+func (*ClearWorkspacesRequest) Descriptor() ([]byte, []int) {
+	return file_xagent_v1_xagent_proto_rawDescGZIP(), []int{64}
+}
+
+type ClearWorkspacesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClearWorkspacesResponse) Reset() {
+	*x = ClearWorkspacesResponse{}
+	mi := &file_xagent_v1_xagent_proto_msgTypes[65]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClearWorkspacesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClearWorkspacesResponse) ProtoMessage() {}
+
+func (x *ClearWorkspacesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_xagent_v1_xagent_proto_msgTypes[65]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClearWorkspacesResponse.ProtoReflect.Descriptor instead.
+func (*ClearWorkspacesResponse) Descriptor() ([]byte, []int) {
+	return file_xagent_v1_xagent_proto_rawDescGZIP(), []int{65}
+}
+
 var File_xagent_v1_xagent_proto protoreflect.FileDescriptor
 
 const file_xagent_v1_xagent_proto_rawDesc = "" +
@@ -3335,7 +3407,9 @@ const file_xagent_v1_xagent_proto_rawDesc = "" +
 	"\x16ListWorkspacesResponse\x12>\n" +
 	"\n" +
 	"workspaces\x18\x01 \x03(\v2\x1e.xagent.v1.RegisteredWorkspaceR\n" +
-	"workspaces2\xdc\x11\n" +
+	"workspaces\"\x18\n" +
+	"\x16ClearWorkspacesRequest\"\x19\n" +
+	"\x17ClearWorkspacesResponse2\xb6\x12\n" +
 	"\rXAgentService\x12F\n" +
 	"\tListTasks\x12\x1b.xagent.v1.ListTasksRequest\x1a\x1c.xagent.v1.ListTasksResponse\x12X\n" +
 	"\x0fListRunnerTasks\x12!.xagent.v1.ListRunnerTasksRequest\x1a\".xagent.v1.ListRunnerTasksResponse\x12U\n" +
@@ -3371,7 +3445,8 @@ const file_xagent_v1_xagent_proto_rawDesc = "" +
 	"\fProcessEvent\x12\x1e.xagent.v1.ProcessEventRequest\x1a\x1f.xagent.v1.ProcessEventResponse\x12a\n" +
 	"\x12SubmitRunnerEvents\x12$.xagent.v1.SubmitRunnerEventsRequest\x1a%.xagent.v1.SubmitRunnerEventsResponse\x12a\n" +
 	"\x12RegisterWorkspaces\x12$.xagent.v1.RegisterWorkspacesRequest\x1a%.xagent.v1.RegisterWorkspacesResponse\x12U\n" +
-	"\x0eListWorkspaces\x12 .xagent.v1.ListWorkspacesRequest\x1a!.xagent.v1.ListWorkspacesResponseB<Z:github.com/icholy/xagent/internal/proto/xagent/v1;xagentv1b\x06proto3"
+	"\x0eListWorkspaces\x12 .xagent.v1.ListWorkspacesRequest\x1a!.xagent.v1.ListWorkspacesResponse\x12X\n" +
+	"\x0fClearWorkspaces\x12!.xagent.v1.ClearWorkspacesRequest\x1a\".xagent.v1.ClearWorkspacesResponseB<Z:github.com/icholy/xagent/internal/proto/xagent/v1;xagentv1b\x06proto3"
 
 var (
 	file_xagent_v1_xagent_proto_rawDescOnce sync.Once
@@ -3385,7 +3460,7 @@ func file_xagent_v1_xagent_proto_rawDescGZIP() []byte {
 	return file_xagent_v1_xagent_proto_rawDescData
 }
 
-var file_xagent_v1_xagent_proto_msgTypes = make([]protoimpl.MessageInfo, 65)
+var file_xagent_v1_xagent_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
 var file_xagent_v1_xagent_proto_goTypes = []any{
 	(*Instruction)(nil),                // 0: xagent.v1.Instruction
 	(*Task)(nil),                       // 1: xagent.v1.Task
@@ -3451,14 +3526,16 @@ var file_xagent_v1_xagent_proto_goTypes = []any{
 	(*RegisterWorkspacesResponse)(nil), // 61: xagent.v1.RegisterWorkspacesResponse
 	(*ListWorkspacesRequest)(nil),      // 62: xagent.v1.ListWorkspacesRequest
 	(*ListWorkspacesResponse)(nil),     // 63: xagent.v1.ListWorkspacesResponse
-	nil,                                // 64: xagent.v1.McpServer.EnvEntry
-	(*timestamppb.Timestamp)(nil),      // 65: google.protobuf.Timestamp
+	(*ClearWorkspacesRequest)(nil),     // 64: xagent.v1.ClearWorkspacesRequest
+	(*ClearWorkspacesResponse)(nil),    // 65: xagent.v1.ClearWorkspacesResponse
+	nil,                                // 66: xagent.v1.McpServer.EnvEntry
+	(*timestamppb.Timestamp)(nil),      // 67: google.protobuf.Timestamp
 }
 var file_xagent_v1_xagent_proto_depIdxs = []int32{
 	0,  // 0: xagent.v1.Task.instructions:type_name -> xagent.v1.Instruction
-	65, // 1: xagent.v1.Task.created_at:type_name -> google.protobuf.Timestamp
-	65, // 2: xagent.v1.Task.updated_at:type_name -> google.protobuf.Timestamp
-	64, // 3: xagent.v1.McpServer.env:type_name -> xagent.v1.McpServer.EnvEntry
+	67, // 1: xagent.v1.Task.created_at:type_name -> google.protobuf.Timestamp
+	67, // 2: xagent.v1.Task.updated_at:type_name -> google.protobuf.Timestamp
+	66, // 3: xagent.v1.McpServer.env:type_name -> xagent.v1.McpServer.EnvEntry
 	1,  // 4: xagent.v1.ListTasksResponse.tasks:type_name -> xagent.v1.Task
 	1,  // 5: xagent.v1.ListRunnerTasksResponse.tasks:type_name -> xagent.v1.Task
 	1,  // 6: xagent.v1.ListChildTasksResponse.tasks:type_name -> xagent.v1.Task
@@ -3470,20 +3547,20 @@ var file_xagent_v1_xagent_proto_depIdxs = []int32{
 	37, // 12: xagent.v1.GetTaskDetailsResponse.events:type_name -> xagent.v1.Event
 	30, // 13: xagent.v1.GetTaskDetailsResponse.links:type_name -> xagent.v1.TaskLink
 	0,  // 14: xagent.v1.UpdateTaskRequest.add_instructions:type_name -> xagent.v1.Instruction
-	65, // 15: xagent.v1.LogEntry.created_at:type_name -> google.protobuf.Timestamp
+	67, // 15: xagent.v1.LogEntry.created_at:type_name -> google.protobuf.Timestamp
 	25, // 16: xagent.v1.UploadLogsRequest.entries:type_name -> xagent.v1.LogEntry
 	25, // 17: xagent.v1.ListLogsResponse.entries:type_name -> xagent.v1.LogEntry
-	65, // 18: xagent.v1.TaskLink.created_at:type_name -> google.protobuf.Timestamp
+	67, // 18: xagent.v1.TaskLink.created_at:type_name -> google.protobuf.Timestamp
 	30, // 19: xagent.v1.CreateLinkResponse.link:type_name -> xagent.v1.TaskLink
 	30, // 20: xagent.v1.ListLinksResponse.links:type_name -> xagent.v1.TaskLink
 	30, // 21: xagent.v1.FindLinksByURLResponse.links:type_name -> xagent.v1.TaskLink
-	65, // 22: xagent.v1.Event.created_at:type_name -> google.protobuf.Timestamp
+	67, // 22: xagent.v1.Event.created_at:type_name -> google.protobuf.Timestamp
 	37, // 23: xagent.v1.ListEventsResponse.events:type_name -> xagent.v1.Event
 	37, // 24: xagent.v1.CreateEventResponse.event:type_name -> xagent.v1.Event
 	37, // 25: xagent.v1.GetEventResponse.event:type_name -> xagent.v1.Event
 	37, // 26: xagent.v1.ListEventsByTaskResponse.events:type_name -> xagent.v1.Event
 	56, // 27: xagent.v1.SubmitRunnerEventsRequest.events:type_name -> xagent.v1.RunnerEvent
-	65, // 28: xagent.v1.RegisteredWorkspace.updated_at:type_name -> google.protobuf.Timestamp
+	67, // 28: xagent.v1.RegisteredWorkspace.updated_at:type_name -> google.protobuf.Timestamp
 	59, // 29: xagent.v1.RegisterWorkspacesRequest.workspaces:type_name -> xagent.v1.RegisteredWorkspace
 	59, // 30: xagent.v1.ListWorkspacesResponse.workspaces:type_name -> xagent.v1.RegisteredWorkspace
 	3,  // 31: xagent.v1.XAgentService.ListTasks:input_type -> xagent.v1.ListTasksRequest
@@ -3514,36 +3591,38 @@ var file_xagent_v1_xagent_proto_depIdxs = []int32{
 	57, // 56: xagent.v1.XAgentService.SubmitRunnerEvents:input_type -> xagent.v1.SubmitRunnerEventsRequest
 	60, // 57: xagent.v1.XAgentService.RegisterWorkspaces:input_type -> xagent.v1.RegisterWorkspacesRequest
 	62, // 58: xagent.v1.XAgentService.ListWorkspaces:input_type -> xagent.v1.ListWorkspacesRequest
-	4,  // 59: xagent.v1.XAgentService.ListTasks:output_type -> xagent.v1.ListTasksResponse
-	6,  // 60: xagent.v1.XAgentService.ListRunnerTasks:output_type -> xagent.v1.ListRunnerTasksResponse
-	8,  // 61: xagent.v1.XAgentService.ListChildTasks:output_type -> xagent.v1.ListChildTasksResponse
-	10, // 62: xagent.v1.XAgentService.CreateTask:output_type -> xagent.v1.CreateTaskResponse
-	12, // 63: xagent.v1.XAgentService.GetTask:output_type -> xagent.v1.GetTaskResponse
-	14, // 64: xagent.v1.XAgentService.GetTaskDetails:output_type -> xagent.v1.GetTaskDetailsResponse
-	16, // 65: xagent.v1.XAgentService.UpdateTask:output_type -> xagent.v1.UpdateTaskResponse
-	18, // 66: xagent.v1.XAgentService.DeleteTask:output_type -> xagent.v1.DeleteTaskResponse
-	20, // 67: xagent.v1.XAgentService.ArchiveTask:output_type -> xagent.v1.ArchiveTaskResponse
-	22, // 68: xagent.v1.XAgentService.CancelTask:output_type -> xagent.v1.CancelTaskResponse
-	24, // 69: xagent.v1.XAgentService.RestartTask:output_type -> xagent.v1.RestartTaskResponse
-	27, // 70: xagent.v1.XAgentService.UploadLogs:output_type -> xagent.v1.UploadLogsResponse
-	29, // 71: xagent.v1.XAgentService.ListLogs:output_type -> xagent.v1.ListLogsResponse
-	32, // 72: xagent.v1.XAgentService.CreateLink:output_type -> xagent.v1.CreateLinkResponse
-	34, // 73: xagent.v1.XAgentService.ListLinks:output_type -> xagent.v1.ListLinksResponse
-	36, // 74: xagent.v1.XAgentService.FindLinksByURL:output_type -> xagent.v1.FindLinksByURLResponse
-	39, // 75: xagent.v1.XAgentService.ListEvents:output_type -> xagent.v1.ListEventsResponse
-	41, // 76: xagent.v1.XAgentService.CreateEvent:output_type -> xagent.v1.CreateEventResponse
-	43, // 77: xagent.v1.XAgentService.GetEvent:output_type -> xagent.v1.GetEventResponse
-	45, // 78: xagent.v1.XAgentService.DeleteEvent:output_type -> xagent.v1.DeleteEventResponse
-	47, // 79: xagent.v1.XAgentService.AddEventTask:output_type -> xagent.v1.AddEventTaskResponse
-	49, // 80: xagent.v1.XAgentService.RemoveEventTask:output_type -> xagent.v1.RemoveEventTaskResponse
-	51, // 81: xagent.v1.XAgentService.ListEventTasks:output_type -> xagent.v1.ListEventTasksResponse
-	53, // 82: xagent.v1.XAgentService.ListEventsByTask:output_type -> xagent.v1.ListEventsByTaskResponse
-	55, // 83: xagent.v1.XAgentService.ProcessEvent:output_type -> xagent.v1.ProcessEventResponse
-	58, // 84: xagent.v1.XAgentService.SubmitRunnerEvents:output_type -> xagent.v1.SubmitRunnerEventsResponse
-	61, // 85: xagent.v1.XAgentService.RegisterWorkspaces:output_type -> xagent.v1.RegisterWorkspacesResponse
-	63, // 86: xagent.v1.XAgentService.ListWorkspaces:output_type -> xagent.v1.ListWorkspacesResponse
-	59, // [59:87] is the sub-list for method output_type
-	31, // [31:59] is the sub-list for method input_type
+	64, // 59: xagent.v1.XAgentService.ClearWorkspaces:input_type -> xagent.v1.ClearWorkspacesRequest
+	4,  // 60: xagent.v1.XAgentService.ListTasks:output_type -> xagent.v1.ListTasksResponse
+	6,  // 61: xagent.v1.XAgentService.ListRunnerTasks:output_type -> xagent.v1.ListRunnerTasksResponse
+	8,  // 62: xagent.v1.XAgentService.ListChildTasks:output_type -> xagent.v1.ListChildTasksResponse
+	10, // 63: xagent.v1.XAgentService.CreateTask:output_type -> xagent.v1.CreateTaskResponse
+	12, // 64: xagent.v1.XAgentService.GetTask:output_type -> xagent.v1.GetTaskResponse
+	14, // 65: xagent.v1.XAgentService.GetTaskDetails:output_type -> xagent.v1.GetTaskDetailsResponse
+	16, // 66: xagent.v1.XAgentService.UpdateTask:output_type -> xagent.v1.UpdateTaskResponse
+	18, // 67: xagent.v1.XAgentService.DeleteTask:output_type -> xagent.v1.DeleteTaskResponse
+	20, // 68: xagent.v1.XAgentService.ArchiveTask:output_type -> xagent.v1.ArchiveTaskResponse
+	22, // 69: xagent.v1.XAgentService.CancelTask:output_type -> xagent.v1.CancelTaskResponse
+	24, // 70: xagent.v1.XAgentService.RestartTask:output_type -> xagent.v1.RestartTaskResponse
+	27, // 71: xagent.v1.XAgentService.UploadLogs:output_type -> xagent.v1.UploadLogsResponse
+	29, // 72: xagent.v1.XAgentService.ListLogs:output_type -> xagent.v1.ListLogsResponse
+	32, // 73: xagent.v1.XAgentService.CreateLink:output_type -> xagent.v1.CreateLinkResponse
+	34, // 74: xagent.v1.XAgentService.ListLinks:output_type -> xagent.v1.ListLinksResponse
+	36, // 75: xagent.v1.XAgentService.FindLinksByURL:output_type -> xagent.v1.FindLinksByURLResponse
+	39, // 76: xagent.v1.XAgentService.ListEvents:output_type -> xagent.v1.ListEventsResponse
+	41, // 77: xagent.v1.XAgentService.CreateEvent:output_type -> xagent.v1.CreateEventResponse
+	43, // 78: xagent.v1.XAgentService.GetEvent:output_type -> xagent.v1.GetEventResponse
+	45, // 79: xagent.v1.XAgentService.DeleteEvent:output_type -> xagent.v1.DeleteEventResponse
+	47, // 80: xagent.v1.XAgentService.AddEventTask:output_type -> xagent.v1.AddEventTaskResponse
+	49, // 81: xagent.v1.XAgentService.RemoveEventTask:output_type -> xagent.v1.RemoveEventTaskResponse
+	51, // 82: xagent.v1.XAgentService.ListEventTasks:output_type -> xagent.v1.ListEventTasksResponse
+	53, // 83: xagent.v1.XAgentService.ListEventsByTask:output_type -> xagent.v1.ListEventsByTaskResponse
+	55, // 84: xagent.v1.XAgentService.ProcessEvent:output_type -> xagent.v1.ProcessEventResponse
+	58, // 85: xagent.v1.XAgentService.SubmitRunnerEvents:output_type -> xagent.v1.SubmitRunnerEventsResponse
+	61, // 86: xagent.v1.XAgentService.RegisterWorkspaces:output_type -> xagent.v1.RegisterWorkspacesResponse
+	63, // 87: xagent.v1.XAgentService.ListWorkspaces:output_type -> xagent.v1.ListWorkspacesResponse
+	65, // 88: xagent.v1.XAgentService.ClearWorkspaces:output_type -> xagent.v1.ClearWorkspacesResponse
+	60, // [60:89] is the sub-list for method output_type
+	31, // [31:60] is the sub-list for method input_type
 	31, // [31:31] is the sub-list for extension type_name
 	31, // [31:31] is the sub-list for extension extendee
 	0,  // [0:31] is the sub-list for field type_name
@@ -3560,7 +3639,7 @@ func file_xagent_v1_xagent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_xagent_v1_xagent_proto_rawDesc), len(file_xagent_v1_xagent_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   65,
+			NumMessages:   67,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/proto/xagent/v1/xagentv1connect/xagent.connect.go
+++ b/internal/proto/xagent/v1/xagentv1connect/xagent.connect.go
@@ -112,6 +112,9 @@ const (
 	// XAgentServiceListWorkspacesProcedure is the fully-qualified name of the XAgentService's
 	// ListWorkspaces RPC.
 	XAgentServiceListWorkspacesProcedure = "/xagent.v1.XAgentService/ListWorkspaces"
+	// XAgentServiceClearWorkspacesProcedure is the fully-qualified name of the XAgentService's
+	// ClearWorkspaces RPC.
+	XAgentServiceClearWorkspacesProcedure = "/xagent.v1.XAgentService/ClearWorkspaces"
 )
 
 // XAgentServiceClient is a client for the xagent.v1.XAgentService service.
@@ -144,6 +147,7 @@ type XAgentServiceClient interface {
 	SubmitRunnerEvents(context.Context, *v1.SubmitRunnerEventsRequest) (*v1.SubmitRunnerEventsResponse, error)
 	RegisterWorkspaces(context.Context, *v1.RegisterWorkspacesRequest) (*v1.RegisterWorkspacesResponse, error)
 	ListWorkspaces(context.Context, *v1.ListWorkspacesRequest) (*v1.ListWorkspacesResponse, error)
+	ClearWorkspaces(context.Context, *v1.ClearWorkspacesRequest) (*v1.ClearWorkspacesResponse, error)
 }
 
 // NewXAgentServiceClient constructs a client for the xagent.v1.XAgentService service. By default,
@@ -325,6 +329,12 @@ func NewXAgentServiceClient(httpClient connect.HTTPClient, baseURL string, opts 
 			connect.WithSchema(xAgentServiceMethods.ByName("ListWorkspaces")),
 			connect.WithClientOptions(opts...),
 		),
+		clearWorkspaces: connect.NewClient[v1.ClearWorkspacesRequest, v1.ClearWorkspacesResponse](
+			httpClient,
+			baseURL+XAgentServiceClearWorkspacesProcedure,
+			connect.WithSchema(xAgentServiceMethods.ByName("ClearWorkspaces")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -358,6 +368,7 @@ type xAgentServiceClient struct {
 	submitRunnerEvents *connect.Client[v1.SubmitRunnerEventsRequest, v1.SubmitRunnerEventsResponse]
 	registerWorkspaces *connect.Client[v1.RegisterWorkspacesRequest, v1.RegisterWorkspacesResponse]
 	listWorkspaces     *connect.Client[v1.ListWorkspacesRequest, v1.ListWorkspacesResponse]
+	clearWorkspaces    *connect.Client[v1.ClearWorkspacesRequest, v1.ClearWorkspacesResponse]
 }
 
 // ListTasks calls xagent.v1.XAgentService.ListTasks.
@@ -612,6 +623,15 @@ func (c *xAgentServiceClient) ListWorkspaces(ctx context.Context, req *v1.ListWo
 	return nil, err
 }
 
+// ClearWorkspaces calls xagent.v1.XAgentService.ClearWorkspaces.
+func (c *xAgentServiceClient) ClearWorkspaces(ctx context.Context, req *v1.ClearWorkspacesRequest) (*v1.ClearWorkspacesResponse, error) {
+	response, err := c.clearWorkspaces.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
+}
+
 // XAgentServiceHandler is an implementation of the xagent.v1.XAgentService service.
 type XAgentServiceHandler interface {
 	ListTasks(context.Context, *v1.ListTasksRequest) (*v1.ListTasksResponse, error)
@@ -642,6 +662,7 @@ type XAgentServiceHandler interface {
 	SubmitRunnerEvents(context.Context, *v1.SubmitRunnerEventsRequest) (*v1.SubmitRunnerEventsResponse, error)
 	RegisterWorkspaces(context.Context, *v1.RegisterWorkspacesRequest) (*v1.RegisterWorkspacesResponse, error)
 	ListWorkspaces(context.Context, *v1.ListWorkspacesRequest) (*v1.ListWorkspacesResponse, error)
+	ClearWorkspaces(context.Context, *v1.ClearWorkspacesRequest) (*v1.ClearWorkspacesResponse, error)
 }
 
 // NewXAgentServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -819,6 +840,12 @@ func NewXAgentServiceHandler(svc XAgentServiceHandler, opts ...connect.HandlerOp
 		connect.WithSchema(xAgentServiceMethods.ByName("ListWorkspaces")),
 		connect.WithHandlerOptions(opts...),
 	)
+	xAgentServiceClearWorkspacesHandler := connect.NewUnaryHandlerSimple(
+		XAgentServiceClearWorkspacesProcedure,
+		svc.ClearWorkspaces,
+		connect.WithSchema(xAgentServiceMethods.ByName("ClearWorkspaces")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/xagent.v1.XAgentService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case XAgentServiceListTasksProcedure:
@@ -877,6 +904,8 @@ func NewXAgentServiceHandler(svc XAgentServiceHandler, opts ...connect.HandlerOp
 			xAgentServiceRegisterWorkspacesHandler.ServeHTTP(w, r)
 		case XAgentServiceListWorkspacesProcedure:
 			xAgentServiceListWorkspacesHandler.ServeHTTP(w, r)
+		case XAgentServiceClearWorkspacesProcedure:
+			xAgentServiceClearWorkspacesHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -996,4 +1025,8 @@ func (UnimplementedXAgentServiceHandler) RegisterWorkspaces(context.Context, *v1
 
 func (UnimplementedXAgentServiceHandler) ListWorkspaces(context.Context, *v1.ListWorkspacesRequest) (*v1.ListWorkspacesResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("xagent.v1.XAgentService.ListWorkspaces is not implemented"))
+}
+
+func (UnimplementedXAgentServiceHandler) ClearWorkspaces(context.Context, *v1.ClearWorkspacesRequest) (*v1.ClearWorkspacesResponse, error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("xagent.v1.XAgentService.ClearWorkspaces is not implemented"))
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -746,3 +746,12 @@ func (s *Server) ListWorkspaces(ctx context.Context, req *xagentv1.ListWorkspace
 	}
 	return &xagentv1.ListWorkspacesResponse{Workspaces: result}, nil
 }
+
+func (s *Server) ClearWorkspaces(ctx context.Context, req *xagentv1.ClearWorkspacesRequest) (*xagentv1.ClearWorkspacesResponse, error) {
+	userID := s.userID(ctx)
+	if err := s.workspaces.Clear(ctx, nil, userID); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	s.log.Info("workspaces cleared", "owner", userID)
+	return &xagentv1.ClearWorkspacesResponse{}, nil
+}

--- a/internal/server/workspace_test.go
+++ b/internal/server/workspace_test.go
@@ -110,3 +110,71 @@ func TestRegisterWorkspaces_SameRunnerDifferentUsers(t *testing.T) {
 	assert.Equal(t, len(listRespB.Workspaces), 1)
 	assert.Equal(t, listRespB.Workspaces[0].Name, "workspace-b")
 }
+
+func TestClearWorkspaces(t *testing.T) {
+	srv := setupTestServer(t)
+	ctx := withUserID(t, "test-user")
+
+	// Register workspaces
+	_, err := srv.RegisterWorkspaces(ctx, &xagentv1.RegisterWorkspacesRequest{
+		RunnerId: "runner-1",
+		Workspaces: []*xagentv1.RegisteredWorkspace{
+			{Name: "workspace-a"},
+			{Name: "workspace-b"},
+		},
+	})
+	assert.NilError(t, err)
+
+	// Verify workspaces exist
+	listResp, err := srv.ListWorkspaces(ctx, &xagentv1.ListWorkspacesRequest{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(listResp.Workspaces), 2)
+
+	// Clear workspaces
+	_, err = srv.ClearWorkspaces(ctx, &xagentv1.ClearWorkspacesRequest{})
+	assert.NilError(t, err)
+
+	// Verify workspaces are cleared
+	listResp, err = srv.ListWorkspaces(ctx, &xagentv1.ListWorkspacesRequest{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(listResp.Workspaces), 0)
+}
+
+func TestClearWorkspaces_Permissions(t *testing.T) {
+	srv := setupTestServer(t)
+	userA := withUserID(t, "user-a")
+	userB := withUserID(t, "user-b")
+
+	// User A registers workspaces
+	_, err := srv.RegisterWorkspaces(userA, &xagentv1.RegisterWorkspacesRequest{
+		RunnerId: "runner-1",
+		Workspaces: []*xagentv1.RegisteredWorkspace{
+			{Name: "workspace-a"},
+		},
+	})
+	assert.NilError(t, err)
+
+	// User B registers workspaces
+	_, err = srv.RegisterWorkspaces(userB, &xagentv1.RegisterWorkspacesRequest{
+		RunnerId: "runner-1",
+		Workspaces: []*xagentv1.RegisteredWorkspace{
+			{Name: "workspace-b"},
+		},
+	})
+	assert.NilError(t, err)
+
+	// User A clears workspaces - should only clear their own
+	_, err = srv.ClearWorkspaces(userA, &xagentv1.ClearWorkspacesRequest{})
+	assert.NilError(t, err)
+
+	// Verify User A has no workspaces
+	listRespA, err := srv.ListWorkspaces(userA, &xagentv1.ListWorkspacesRequest{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(listRespA.Workspaces), 0)
+
+	// Verify User B still has their workspaces
+	listRespB, err := srv.ListWorkspaces(userB, &xagentv1.ListWorkspacesRequest{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(listRespB.Workspaces), 1)
+	assert.Equal(t, listRespB.Workspaces[0].Name, "workspace-b")
+}

--- a/internal/store/workspace.go
+++ b/internal/store/workspace.go
@@ -71,3 +71,9 @@ func (r *WorkspaceRepository) scanWorkspace(rows *sql.Rows) (*model.Workspace, e
 	}
 	return &ws, nil
 }
+
+// Clear deletes all workspaces for the given owner.
+func (r *WorkspaceRepository) Clear(ctx context.Context, tx *sql.Tx, owner string) error {
+	_, err := r.exec(tx).ExecContext(ctx, `DELETE FROM workspaces WHERE owner = ?`, owner)
+	return err
+}

--- a/internal/xmcp/client_moq_test.go
+++ b/internal/xmcp/client_moq_test.go
@@ -29,6 +29,9 @@ var _ xagentclient.Client = &ClientMock{}
 //			CancelTaskFunc: func(contextMoqParam context.Context, cancelTaskRequest *xagentv1.CancelTaskRequest) (*xagentv1.CancelTaskResponse, error) {
 //				panic("mock out the CancelTask method")
 //			},
+//			ClearWorkspacesFunc: func(contextMoqParam context.Context, clearWorkspacesRequest *xagentv1.ClearWorkspacesRequest) (*xagentv1.ClearWorkspacesResponse, error) {
+//				panic("mock out the ClearWorkspaces method")
+//			},
 //			CreateEventFunc: func(contextMoqParam context.Context, createEventRequest *xagentv1.CreateEventRequest) (*xagentv1.CreateEventResponse, error) {
 //				panic("mock out the CreateEvent method")
 //			},
@@ -119,6 +122,9 @@ type ClientMock struct {
 
 	// CancelTaskFunc mocks the CancelTask method.
 	CancelTaskFunc func(contextMoqParam context.Context, cancelTaskRequest *xagentv1.CancelTaskRequest) (*xagentv1.CancelTaskResponse, error)
+
+	// ClearWorkspacesFunc mocks the ClearWorkspaces method.
+	ClearWorkspacesFunc func(contextMoqParam context.Context, clearWorkspacesRequest *xagentv1.ClearWorkspacesRequest) (*xagentv1.ClearWorkspacesResponse, error)
 
 	// CreateEventFunc mocks the CreateEvent method.
 	CreateEventFunc func(contextMoqParam context.Context, createEventRequest *xagentv1.CreateEventRequest) (*xagentv1.CreateEventResponse, error)
@@ -217,6 +223,13 @@ type ClientMock struct {
 			ContextMoqParam context.Context
 			// CancelTaskRequest is the cancelTaskRequest argument value.
 			CancelTaskRequest *xagentv1.CancelTaskRequest
+		}
+		// ClearWorkspaces holds details about calls to the ClearWorkspaces method.
+		ClearWorkspaces []struct {
+			// ContextMoqParam is the contextMoqParam argument value.
+			ContextMoqParam context.Context
+			// ClearWorkspacesRequest is the clearWorkspacesRequest argument value.
+			ClearWorkspacesRequest *xagentv1.ClearWorkspacesRequest
 		}
 		// CreateEvent holds details about calls to the CreateEvent method.
 		CreateEvent []struct {
@@ -397,6 +410,7 @@ type ClientMock struct {
 	lockAddEventTask       sync.RWMutex
 	lockArchiveTask        sync.RWMutex
 	lockCancelTask         sync.RWMutex
+	lockClearWorkspaces    sync.RWMutex
 	lockCreateEvent        sync.RWMutex
 	lockCreateLink         sync.RWMutex
 	lockCreateTask         sync.RWMutex
@@ -529,6 +543,42 @@ func (mock *ClientMock) CancelTaskCalls() []struct {
 	mock.lockCancelTask.RLock()
 	calls = mock.calls.CancelTask
 	mock.lockCancelTask.RUnlock()
+	return calls
+}
+
+// ClearWorkspaces calls ClearWorkspacesFunc.
+func (mock *ClientMock) ClearWorkspaces(contextMoqParam context.Context, clearWorkspacesRequest *xagentv1.ClearWorkspacesRequest) (*xagentv1.ClearWorkspacesResponse, error) {
+	if mock.ClearWorkspacesFunc == nil {
+		panic("ClientMock.ClearWorkspacesFunc: method is nil but Client.ClearWorkspaces was just called")
+	}
+	callInfo := struct {
+		ContextMoqParam        context.Context
+		ClearWorkspacesRequest *xagentv1.ClearWorkspacesRequest
+	}{
+		ContextMoqParam:        contextMoqParam,
+		ClearWorkspacesRequest: clearWorkspacesRequest,
+	}
+	mock.lockClearWorkspaces.Lock()
+	mock.calls.ClearWorkspaces = append(mock.calls.ClearWorkspaces, callInfo)
+	mock.lockClearWorkspaces.Unlock()
+	return mock.ClearWorkspacesFunc(contextMoqParam, clearWorkspacesRequest)
+}
+
+// ClearWorkspacesCalls gets all the calls that were made to ClearWorkspaces.
+// Check the length with:
+//
+//	len(mockedClient.ClearWorkspacesCalls())
+func (mock *ClientMock) ClearWorkspacesCalls() []struct {
+	ContextMoqParam        context.Context
+	ClearWorkspacesRequest *xagentv1.ClearWorkspacesRequest
+} {
+	var calls []struct {
+		ContextMoqParam        context.Context
+		ClearWorkspacesRequest *xagentv1.ClearWorkspacesRequest
+	}
+	mock.lockClearWorkspaces.RLock()
+	calls = mock.calls.ClearWorkspaces
+	mock.lockClearWorkspaces.RUnlock()
 	return calls
 }
 

--- a/proto/xagent/v1/xagent.proto
+++ b/proto/xagent/v1/xagent.proto
@@ -35,6 +35,7 @@ service XAgentService {
   rpc SubmitRunnerEvents(SubmitRunnerEventsRequest) returns (SubmitRunnerEventsResponse);
   rpc RegisterWorkspaces(RegisterWorkspacesRequest) returns (RegisterWorkspacesResponse);
   rpc ListWorkspaces(ListWorkspacesRequest) returns (ListWorkspacesResponse);
+  rpc ClearWorkspaces(ClearWorkspacesRequest) returns (ClearWorkspacesResponse);
 }
 
 message Instruction {
@@ -319,3 +320,7 @@ message ListWorkspacesRequest {}
 message ListWorkspacesResponse {
   repeated RegisteredWorkspace workspaces = 1;
 }
+
+message ClearWorkspacesRequest {}
+
+message ClearWorkspacesResponse {}

--- a/webui/src/gen/xagent/v1/xagent-XAgentService_connectquery.ts
+++ b/webui/src/gen/xagent/v1/xagent-XAgentService_connectquery.ts
@@ -10,6 +10,11 @@ import { XAgentService } from "./xagent_pb";
 export const listTasks = XAgentService.method.listTasks;
 
 /**
+ * @generated from rpc xagent.v1.XAgentService.ListRunnerTasks
+ */
+export const listRunnerTasks = XAgentService.method.listRunnerTasks;
+
+/**
  * @generated from rpc xagent.v1.XAgentService.ListChildTasks
  */
 export const listChildTasks = XAgentService.method.listChildTasks;
@@ -138,3 +143,8 @@ export const registerWorkspaces = XAgentService.method.registerWorkspaces;
  * @generated from rpc xagent.v1.XAgentService.ListWorkspaces
  */
 export const listWorkspaces = XAgentService.method.listWorkspaces;
+
+/**
+ * @generated from rpc xagent.v1.XAgentService.ClearWorkspaces
+ */
+export const clearWorkspaces = XAgentService.method.clearWorkspaces;

--- a/webui/src/gen/xagent/v1/xagent_pb.ts
+++ b/webui/src/gen/xagent/v1/xagent_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file xagent/v1/xagent.proto.
  */
 export const file_xagent_v1_xagent: GenFile = /*@__PURE__*/
-  fileDesc("ChZ4YWdlbnQvdjEveGFnZW50LnByb3RvEgl4YWdlbnQudjEiKAoLSW5zdHJ1Y3Rpb24SDAoEdGV4dBgBIAEoCRILCgN1cmwYAiABKAkiogIKBFRhc2sSCgoCaWQYASABKAMSDAoEbmFtZRgCIAEoCRIOCgZwYXJlbnQYAyABKAMSEQoJd29ya3NwYWNlGAQgASgJEiwKDGluc3RydWN0aW9ucxgFIAMoCzIWLnhhZ2VudC52MS5JbnN0cnVjdGlvbhIOCgZzdGF0dXMYBiABKAkSLgoKY3JlYXRlZF9hdBgHIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLgoKdXBkYXRlZF9hdBgIIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASDwoHY29tbWFuZBgJIAEoCRIPCgd2ZXJzaW9uGAogASgDEg0KBW93bmVyGAsgASgJEg4KBnJ1bm5lchgMIAEoCSKQAQoJTWNwU2VydmVyEgwKBG5hbWUYASABKAkSDwoHY29tbWFuZBgCIAEoCRIMCgRhcmdzGAMgAygJEioKA2VudhgEIAMoCzIdLnhhZ2VudC52MS5NY3BTZXJ2ZXIuRW52RW50cnkaKgoIRW52RW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASI3ChBMaXN0VGFza3NSZXF1ZXN0EhMKC2hhc19jb21tYW5kGAEgASgIEg4KBnJ1bm5lchgCIAEoCSIzChFMaXN0VGFza3NSZXNwb25zZRIeCgV0YXNrcxgBIAMoCzIPLnhhZ2VudC52MS5UYXNrIioKFUxpc3RDaGlsZFRhc2tzUmVxdWVzdBIRCglwYXJlbnRfaWQYASABKAMiOAoWTGlzdENoaWxkVGFza3NSZXNwb25zZRIeCgV0YXNrcxgBIAMoCzIPLnhhZ2VudC52MS5UYXNrIoIBChFDcmVhdGVUYXNrUmVxdWVzdBIMCgRuYW1lGAEgASgJEg4KBnBhcmVudBgCIAEoAxIRCgl3b3Jrc3BhY2UYAyABKAkSLAoMaW5zdHJ1Y3Rpb25zGAQgAygLMhYueGFnZW50LnYxLkluc3RydWN0aW9uEg4KBnJ1bm5lchgFIAEoCSIzChJDcmVhdGVUYXNrUmVzcG9uc2USHQoEdGFzaxgBIAEoCzIPLnhhZ2VudC52MS5UYXNrIhwKDkdldFRhc2tSZXF1ZXN0EgoKAmlkGAEgASgDIjAKD0dldFRhc2tSZXNwb25zZRIdCgR0YXNrGAEgASgLMg8ueGFnZW50LnYxLlRhc2siIwoVR2V0VGFza0RldGFpbHNSZXF1ZXN0EgoKAmlkGAEgASgDIqABChZHZXRUYXNrRGV0YWlsc1Jlc3BvbnNlEh0KBHRhc2sYASABKAsyDy54YWdlbnQudjEuVGFzaxIhCghjaGlsZHJlbhgCIAMoCzIPLnhhZ2VudC52MS5UYXNrEiAKBmV2ZW50cxgDIAMoCzIQLnhhZ2VudC52MS5FdmVudBIiCgVsaW5rcxgEIAMoCzITLnhhZ2VudC52MS5UYXNrTGluayJ0ChFVcGRhdGVUYXNrUmVxdWVzdBIKCgJpZBgBIAEoAxIMCgRuYW1lGAIgASgJEjAKEGFkZF9pbnN0cnVjdGlvbnMYBCADKAsyFi54YWdlbnQudjEuSW5zdHJ1Y3Rpb24SDQoFc3RhcnQYBSABKAhKBAgDEAQiFAoSVXBkYXRlVGFza1Jlc3BvbnNlIh8KEURlbGV0ZVRhc2tSZXF1ZXN0EgoKAmlkGAEgASgDIhQKEkRlbGV0ZVRhc2tSZXNwb25zZSIgChJBcmNoaXZlVGFza1JlcXVlc3QSCgoCaWQYASABKAMiFQoTQXJjaGl2ZVRhc2tSZXNwb25zZSIfChFDYW5jZWxUYXNrUmVxdWVzdBIKCgJpZBgBIAEoAyIUChJDYW5jZWxUYXNrUmVzcG9uc2UiIAoSUmVzdGFydFRhc2tSZXF1ZXN0EgoKAmlkGAEgASgDIhUKE1Jlc3RhcnRUYXNrUmVzcG9uc2UiWQoITG9nRW50cnkSDAoEdHlwZRgBIAEoCRIPCgdjb250ZW50GAIgASgJEi4KCmNyZWF0ZWRfYXQYAyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wIkoKEVVwbG9hZExvZ3NSZXF1ZXN0Eg8KB3Rhc2tfaWQYASABKAMSJAoHZW50cmllcxgCIAMoCzITLnhhZ2VudC52MS5Mb2dFbnRyeSIUChJVcGxvYWRMb2dzUmVzcG9uc2UiIgoPTGlzdExvZ3NSZXF1ZXN0Eg8KB3Rhc2tfaWQYASABKAMiOAoQTGlzdExvZ3NSZXNwb25zZRIkCgdlbnRyaWVzGAEgAygLMhMueGFnZW50LnYxLkxvZ0VudHJ5IpYBCghUYXNrTGluaxIKCgJpZBgBIAEoAxIPCgd0YXNrX2lkGAIgASgDEhEKCXJlbGV2YW5jZRgDIAEoCRILCgN1cmwYBCABKAkSDQoFdGl0bGUYBSABKAkSDgoGbm90aWZ5GAYgASgIEi4KCmNyZWF0ZWRfYXQYByABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wImMKEUNyZWF0ZUxpbmtSZXF1ZXN0Eg8KB3Rhc2tfaWQYASABKAMSEQoJcmVsZXZhbmNlGAIgASgJEgsKA3VybBgDIAEoCRINCgV0aXRsZRgEIAEoCRIOCgZub3RpZnkYBSABKAgiNwoSQ3JlYXRlTGlua1Jlc3BvbnNlEiEKBGxpbmsYASABKAsyEy54YWdlbnQudjEuVGFza0xpbmsiIwoQTGlzdExpbmtzUmVxdWVzdBIPCgd0YXNrX2lkGAEgASgDIjcKEUxpc3RMaW5rc1Jlc3BvbnNlEiIKBWxpbmtzGAEgAygLMhMueGFnZW50LnYxLlRhc2tMaW5rIiQKFUZpbmRMaW5rc0J5VVJMUmVxdWVzdBILCgN1cmwYASABKAkiPAoWRmluZExpbmtzQnlVUkxSZXNwb25zZRIiCgVsaW5rcxgBIAMoCzITLnhhZ2VudC52MS5UYXNrTGluayJzCgVFdmVudBIKCgJpZBgBIAEoAxITCgtkZXNjcmlwdGlvbhgCIAEoCRIMCgRkYXRhGAMgASgJEgsKA3VybBgEIAEoCRIuCgpjcmVhdGVkX2F0GAUgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCIiChFMaXN0RXZlbnRzUmVxdWVzdBINCgVsaW1pdBgBIAEoBSI2ChJMaXN0RXZlbnRzUmVzcG9uc2USIAoGZXZlbnRzGAEgAygLMhAueGFnZW50LnYxLkV2ZW50IkQKEkNyZWF0ZUV2ZW50UmVxdWVzdBITCgtkZXNjcmlwdGlvbhgBIAEoCRIMCgRkYXRhGAIgASgJEgsKA3VybBgDIAEoCSI2ChNDcmVhdGVFdmVudFJlc3BvbnNlEh8KBWV2ZW50GAEgASgLMhAueGFnZW50LnYxLkV2ZW50Ih0KD0dldEV2ZW50UmVxdWVzdBIKCgJpZBgBIAEoAyIzChBHZXRFdmVudFJlc3BvbnNlEh8KBWV2ZW50GAEgASgLMhAueGFnZW50LnYxLkV2ZW50IiAKEkRlbGV0ZUV2ZW50UmVxdWVzdBIKCgJpZBgBIAEoAyIVChNEZWxldGVFdmVudFJlc3BvbnNlIjgKE0FkZEV2ZW50VGFza1JlcXVlc3QSEAoIZXZlbnRfaWQYASABKAMSDwoHdGFza19pZBgCIAEoAyIWChRBZGRFdmVudFRhc2tSZXNwb25zZSI7ChZSZW1vdmVFdmVudFRhc2tSZXF1ZXN0EhAKCGV2ZW50X2lkGAEgASgDEg8KB3Rhc2tfaWQYAiABKAMiGQoXUmVtb3ZlRXZlbnRUYXNrUmVzcG9uc2UiKQoVTGlzdEV2ZW50VGFza3NSZXF1ZXN0EhAKCGV2ZW50X2lkGAEgASgDIioKFkxpc3RFdmVudFRhc2tzUmVzcG9uc2USEAoIdGFza19pZHMYASADKAMiKgoXTGlzdEV2ZW50c0J5VGFza1JlcXVlc3QSDwoHdGFza19pZBgBIAEoAyI8ChhMaXN0RXZlbnRzQnlUYXNrUmVzcG9uc2USIAoGZXZlbnRzGAEgAygLMhAueGFnZW50LnYxLkV2ZW50IiEKE1Byb2Nlc3NFdmVudFJlcXVlc3QSCgoCaWQYASABKAMiKAoUUHJvY2Vzc0V2ZW50UmVzcG9uc2USEAoIdGFza19pZHMYASADKAMiUQoLUnVubmVyRXZlbnQSDwoHdGFza19pZBgBIAEoAxINCgVldmVudBgCIAEoCRIPCgd2ZXJzaW9uGAMgASgDEhEKCXJlY29uY2lsZRgEIAEoCCJDChlTdWJtaXRSdW5uZXJFdmVudHNSZXF1ZXN0EiYKBmV2ZW50cxgBIAMoCzIWLnhhZ2VudC52MS5SdW5uZXJFdmVudCIcChpTdWJtaXRSdW5uZXJFdmVudHNSZXNwb25zZSJmChNSZWdpc3RlcmVkV29ya3NwYWNlEgwKBG5hbWUYASABKAkSEQoJcnVubmVyX2lkGAIgASgJEi4KCnVwZGF0ZWRfYXQYAyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wImIKGVJlZ2lzdGVyV29ya3NwYWNlc1JlcXVlc3QSEQoJcnVubmVyX2lkGAEgASgJEjIKCndvcmtzcGFjZXMYAiADKAsyHi54YWdlbnQudjEuUmVnaXN0ZXJlZFdvcmtzcGFjZSIcChpSZWdpc3RlcldvcmtzcGFjZXNSZXNwb25zZSIXChVMaXN0V29ya3NwYWNlc1JlcXVlc3QiTAoWTGlzdFdvcmtzcGFjZXNSZXNwb25zZRIyCgp3b3Jrc3BhY2VzGAEgAygLMh4ueGFnZW50LnYxLlJlZ2lzdGVyZWRXb3Jrc3BhY2UyghEKDVhBZ2VudFNlcnZpY2USRgoJTGlzdFRhc2tzEhsueGFnZW50LnYxLkxpc3RUYXNrc1JlcXVlc3QaHC54YWdlbnQudjEuTGlzdFRhc2tzUmVzcG9uc2USVQoOTGlzdENoaWxkVGFza3MSIC54YWdlbnQudjEuTGlzdENoaWxkVGFza3NSZXF1ZXN0GiEueGFnZW50LnYxLkxpc3RDaGlsZFRhc2tzUmVzcG9uc2USSQoKQ3JlYXRlVGFzaxIcLnhhZ2VudC52MS5DcmVhdGVUYXNrUmVxdWVzdBodLnhhZ2VudC52MS5DcmVhdGVUYXNrUmVzcG9uc2USQAoHR2V0VGFzaxIZLnhhZ2VudC52MS5HZXRUYXNrUmVxdWVzdBoaLnhhZ2VudC52MS5HZXRUYXNrUmVzcG9uc2USVQoOR2V0VGFza0RldGFpbHMSIC54YWdlbnQudjEuR2V0VGFza0RldGFpbHNSZXF1ZXN0GiEueGFnZW50LnYxLkdldFRhc2tEZXRhaWxzUmVzcG9uc2USSQoKVXBkYXRlVGFzaxIcLnhhZ2VudC52MS5VcGRhdGVUYXNrUmVxdWVzdBodLnhhZ2VudC52MS5VcGRhdGVUYXNrUmVzcG9uc2USSQoKRGVsZXRlVGFzaxIcLnhhZ2VudC52MS5EZWxldGVUYXNrUmVxdWVzdBodLnhhZ2VudC52MS5EZWxldGVUYXNrUmVzcG9uc2USTAoLQXJjaGl2ZVRhc2sSHS54YWdlbnQudjEuQXJjaGl2ZVRhc2tSZXF1ZXN0Gh4ueGFnZW50LnYxLkFyY2hpdmVUYXNrUmVzcG9uc2USSQoKQ2FuY2VsVGFzaxIcLnhhZ2VudC52MS5DYW5jZWxUYXNrUmVxdWVzdBodLnhhZ2VudC52MS5DYW5jZWxUYXNrUmVzcG9uc2USTAoLUmVzdGFydFRhc2sSHS54YWdlbnQudjEuUmVzdGFydFRhc2tSZXF1ZXN0Gh4ueGFnZW50LnYxLlJlc3RhcnRUYXNrUmVzcG9uc2USSQoKVXBsb2FkTG9ncxIcLnhhZ2VudC52MS5VcGxvYWRMb2dzUmVxdWVzdBodLnhhZ2VudC52MS5VcGxvYWRMb2dzUmVzcG9uc2USQwoITGlzdExvZ3MSGi54YWdlbnQudjEuTGlzdExvZ3NSZXF1ZXN0GhsueGFnZW50LnYxLkxpc3RMb2dzUmVzcG9uc2USSQoKQ3JlYXRlTGluaxIcLnhhZ2VudC52MS5DcmVhdGVMaW5rUmVxdWVzdBodLnhhZ2VudC52MS5DcmVhdGVMaW5rUmVzcG9uc2USRgoJTGlzdExpbmtzEhsueGFnZW50LnYxLkxpc3RMaW5rc1JlcXVlc3QaHC54YWdlbnQudjEuTGlzdExpbmtzUmVzcG9uc2USVQoORmluZExpbmtzQnlVUkwSIC54YWdlbnQudjEuRmluZExpbmtzQnlVUkxSZXF1ZXN0GiEueGFnZW50LnYxLkZpbmRMaW5rc0J5VVJMUmVzcG9uc2USSQoKTGlzdEV2ZW50cxIcLnhhZ2VudC52MS5MaXN0RXZlbnRzUmVxdWVzdBodLnhhZ2VudC52MS5MaXN0RXZlbnRzUmVzcG9uc2USTAoLQ3JlYXRlRXZlbnQSHS54YWdlbnQudjEuQ3JlYXRlRXZlbnRSZXF1ZXN0Gh4ueGFnZW50LnYxLkNyZWF0ZUV2ZW50UmVzcG9uc2USQwoIR2V0RXZlbnQSGi54YWdlbnQudjEuR2V0RXZlbnRSZXF1ZXN0GhsueGFnZW50LnYxLkdldEV2ZW50UmVzcG9uc2USTAoLRGVsZXRlRXZlbnQSHS54YWdlbnQudjEuRGVsZXRlRXZlbnRSZXF1ZXN0Gh4ueGFnZW50LnYxLkRlbGV0ZUV2ZW50UmVzcG9uc2USTwoMQWRkRXZlbnRUYXNrEh4ueGFnZW50LnYxLkFkZEV2ZW50VGFza1JlcXVlc3QaHy54YWdlbnQudjEuQWRkRXZlbnRUYXNrUmVzcG9uc2USWAoPUmVtb3ZlRXZlbnRUYXNrEiEueGFnZW50LnYxLlJlbW92ZUV2ZW50VGFza1JlcXVlc3QaIi54YWdlbnQudjEuUmVtb3ZlRXZlbnRUYXNrUmVzcG9uc2USVQoOTGlzdEV2ZW50VGFza3MSIC54YWdlbnQudjEuTGlzdEV2ZW50VGFza3NSZXF1ZXN0GiEueGFnZW50LnYxLkxpc3RFdmVudFRhc2tzUmVzcG9uc2USWwoQTGlzdEV2ZW50c0J5VGFzaxIiLnhhZ2VudC52MS5MaXN0RXZlbnRzQnlUYXNrUmVxdWVzdBojLnhhZ2VudC52MS5MaXN0RXZlbnRzQnlUYXNrUmVzcG9uc2USTwoMUHJvY2Vzc0V2ZW50Eh4ueGFnZW50LnYxLlByb2Nlc3NFdmVudFJlcXVlc3QaHy54YWdlbnQudjEuUHJvY2Vzc0V2ZW50UmVzcG9uc2USYQoSU3VibWl0UnVubmVyRXZlbnRzEiQueGFnZW50LnYxLlN1Ym1pdFJ1bm5lckV2ZW50c1JlcXVlc3QaJS54YWdlbnQudjEuU3VibWl0UnVubmVyRXZlbnRzUmVzcG9uc2USYQoSUmVnaXN0ZXJXb3Jrc3BhY2VzEiQueGFnZW50LnYxLlJlZ2lzdGVyV29ya3NwYWNlc1JlcXVlc3QaJS54YWdlbnQudjEuUmVnaXN0ZXJXb3Jrc3BhY2VzUmVzcG9uc2USVQoOTGlzdFdvcmtzcGFjZXMSIC54YWdlbnQudjEuTGlzdFdvcmtzcGFjZXNSZXF1ZXN0GiEueGFnZW50LnYxLkxpc3RXb3Jrc3BhY2VzUmVzcG9uc2VCPFo6Z2l0aHViLmNvbS9pY2hvbHkveGFnZW50L2ludGVybmFsL3Byb3RvL3hhZ2VudC92MTt4YWdlbnR2MWIGcHJvdG8z", [file_google_protobuf_timestamp]);
+  fileDesc("ChZ4YWdlbnQvdjEveGFnZW50LnByb3RvEgl4YWdlbnQudjEiKAoLSW5zdHJ1Y3Rpb24SDAoEdGV4dBgBIAEoCRILCgN1cmwYAiABKAkiogIKBFRhc2sSCgoCaWQYASABKAMSDAoEbmFtZRgCIAEoCRIOCgZwYXJlbnQYAyABKAMSEQoJd29ya3NwYWNlGAQgASgJEiwKDGluc3RydWN0aW9ucxgFIAMoCzIWLnhhZ2VudC52MS5JbnN0cnVjdGlvbhIOCgZzdGF0dXMYBiABKAkSLgoKY3JlYXRlZF9hdBgHIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLgoKdXBkYXRlZF9hdBgIIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASDwoHY29tbWFuZBgJIAEoCRIPCgd2ZXJzaW9uGAogASgDEg0KBW93bmVyGAsgASgJEg4KBnJ1bm5lchgMIAEoCSKQAQoJTWNwU2VydmVyEgwKBG5hbWUYASABKAkSDwoHY29tbWFuZBgCIAEoCRIMCgRhcmdzGAMgAygJEioKA2VudhgEIAMoCzIdLnhhZ2VudC52MS5NY3BTZXJ2ZXIuRW52RW50cnkaKgoIRW52RW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASISChBMaXN0VGFza3NSZXF1ZXN0IjMKEUxpc3RUYXNrc1Jlc3BvbnNlEh4KBXRhc2tzGAEgAygLMg8ueGFnZW50LnYxLlRhc2siKAoWTGlzdFJ1bm5lclRhc2tzUmVxdWVzdBIOCgZydW5uZXIYASABKAkiOQoXTGlzdFJ1bm5lclRhc2tzUmVzcG9uc2USHgoFdGFza3MYASADKAsyDy54YWdlbnQudjEuVGFzayIqChVMaXN0Q2hpbGRUYXNrc1JlcXVlc3QSEQoJcGFyZW50X2lkGAEgASgDIjgKFkxpc3RDaGlsZFRhc2tzUmVzcG9uc2USHgoFdGFza3MYASADKAsyDy54YWdlbnQudjEuVGFzayKCAQoRQ3JlYXRlVGFza1JlcXVlc3QSDAoEbmFtZRgBIAEoCRIOCgZwYXJlbnQYAiABKAMSEQoJd29ya3NwYWNlGAMgASgJEiwKDGluc3RydWN0aW9ucxgEIAMoCzIWLnhhZ2VudC52MS5JbnN0cnVjdGlvbhIOCgZydW5uZXIYBSABKAkiMwoSQ3JlYXRlVGFza1Jlc3BvbnNlEh0KBHRhc2sYASABKAsyDy54YWdlbnQudjEuVGFzayIcCg5HZXRUYXNrUmVxdWVzdBIKCgJpZBgBIAEoAyIwCg9HZXRUYXNrUmVzcG9uc2USHQoEdGFzaxgBIAEoCzIPLnhhZ2VudC52MS5UYXNrIiMKFUdldFRhc2tEZXRhaWxzUmVxdWVzdBIKCgJpZBgBIAEoAyKgAQoWR2V0VGFza0RldGFpbHNSZXNwb25zZRIdCgR0YXNrGAEgASgLMg8ueGFnZW50LnYxLlRhc2sSIQoIY2hpbGRyZW4YAiADKAsyDy54YWdlbnQudjEuVGFzaxIgCgZldmVudHMYAyADKAsyEC54YWdlbnQudjEuRXZlbnQSIgoFbGlua3MYBCADKAsyEy54YWdlbnQudjEuVGFza0xpbmsidAoRVXBkYXRlVGFza1JlcXVlc3QSCgoCaWQYASABKAMSDAoEbmFtZRgCIAEoCRIwChBhZGRfaW5zdHJ1Y3Rpb25zGAQgAygLMhYueGFnZW50LnYxLkluc3RydWN0aW9uEg0KBXN0YXJ0GAUgASgISgQIAxAEIhQKElVwZGF0ZVRhc2tSZXNwb25zZSIfChFEZWxldGVUYXNrUmVxdWVzdBIKCgJpZBgBIAEoAyIUChJEZWxldGVUYXNrUmVzcG9uc2UiIAoSQXJjaGl2ZVRhc2tSZXF1ZXN0EgoKAmlkGAEgASgDIhUKE0FyY2hpdmVUYXNrUmVzcG9uc2UiHwoRQ2FuY2VsVGFza1JlcXVlc3QSCgoCaWQYASABKAMiFAoSQ2FuY2VsVGFza1Jlc3BvbnNlIiAKElJlc3RhcnRUYXNrUmVxdWVzdBIKCgJpZBgBIAEoAyIVChNSZXN0YXJ0VGFza1Jlc3BvbnNlIlkKCExvZ0VudHJ5EgwKBHR5cGUYASABKAkSDwoHY29udGVudBgCIAEoCRIuCgpjcmVhdGVkX2F0GAMgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCJKChFVcGxvYWRMb2dzUmVxdWVzdBIPCgd0YXNrX2lkGAEgASgDEiQKB2VudHJpZXMYAiADKAsyEy54YWdlbnQudjEuTG9nRW50cnkiFAoSVXBsb2FkTG9nc1Jlc3BvbnNlIiIKD0xpc3RMb2dzUmVxdWVzdBIPCgd0YXNrX2lkGAEgASgDIjgKEExpc3RMb2dzUmVzcG9uc2USJAoHZW50cmllcxgBIAMoCzITLnhhZ2VudC52MS5Mb2dFbnRyeSKWAQoIVGFza0xpbmsSCgoCaWQYASABKAMSDwoHdGFza19pZBgCIAEoAxIRCglyZWxldmFuY2UYAyABKAkSCwoDdXJsGAQgASgJEg0KBXRpdGxlGAUgASgJEg4KBm5vdGlmeRgGIAEoCBIuCgpjcmVhdGVkX2F0GAcgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCJjChFDcmVhdGVMaW5rUmVxdWVzdBIPCgd0YXNrX2lkGAEgASgDEhEKCXJlbGV2YW5jZRgCIAEoCRILCgN1cmwYAyABKAkSDQoFdGl0bGUYBCABKAkSDgoGbm90aWZ5GAUgASgIIjcKEkNyZWF0ZUxpbmtSZXNwb25zZRIhCgRsaW5rGAEgASgLMhMueGFnZW50LnYxLlRhc2tMaW5rIiMKEExpc3RMaW5rc1JlcXVlc3QSDwoHdGFza19pZBgBIAEoAyI3ChFMaXN0TGlua3NSZXNwb25zZRIiCgVsaW5rcxgBIAMoCzITLnhhZ2VudC52MS5UYXNrTGluayIkChVGaW5kTGlua3NCeVVSTFJlcXVlc3QSCwoDdXJsGAEgASgJIjwKFkZpbmRMaW5rc0J5VVJMUmVzcG9uc2USIgoFbGlua3MYASADKAsyEy54YWdlbnQudjEuVGFza0xpbmsicwoFRXZlbnQSCgoCaWQYASABKAMSEwoLZGVzY3JpcHRpb24YAiABKAkSDAoEZGF0YRgDIAEoCRILCgN1cmwYBCABKAkSLgoKY3JlYXRlZF9hdBgFIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAiIgoRTGlzdEV2ZW50c1JlcXVlc3QSDQoFbGltaXQYASABKAUiNgoSTGlzdEV2ZW50c1Jlc3BvbnNlEiAKBmV2ZW50cxgBIAMoCzIQLnhhZ2VudC52MS5FdmVudCJEChJDcmVhdGVFdmVudFJlcXVlc3QSEwoLZGVzY3JpcHRpb24YASABKAkSDAoEZGF0YRgCIAEoCRILCgN1cmwYAyABKAkiNgoTQ3JlYXRlRXZlbnRSZXNwb25zZRIfCgVldmVudBgBIAEoCzIQLnhhZ2VudC52MS5FdmVudCIdCg9HZXRFdmVudFJlcXVlc3QSCgoCaWQYASABKAMiMwoQR2V0RXZlbnRSZXNwb25zZRIfCgVldmVudBgBIAEoCzIQLnhhZ2VudC52MS5FdmVudCIgChJEZWxldGVFdmVudFJlcXVlc3QSCgoCaWQYASABKAMiFQoTRGVsZXRlRXZlbnRSZXNwb25zZSI4ChNBZGRFdmVudFRhc2tSZXF1ZXN0EhAKCGV2ZW50X2lkGAEgASgDEg8KB3Rhc2tfaWQYAiABKAMiFgoUQWRkRXZlbnRUYXNrUmVzcG9uc2UiOwoWUmVtb3ZlRXZlbnRUYXNrUmVxdWVzdBIQCghldmVudF9pZBgBIAEoAxIPCgd0YXNrX2lkGAIgASgDIhkKF1JlbW92ZUV2ZW50VGFza1Jlc3BvbnNlIikKFUxpc3RFdmVudFRhc2tzUmVxdWVzdBIQCghldmVudF9pZBgBIAEoAyIqChZMaXN0RXZlbnRUYXNrc1Jlc3BvbnNlEhAKCHRhc2tfaWRzGAEgAygDIioKF0xpc3RFdmVudHNCeVRhc2tSZXF1ZXN0Eg8KB3Rhc2tfaWQYASABKAMiPAoYTGlzdEV2ZW50c0J5VGFza1Jlc3BvbnNlEiAKBmV2ZW50cxgBIAMoCzIQLnhhZ2VudC52MS5FdmVudCIhChNQcm9jZXNzRXZlbnRSZXF1ZXN0EgoKAmlkGAEgASgDIigKFFByb2Nlc3NFdmVudFJlc3BvbnNlEhAKCHRhc2tfaWRzGAEgAygDIlEKC1J1bm5lckV2ZW50Eg8KB3Rhc2tfaWQYASABKAMSDQoFZXZlbnQYAiABKAkSDwoHdmVyc2lvbhgDIAEoAxIRCglyZWNvbmNpbGUYBCABKAgiQwoZU3VibWl0UnVubmVyRXZlbnRzUmVxdWVzdBImCgZldmVudHMYASADKAsyFi54YWdlbnQudjEuUnVubmVyRXZlbnQiHAoaU3VibWl0UnVubmVyRXZlbnRzUmVzcG9uc2UiZgoTUmVnaXN0ZXJlZFdvcmtzcGFjZRIMCgRuYW1lGAEgASgJEhEKCXJ1bm5lcl9pZBgCIAEoCRIuCgp1cGRhdGVkX2F0GAMgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCJiChlSZWdpc3RlcldvcmtzcGFjZXNSZXF1ZXN0EhEKCXJ1bm5lcl9pZBgBIAEoCRIyCgp3b3Jrc3BhY2VzGAIgAygLMh4ueGFnZW50LnYxLlJlZ2lzdGVyZWRXb3Jrc3BhY2UiHAoaUmVnaXN0ZXJXb3Jrc3BhY2VzUmVzcG9uc2UiFwoVTGlzdFdvcmtzcGFjZXNSZXF1ZXN0IkwKFkxpc3RXb3Jrc3BhY2VzUmVzcG9uc2USMgoKd29ya3NwYWNlcxgBIAMoCzIeLnhhZ2VudC52MS5SZWdpc3RlcmVkV29ya3NwYWNlIhgKFkNsZWFyV29ya3NwYWNlc1JlcXVlc3QiGQoXQ2xlYXJXb3Jrc3BhY2VzUmVzcG9uc2UythIKDVhBZ2VudFNlcnZpY2USRgoJTGlzdFRhc2tzEhsueGFnZW50LnYxLkxpc3RUYXNrc1JlcXVlc3QaHC54YWdlbnQudjEuTGlzdFRhc2tzUmVzcG9uc2USWAoPTGlzdFJ1bm5lclRhc2tzEiEueGFnZW50LnYxLkxpc3RSdW5uZXJUYXNrc1JlcXVlc3QaIi54YWdlbnQudjEuTGlzdFJ1bm5lclRhc2tzUmVzcG9uc2USVQoOTGlzdENoaWxkVGFza3MSIC54YWdlbnQudjEuTGlzdENoaWxkVGFza3NSZXF1ZXN0GiEueGFnZW50LnYxLkxpc3RDaGlsZFRhc2tzUmVzcG9uc2USSQoKQ3JlYXRlVGFzaxIcLnhhZ2VudC52MS5DcmVhdGVUYXNrUmVxdWVzdBodLnhhZ2VudC52MS5DcmVhdGVUYXNrUmVzcG9uc2USQAoHR2V0VGFzaxIZLnhhZ2VudC52MS5HZXRUYXNrUmVxdWVzdBoaLnhhZ2VudC52MS5HZXRUYXNrUmVzcG9uc2USVQoOR2V0VGFza0RldGFpbHMSIC54YWdlbnQudjEuR2V0VGFza0RldGFpbHNSZXF1ZXN0GiEueGFnZW50LnYxLkdldFRhc2tEZXRhaWxzUmVzcG9uc2USSQoKVXBkYXRlVGFzaxIcLnhhZ2VudC52MS5VcGRhdGVUYXNrUmVxdWVzdBodLnhhZ2VudC52MS5VcGRhdGVUYXNrUmVzcG9uc2USSQoKRGVsZXRlVGFzaxIcLnhhZ2VudC52MS5EZWxldGVUYXNrUmVxdWVzdBodLnhhZ2VudC52MS5EZWxldGVUYXNrUmVzcG9uc2USTAoLQXJjaGl2ZVRhc2sSHS54YWdlbnQudjEuQXJjaGl2ZVRhc2tSZXF1ZXN0Gh4ueGFnZW50LnYxLkFyY2hpdmVUYXNrUmVzcG9uc2USSQoKQ2FuY2VsVGFzaxIcLnhhZ2VudC52MS5DYW5jZWxUYXNrUmVxdWVzdBodLnhhZ2VudC52MS5DYW5jZWxUYXNrUmVzcG9uc2USTAoLUmVzdGFydFRhc2sSHS54YWdlbnQudjEuUmVzdGFydFRhc2tSZXF1ZXN0Gh4ueGFnZW50LnYxLlJlc3RhcnRUYXNrUmVzcG9uc2USSQoKVXBsb2FkTG9ncxIcLnhhZ2VudC52MS5VcGxvYWRMb2dzUmVxdWVzdBodLnhhZ2VudC52MS5VcGxvYWRMb2dzUmVzcG9uc2USQwoITGlzdExvZ3MSGi54YWdlbnQudjEuTGlzdExvZ3NSZXF1ZXN0GhsueGFnZW50LnYxLkxpc3RMb2dzUmVzcG9uc2USSQoKQ3JlYXRlTGluaxIcLnhhZ2VudC52MS5DcmVhdGVMaW5rUmVxdWVzdBodLnhhZ2VudC52MS5DcmVhdGVMaW5rUmVzcG9uc2USRgoJTGlzdExpbmtzEhsueGFnZW50LnYxLkxpc3RMaW5rc1JlcXVlc3QaHC54YWdlbnQudjEuTGlzdExpbmtzUmVzcG9uc2USVQoORmluZExpbmtzQnlVUkwSIC54YWdlbnQudjEuRmluZExpbmtzQnlVUkxSZXF1ZXN0GiEueGFnZW50LnYxLkZpbmRMaW5rc0J5VVJMUmVzcG9uc2USSQoKTGlzdEV2ZW50cxIcLnhhZ2VudC52MS5MaXN0RXZlbnRzUmVxdWVzdBodLnhhZ2VudC52MS5MaXN0RXZlbnRzUmVzcG9uc2USTAoLQ3JlYXRlRXZlbnQSHS54YWdlbnQudjEuQ3JlYXRlRXZlbnRSZXF1ZXN0Gh4ueGFnZW50LnYxLkNyZWF0ZUV2ZW50UmVzcG9uc2USQwoIR2V0RXZlbnQSGi54YWdlbnQudjEuR2V0RXZlbnRSZXF1ZXN0GhsueGFnZW50LnYxLkdldEV2ZW50UmVzcG9uc2USTAoLRGVsZXRlRXZlbnQSHS54YWdlbnQudjEuRGVsZXRlRXZlbnRSZXF1ZXN0Gh4ueGFnZW50LnYxLkRlbGV0ZUV2ZW50UmVzcG9uc2USTwoMQWRkRXZlbnRUYXNrEh4ueGFnZW50LnYxLkFkZEV2ZW50VGFza1JlcXVlc3QaHy54YWdlbnQudjEuQWRkRXZlbnRUYXNrUmVzcG9uc2USWAoPUmVtb3ZlRXZlbnRUYXNrEiEueGFnZW50LnYxLlJlbW92ZUV2ZW50VGFza1JlcXVlc3QaIi54YWdlbnQudjEuUmVtb3ZlRXZlbnRUYXNrUmVzcG9uc2USVQoOTGlzdEV2ZW50VGFza3MSIC54YWdlbnQudjEuTGlzdEV2ZW50VGFza3NSZXF1ZXN0GiEueGFnZW50LnYxLkxpc3RFdmVudFRhc2tzUmVzcG9uc2USWwoQTGlzdEV2ZW50c0J5VGFzaxIiLnhhZ2VudC52MS5MaXN0RXZlbnRzQnlUYXNrUmVxdWVzdBojLnhhZ2VudC52MS5MaXN0RXZlbnRzQnlUYXNrUmVzcG9uc2USTwoMUHJvY2Vzc0V2ZW50Eh4ueGFnZW50LnYxLlByb2Nlc3NFdmVudFJlcXVlc3QaHy54YWdlbnQudjEuUHJvY2Vzc0V2ZW50UmVzcG9uc2USYQoSU3VibWl0UnVubmVyRXZlbnRzEiQueGFnZW50LnYxLlN1Ym1pdFJ1bm5lckV2ZW50c1JlcXVlc3QaJS54YWdlbnQudjEuU3VibWl0UnVubmVyRXZlbnRzUmVzcG9uc2USYQoSUmVnaXN0ZXJXb3Jrc3BhY2VzEiQueGFnZW50LnYxLlJlZ2lzdGVyV29ya3NwYWNlc1JlcXVlc3QaJS54YWdlbnQudjEuUmVnaXN0ZXJXb3Jrc3BhY2VzUmVzcG9uc2USVQoOTGlzdFdvcmtzcGFjZXMSIC54YWdlbnQudjEuTGlzdFdvcmtzcGFjZXNSZXF1ZXN0GiEueGFnZW50LnYxLkxpc3RXb3Jrc3BhY2VzUmVzcG9uc2USWAoPQ2xlYXJXb3Jrc3BhY2VzEiEueGFnZW50LnYxLkNsZWFyV29ya3NwYWNlc1JlcXVlc3QaIi54YWdlbnQudjEuQ2xlYXJXb3Jrc3BhY2VzUmVzcG9uc2VCPFo6Z2l0aHViLmNvbS9pY2hvbHkveGFnZW50L2ludGVybmFsL3Byb3RvL3hhZ2VudC92MTt4YWdlbnR2MWIGcHJvdG8z", [file_google_protobuf_timestamp]);
 
 /**
  * @generated from message xagent.v1.Instruction
@@ -152,19 +152,6 @@ export const McpServerSchema: GenMessage<McpServer> = /*@__PURE__*/
  * @generated from message xagent.v1.ListTasksRequest
  */
 export type ListTasksRequest = Message<"xagent.v1.ListTasksRequest"> & {
-  /**
-   * If true, only return tasks with non-empty command
-   *
-   * @generated from field: bool has_command = 1;
-   */
-  hasCommand: boolean;
-
-  /**
-   * If set, only return tasks for this runner
-   *
-   * @generated from field: string runner = 2;
-   */
-  runner: string;
 };
 
 /**
@@ -192,6 +179,42 @@ export const ListTasksResponseSchema: GenMessage<ListTasksResponse> = /*@__PURE_
   messageDesc(file_xagent_v1_xagent, 4);
 
 /**
+ * @generated from message xagent.v1.ListRunnerTasksRequest
+ */
+export type ListRunnerTasksRequest = Message<"xagent.v1.ListRunnerTasksRequest"> & {
+  /**
+   * Runner ID (required)
+   *
+   * @generated from field: string runner = 1;
+   */
+  runner: string;
+};
+
+/**
+ * Describes the message xagent.v1.ListRunnerTasksRequest.
+ * Use `create(ListRunnerTasksRequestSchema)` to create a new message.
+ */
+export const ListRunnerTasksRequestSchema: GenMessage<ListRunnerTasksRequest> = /*@__PURE__*/
+  messageDesc(file_xagent_v1_xagent, 5);
+
+/**
+ * @generated from message xagent.v1.ListRunnerTasksResponse
+ */
+export type ListRunnerTasksResponse = Message<"xagent.v1.ListRunnerTasksResponse"> & {
+  /**
+   * @generated from field: repeated xagent.v1.Task tasks = 1;
+   */
+  tasks: Task[];
+};
+
+/**
+ * Describes the message xagent.v1.ListRunnerTasksResponse.
+ * Use `create(ListRunnerTasksResponseSchema)` to create a new message.
+ */
+export const ListRunnerTasksResponseSchema: GenMessage<ListRunnerTasksResponse> = /*@__PURE__*/
+  messageDesc(file_xagent_v1_xagent, 6);
+
+/**
  * @generated from message xagent.v1.ListChildTasksRequest
  */
 export type ListChildTasksRequest = Message<"xagent.v1.ListChildTasksRequest"> & {
@@ -206,7 +229,7 @@ export type ListChildTasksRequest = Message<"xagent.v1.ListChildTasksRequest"> &
  * Use `create(ListChildTasksRequestSchema)` to create a new message.
  */
 export const ListChildTasksRequestSchema: GenMessage<ListChildTasksRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 5);
+  messageDesc(file_xagent_v1_xagent, 7);
 
 /**
  * @generated from message xagent.v1.ListChildTasksResponse
@@ -223,7 +246,7 @@ export type ListChildTasksResponse = Message<"xagent.v1.ListChildTasksResponse">
  * Use `create(ListChildTasksResponseSchema)` to create a new message.
  */
 export const ListChildTasksResponseSchema: GenMessage<ListChildTasksResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 6);
+  messageDesc(file_xagent_v1_xagent, 8);
 
 /**
  * @generated from message xagent.v1.CreateTaskRequest
@@ -262,7 +285,7 @@ export type CreateTaskRequest = Message<"xagent.v1.CreateTaskRequest"> & {
  * Use `create(CreateTaskRequestSchema)` to create a new message.
  */
 export const CreateTaskRequestSchema: GenMessage<CreateTaskRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 7);
+  messageDesc(file_xagent_v1_xagent, 9);
 
 /**
  * @generated from message xagent.v1.CreateTaskResponse
@@ -279,7 +302,7 @@ export type CreateTaskResponse = Message<"xagent.v1.CreateTaskResponse"> & {
  * Use `create(CreateTaskResponseSchema)` to create a new message.
  */
 export const CreateTaskResponseSchema: GenMessage<CreateTaskResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 8);
+  messageDesc(file_xagent_v1_xagent, 10);
 
 /**
  * @generated from message xagent.v1.GetTaskRequest
@@ -296,7 +319,7 @@ export type GetTaskRequest = Message<"xagent.v1.GetTaskRequest"> & {
  * Use `create(GetTaskRequestSchema)` to create a new message.
  */
 export const GetTaskRequestSchema: GenMessage<GetTaskRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 9);
+  messageDesc(file_xagent_v1_xagent, 11);
 
 /**
  * @generated from message xagent.v1.GetTaskResponse
@@ -313,7 +336,7 @@ export type GetTaskResponse = Message<"xagent.v1.GetTaskResponse"> & {
  * Use `create(GetTaskResponseSchema)` to create a new message.
  */
 export const GetTaskResponseSchema: GenMessage<GetTaskResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 10);
+  messageDesc(file_xagent_v1_xagent, 12);
 
 /**
  * @generated from message xagent.v1.GetTaskDetailsRequest
@@ -330,7 +353,7 @@ export type GetTaskDetailsRequest = Message<"xagent.v1.GetTaskDetailsRequest"> &
  * Use `create(GetTaskDetailsRequestSchema)` to create a new message.
  */
 export const GetTaskDetailsRequestSchema: GenMessage<GetTaskDetailsRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 11);
+  messageDesc(file_xagent_v1_xagent, 13);
 
 /**
  * @generated from message xagent.v1.GetTaskDetailsResponse
@@ -362,7 +385,7 @@ export type GetTaskDetailsResponse = Message<"xagent.v1.GetTaskDetailsResponse">
  * Use `create(GetTaskDetailsResponseSchema)` to create a new message.
  */
 export const GetTaskDetailsResponseSchema: GenMessage<GetTaskDetailsResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 12);
+  messageDesc(file_xagent_v1_xagent, 14);
 
 /**
  * @generated from message xagent.v1.UpdateTaskRequest
@@ -396,7 +419,7 @@ export type UpdateTaskRequest = Message<"xagent.v1.UpdateTaskRequest"> & {
  * Use `create(UpdateTaskRequestSchema)` to create a new message.
  */
 export const UpdateTaskRequestSchema: GenMessage<UpdateTaskRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 13);
+  messageDesc(file_xagent_v1_xagent, 15);
 
 /**
  * @generated from message xagent.v1.UpdateTaskResponse
@@ -409,7 +432,7 @@ export type UpdateTaskResponse = Message<"xagent.v1.UpdateTaskResponse"> & {
  * Use `create(UpdateTaskResponseSchema)` to create a new message.
  */
 export const UpdateTaskResponseSchema: GenMessage<UpdateTaskResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 14);
+  messageDesc(file_xagent_v1_xagent, 16);
 
 /**
  * @generated from message xagent.v1.DeleteTaskRequest
@@ -426,7 +449,7 @@ export type DeleteTaskRequest = Message<"xagent.v1.DeleteTaskRequest"> & {
  * Use `create(DeleteTaskRequestSchema)` to create a new message.
  */
 export const DeleteTaskRequestSchema: GenMessage<DeleteTaskRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 15);
+  messageDesc(file_xagent_v1_xagent, 17);
 
 /**
  * @generated from message xagent.v1.DeleteTaskResponse
@@ -439,7 +462,7 @@ export type DeleteTaskResponse = Message<"xagent.v1.DeleteTaskResponse"> & {
  * Use `create(DeleteTaskResponseSchema)` to create a new message.
  */
 export const DeleteTaskResponseSchema: GenMessage<DeleteTaskResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 16);
+  messageDesc(file_xagent_v1_xagent, 18);
 
 /**
  * @generated from message xagent.v1.ArchiveTaskRequest
@@ -456,7 +479,7 @@ export type ArchiveTaskRequest = Message<"xagent.v1.ArchiveTaskRequest"> & {
  * Use `create(ArchiveTaskRequestSchema)` to create a new message.
  */
 export const ArchiveTaskRequestSchema: GenMessage<ArchiveTaskRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 17);
+  messageDesc(file_xagent_v1_xagent, 19);
 
 /**
  * @generated from message xagent.v1.ArchiveTaskResponse
@@ -469,7 +492,7 @@ export type ArchiveTaskResponse = Message<"xagent.v1.ArchiveTaskResponse"> & {
  * Use `create(ArchiveTaskResponseSchema)` to create a new message.
  */
 export const ArchiveTaskResponseSchema: GenMessage<ArchiveTaskResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 18);
+  messageDesc(file_xagent_v1_xagent, 20);
 
 /**
  * @generated from message xagent.v1.CancelTaskRequest
@@ -486,7 +509,7 @@ export type CancelTaskRequest = Message<"xagent.v1.CancelTaskRequest"> & {
  * Use `create(CancelTaskRequestSchema)` to create a new message.
  */
 export const CancelTaskRequestSchema: GenMessage<CancelTaskRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 19);
+  messageDesc(file_xagent_v1_xagent, 21);
 
 /**
  * @generated from message xagent.v1.CancelTaskResponse
@@ -499,7 +522,7 @@ export type CancelTaskResponse = Message<"xagent.v1.CancelTaskResponse"> & {
  * Use `create(CancelTaskResponseSchema)` to create a new message.
  */
 export const CancelTaskResponseSchema: GenMessage<CancelTaskResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 20);
+  messageDesc(file_xagent_v1_xagent, 22);
 
 /**
  * @generated from message xagent.v1.RestartTaskRequest
@@ -516,7 +539,7 @@ export type RestartTaskRequest = Message<"xagent.v1.RestartTaskRequest"> & {
  * Use `create(RestartTaskRequestSchema)` to create a new message.
  */
 export const RestartTaskRequestSchema: GenMessage<RestartTaskRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 21);
+  messageDesc(file_xagent_v1_xagent, 23);
 
 /**
  * @generated from message xagent.v1.RestartTaskResponse
@@ -529,7 +552,7 @@ export type RestartTaskResponse = Message<"xagent.v1.RestartTaskResponse"> & {
  * Use `create(RestartTaskResponseSchema)` to create a new message.
  */
 export const RestartTaskResponseSchema: GenMessage<RestartTaskResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 22);
+  messageDesc(file_xagent_v1_xagent, 24);
 
 /**
  * @generated from message xagent.v1.LogEntry
@@ -556,7 +579,7 @@ export type LogEntry = Message<"xagent.v1.LogEntry"> & {
  * Use `create(LogEntrySchema)` to create a new message.
  */
 export const LogEntrySchema: GenMessage<LogEntry> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 23);
+  messageDesc(file_xagent_v1_xagent, 25);
 
 /**
  * @generated from message xagent.v1.UploadLogsRequest
@@ -578,7 +601,7 @@ export type UploadLogsRequest = Message<"xagent.v1.UploadLogsRequest"> & {
  * Use `create(UploadLogsRequestSchema)` to create a new message.
  */
 export const UploadLogsRequestSchema: GenMessage<UploadLogsRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 24);
+  messageDesc(file_xagent_v1_xagent, 26);
 
 /**
  * @generated from message xagent.v1.UploadLogsResponse
@@ -591,7 +614,7 @@ export type UploadLogsResponse = Message<"xagent.v1.UploadLogsResponse"> & {
  * Use `create(UploadLogsResponseSchema)` to create a new message.
  */
 export const UploadLogsResponseSchema: GenMessage<UploadLogsResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 25);
+  messageDesc(file_xagent_v1_xagent, 27);
 
 /**
  * @generated from message xagent.v1.ListLogsRequest
@@ -608,7 +631,7 @@ export type ListLogsRequest = Message<"xagent.v1.ListLogsRequest"> & {
  * Use `create(ListLogsRequestSchema)` to create a new message.
  */
 export const ListLogsRequestSchema: GenMessage<ListLogsRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 26);
+  messageDesc(file_xagent_v1_xagent, 28);
 
 /**
  * @generated from message xagent.v1.ListLogsResponse
@@ -625,7 +648,7 @@ export type ListLogsResponse = Message<"xagent.v1.ListLogsResponse"> & {
  * Use `create(ListLogsResponseSchema)` to create a new message.
  */
 export const ListLogsResponseSchema: GenMessage<ListLogsResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 27);
+  messageDesc(file_xagent_v1_xagent, 29);
 
 /**
  * @generated from message xagent.v1.TaskLink
@@ -672,7 +695,7 @@ export type TaskLink = Message<"xagent.v1.TaskLink"> & {
  * Use `create(TaskLinkSchema)` to create a new message.
  */
 export const TaskLinkSchema: GenMessage<TaskLink> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 28);
+  messageDesc(file_xagent_v1_xagent, 30);
 
 /**
  * @generated from message xagent.v1.CreateLinkRequest
@@ -709,7 +732,7 @@ export type CreateLinkRequest = Message<"xagent.v1.CreateLinkRequest"> & {
  * Use `create(CreateLinkRequestSchema)` to create a new message.
  */
 export const CreateLinkRequestSchema: GenMessage<CreateLinkRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 29);
+  messageDesc(file_xagent_v1_xagent, 31);
 
 /**
  * @generated from message xagent.v1.CreateLinkResponse
@@ -726,7 +749,7 @@ export type CreateLinkResponse = Message<"xagent.v1.CreateLinkResponse"> & {
  * Use `create(CreateLinkResponseSchema)` to create a new message.
  */
 export const CreateLinkResponseSchema: GenMessage<CreateLinkResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 30);
+  messageDesc(file_xagent_v1_xagent, 32);
 
 /**
  * @generated from message xagent.v1.ListLinksRequest
@@ -743,7 +766,7 @@ export type ListLinksRequest = Message<"xagent.v1.ListLinksRequest"> & {
  * Use `create(ListLinksRequestSchema)` to create a new message.
  */
 export const ListLinksRequestSchema: GenMessage<ListLinksRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 31);
+  messageDesc(file_xagent_v1_xagent, 33);
 
 /**
  * @generated from message xagent.v1.ListLinksResponse
@@ -760,7 +783,7 @@ export type ListLinksResponse = Message<"xagent.v1.ListLinksResponse"> & {
  * Use `create(ListLinksResponseSchema)` to create a new message.
  */
 export const ListLinksResponseSchema: GenMessage<ListLinksResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 32);
+  messageDesc(file_xagent_v1_xagent, 34);
 
 /**
  * @generated from message xagent.v1.FindLinksByURLRequest
@@ -777,7 +800,7 @@ export type FindLinksByURLRequest = Message<"xagent.v1.FindLinksByURLRequest"> &
  * Use `create(FindLinksByURLRequestSchema)` to create a new message.
  */
 export const FindLinksByURLRequestSchema: GenMessage<FindLinksByURLRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 33);
+  messageDesc(file_xagent_v1_xagent, 35);
 
 /**
  * @generated from message xagent.v1.FindLinksByURLResponse
@@ -794,7 +817,7 @@ export type FindLinksByURLResponse = Message<"xagent.v1.FindLinksByURLResponse">
  * Use `create(FindLinksByURLResponseSchema)` to create a new message.
  */
 export const FindLinksByURLResponseSchema: GenMessage<FindLinksByURLResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 34);
+  messageDesc(file_xagent_v1_xagent, 36);
 
 /**
  * @generated from message xagent.v1.Event
@@ -831,7 +854,7 @@ export type Event = Message<"xagent.v1.Event"> & {
  * Use `create(EventSchema)` to create a new message.
  */
 export const EventSchema: GenMessage<Event> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 35);
+  messageDesc(file_xagent_v1_xagent, 37);
 
 /**
  * @generated from message xagent.v1.ListEventsRequest
@@ -850,7 +873,7 @@ export type ListEventsRequest = Message<"xagent.v1.ListEventsRequest"> & {
  * Use `create(ListEventsRequestSchema)` to create a new message.
  */
 export const ListEventsRequestSchema: GenMessage<ListEventsRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 36);
+  messageDesc(file_xagent_v1_xagent, 38);
 
 /**
  * @generated from message xagent.v1.ListEventsResponse
@@ -867,7 +890,7 @@ export type ListEventsResponse = Message<"xagent.v1.ListEventsResponse"> & {
  * Use `create(ListEventsResponseSchema)` to create a new message.
  */
 export const ListEventsResponseSchema: GenMessage<ListEventsResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 37);
+  messageDesc(file_xagent_v1_xagent, 39);
 
 /**
  * @generated from message xagent.v1.CreateEventRequest
@@ -894,7 +917,7 @@ export type CreateEventRequest = Message<"xagent.v1.CreateEventRequest"> & {
  * Use `create(CreateEventRequestSchema)` to create a new message.
  */
 export const CreateEventRequestSchema: GenMessage<CreateEventRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 38);
+  messageDesc(file_xagent_v1_xagent, 40);
 
 /**
  * @generated from message xagent.v1.CreateEventResponse
@@ -911,7 +934,7 @@ export type CreateEventResponse = Message<"xagent.v1.CreateEventResponse"> & {
  * Use `create(CreateEventResponseSchema)` to create a new message.
  */
 export const CreateEventResponseSchema: GenMessage<CreateEventResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 39);
+  messageDesc(file_xagent_v1_xagent, 41);
 
 /**
  * @generated from message xagent.v1.GetEventRequest
@@ -928,7 +951,7 @@ export type GetEventRequest = Message<"xagent.v1.GetEventRequest"> & {
  * Use `create(GetEventRequestSchema)` to create a new message.
  */
 export const GetEventRequestSchema: GenMessage<GetEventRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 40);
+  messageDesc(file_xagent_v1_xagent, 42);
 
 /**
  * @generated from message xagent.v1.GetEventResponse
@@ -945,7 +968,7 @@ export type GetEventResponse = Message<"xagent.v1.GetEventResponse"> & {
  * Use `create(GetEventResponseSchema)` to create a new message.
  */
 export const GetEventResponseSchema: GenMessage<GetEventResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 41);
+  messageDesc(file_xagent_v1_xagent, 43);
 
 /**
  * @generated from message xagent.v1.DeleteEventRequest
@@ -962,7 +985,7 @@ export type DeleteEventRequest = Message<"xagent.v1.DeleteEventRequest"> & {
  * Use `create(DeleteEventRequestSchema)` to create a new message.
  */
 export const DeleteEventRequestSchema: GenMessage<DeleteEventRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 42);
+  messageDesc(file_xagent_v1_xagent, 44);
 
 /**
  * @generated from message xagent.v1.DeleteEventResponse
@@ -975,7 +998,7 @@ export type DeleteEventResponse = Message<"xagent.v1.DeleteEventResponse"> & {
  * Use `create(DeleteEventResponseSchema)` to create a new message.
  */
 export const DeleteEventResponseSchema: GenMessage<DeleteEventResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 43);
+  messageDesc(file_xagent_v1_xagent, 45);
 
 /**
  * @generated from message xagent.v1.AddEventTaskRequest
@@ -997,7 +1020,7 @@ export type AddEventTaskRequest = Message<"xagent.v1.AddEventTaskRequest"> & {
  * Use `create(AddEventTaskRequestSchema)` to create a new message.
  */
 export const AddEventTaskRequestSchema: GenMessage<AddEventTaskRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 44);
+  messageDesc(file_xagent_v1_xagent, 46);
 
 /**
  * @generated from message xagent.v1.AddEventTaskResponse
@@ -1010,7 +1033,7 @@ export type AddEventTaskResponse = Message<"xagent.v1.AddEventTaskResponse"> & {
  * Use `create(AddEventTaskResponseSchema)` to create a new message.
  */
 export const AddEventTaskResponseSchema: GenMessage<AddEventTaskResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 45);
+  messageDesc(file_xagent_v1_xagent, 47);
 
 /**
  * @generated from message xagent.v1.RemoveEventTaskRequest
@@ -1032,7 +1055,7 @@ export type RemoveEventTaskRequest = Message<"xagent.v1.RemoveEventTaskRequest">
  * Use `create(RemoveEventTaskRequestSchema)` to create a new message.
  */
 export const RemoveEventTaskRequestSchema: GenMessage<RemoveEventTaskRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 46);
+  messageDesc(file_xagent_v1_xagent, 48);
 
 /**
  * @generated from message xagent.v1.RemoveEventTaskResponse
@@ -1045,7 +1068,7 @@ export type RemoveEventTaskResponse = Message<"xagent.v1.RemoveEventTaskResponse
  * Use `create(RemoveEventTaskResponseSchema)` to create a new message.
  */
 export const RemoveEventTaskResponseSchema: GenMessage<RemoveEventTaskResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 47);
+  messageDesc(file_xagent_v1_xagent, 49);
 
 /**
  * @generated from message xagent.v1.ListEventTasksRequest
@@ -1062,7 +1085,7 @@ export type ListEventTasksRequest = Message<"xagent.v1.ListEventTasksRequest"> &
  * Use `create(ListEventTasksRequestSchema)` to create a new message.
  */
 export const ListEventTasksRequestSchema: GenMessage<ListEventTasksRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 48);
+  messageDesc(file_xagent_v1_xagent, 50);
 
 /**
  * @generated from message xagent.v1.ListEventTasksResponse
@@ -1079,7 +1102,7 @@ export type ListEventTasksResponse = Message<"xagent.v1.ListEventTasksResponse">
  * Use `create(ListEventTasksResponseSchema)` to create a new message.
  */
 export const ListEventTasksResponseSchema: GenMessage<ListEventTasksResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 49);
+  messageDesc(file_xagent_v1_xagent, 51);
 
 /**
  * @generated from message xagent.v1.ListEventsByTaskRequest
@@ -1096,7 +1119,7 @@ export type ListEventsByTaskRequest = Message<"xagent.v1.ListEventsByTaskRequest
  * Use `create(ListEventsByTaskRequestSchema)` to create a new message.
  */
 export const ListEventsByTaskRequestSchema: GenMessage<ListEventsByTaskRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 50);
+  messageDesc(file_xagent_v1_xagent, 52);
 
 /**
  * @generated from message xagent.v1.ListEventsByTaskResponse
@@ -1113,7 +1136,7 @@ export type ListEventsByTaskResponse = Message<"xagent.v1.ListEventsByTaskRespon
  * Use `create(ListEventsByTaskResponseSchema)` to create a new message.
  */
 export const ListEventsByTaskResponseSchema: GenMessage<ListEventsByTaskResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 51);
+  messageDesc(file_xagent_v1_xagent, 53);
 
 /**
  * @generated from message xagent.v1.ProcessEventRequest
@@ -1130,7 +1153,7 @@ export type ProcessEventRequest = Message<"xagent.v1.ProcessEventRequest"> & {
  * Use `create(ProcessEventRequestSchema)` to create a new message.
  */
 export const ProcessEventRequestSchema: GenMessage<ProcessEventRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 52);
+  messageDesc(file_xagent_v1_xagent, 54);
 
 /**
  * @generated from message xagent.v1.ProcessEventResponse
@@ -1147,7 +1170,7 @@ export type ProcessEventResponse = Message<"xagent.v1.ProcessEventResponse"> & {
  * Use `create(ProcessEventResponseSchema)` to create a new message.
  */
 export const ProcessEventResponseSchema: GenMessage<ProcessEventResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 53);
+  messageDesc(file_xagent_v1_xagent, 55);
 
 /**
  * @generated from message xagent.v1.RunnerEvent
@@ -1185,7 +1208,7 @@ export type RunnerEvent = Message<"xagent.v1.RunnerEvent"> & {
  * Use `create(RunnerEventSchema)` to create a new message.
  */
 export const RunnerEventSchema: GenMessage<RunnerEvent> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 54);
+  messageDesc(file_xagent_v1_xagent, 56);
 
 /**
  * @generated from message xagent.v1.SubmitRunnerEventsRequest
@@ -1202,7 +1225,7 @@ export type SubmitRunnerEventsRequest = Message<"xagent.v1.SubmitRunnerEventsReq
  * Use `create(SubmitRunnerEventsRequestSchema)` to create a new message.
  */
 export const SubmitRunnerEventsRequestSchema: GenMessage<SubmitRunnerEventsRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 55);
+  messageDesc(file_xagent_v1_xagent, 57);
 
 /**
  * @generated from message xagent.v1.SubmitRunnerEventsResponse
@@ -1215,7 +1238,7 @@ export type SubmitRunnerEventsResponse = Message<"xagent.v1.SubmitRunnerEventsRe
  * Use `create(SubmitRunnerEventsResponseSchema)` to create a new message.
  */
 export const SubmitRunnerEventsResponseSchema: GenMessage<SubmitRunnerEventsResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 56);
+  messageDesc(file_xagent_v1_xagent, 58);
 
 /**
  * @generated from message xagent.v1.RegisteredWorkspace
@@ -1242,7 +1265,7 @@ export type RegisteredWorkspace = Message<"xagent.v1.RegisteredWorkspace"> & {
  * Use `create(RegisteredWorkspaceSchema)` to create a new message.
  */
 export const RegisteredWorkspaceSchema: GenMessage<RegisteredWorkspace> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 57);
+  messageDesc(file_xagent_v1_xagent, 59);
 
 /**
  * @generated from message xagent.v1.RegisterWorkspacesRequest
@@ -1264,7 +1287,7 @@ export type RegisterWorkspacesRequest = Message<"xagent.v1.RegisterWorkspacesReq
  * Use `create(RegisterWorkspacesRequestSchema)` to create a new message.
  */
 export const RegisterWorkspacesRequestSchema: GenMessage<RegisterWorkspacesRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 58);
+  messageDesc(file_xagent_v1_xagent, 60);
 
 /**
  * @generated from message xagent.v1.RegisterWorkspacesResponse
@@ -1277,7 +1300,7 @@ export type RegisterWorkspacesResponse = Message<"xagent.v1.RegisterWorkspacesRe
  * Use `create(RegisterWorkspacesResponseSchema)` to create a new message.
  */
 export const RegisterWorkspacesResponseSchema: GenMessage<RegisterWorkspacesResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 59);
+  messageDesc(file_xagent_v1_xagent, 61);
 
 /**
  * @generated from message xagent.v1.ListWorkspacesRequest
@@ -1290,7 +1313,7 @@ export type ListWorkspacesRequest = Message<"xagent.v1.ListWorkspacesRequest"> &
  * Use `create(ListWorkspacesRequestSchema)` to create a new message.
  */
 export const ListWorkspacesRequestSchema: GenMessage<ListWorkspacesRequest> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 60);
+  messageDesc(file_xagent_v1_xagent, 62);
 
 /**
  * @generated from message xagent.v1.ListWorkspacesResponse
@@ -1307,7 +1330,33 @@ export type ListWorkspacesResponse = Message<"xagent.v1.ListWorkspacesResponse">
  * Use `create(ListWorkspacesResponseSchema)` to create a new message.
  */
 export const ListWorkspacesResponseSchema: GenMessage<ListWorkspacesResponse> = /*@__PURE__*/
-  messageDesc(file_xagent_v1_xagent, 61);
+  messageDesc(file_xagent_v1_xagent, 63);
+
+/**
+ * @generated from message xagent.v1.ClearWorkspacesRequest
+ */
+export type ClearWorkspacesRequest = Message<"xagent.v1.ClearWorkspacesRequest"> & {
+};
+
+/**
+ * Describes the message xagent.v1.ClearWorkspacesRequest.
+ * Use `create(ClearWorkspacesRequestSchema)` to create a new message.
+ */
+export const ClearWorkspacesRequestSchema: GenMessage<ClearWorkspacesRequest> = /*@__PURE__*/
+  messageDesc(file_xagent_v1_xagent, 64);
+
+/**
+ * @generated from message xagent.v1.ClearWorkspacesResponse
+ */
+export type ClearWorkspacesResponse = Message<"xagent.v1.ClearWorkspacesResponse"> & {
+};
+
+/**
+ * Describes the message xagent.v1.ClearWorkspacesResponse.
+ * Use `create(ClearWorkspacesResponseSchema)` to create a new message.
+ */
+export const ClearWorkspacesResponseSchema: GenMessage<ClearWorkspacesResponse> = /*@__PURE__*/
+  messageDesc(file_xagent_v1_xagent, 65);
 
 /**
  * @generated from service xagent.v1.XAgentService
@@ -1320,6 +1369,14 @@ export const XAgentService: GenService<{
     methodKind: "unary";
     input: typeof ListTasksRequestSchema;
     output: typeof ListTasksResponseSchema;
+  },
+  /**
+   * @generated from rpc xagent.v1.XAgentService.ListRunnerTasks
+   */
+  listRunnerTasks: {
+    methodKind: "unary";
+    input: typeof ListRunnerTasksRequestSchema;
+    output: typeof ListRunnerTasksResponseSchema;
   },
   /**
    * @generated from rpc xagent.v1.XAgentService.ListChildTasks
@@ -1528,6 +1585,14 @@ export const XAgentService: GenService<{
     methodKind: "unary";
     input: typeof ListWorkspacesRequestSchema;
     output: typeof ListWorkspacesResponseSchema;
+  },
+  /**
+   * @generated from rpc xagent.v1.XAgentService.ClearWorkspaces
+   */
+  clearWorkspaces: {
+    methodKind: "unary";
+    input: typeof ClearWorkspacesRequestSchema;
+    output: typeof ClearWorkspacesResponseSchema;
   },
 }> = /*@__PURE__*/
   serviceDesc(file_xagent_v1_xagent, 0);

--- a/webui/src/routes/workspaces.index.tsx
+++ b/webui/src/routes/workspaces.index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { useQuery } from '@connectrpc/connect-query'
-import { listWorkspaces } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
+import { useQuery, useMutation } from '@connectrpc/connect-query'
+import { listWorkspaces, clearWorkspaces } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
 import { timestampDate } from '@bufbuild/protobuf/wkt'
 import {
   Table,
@@ -10,16 +10,24 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
 import { RelativeTime } from '@/components/relative-time'
+import { Trash2 } from 'lucide-react'
 
 export const Route = createFileRoute('/workspaces/')({
   component: WorkspacesPage,
 })
 
 function WorkspacesPage() {
-  const { data, isLoading, error } = useQuery(listWorkspaces, {}, {
+  const { data, isLoading, error, refetch } = useQuery(listWorkspaces, {}, {
     refetchInterval: 5000,
   })
+  const clearMutation = useMutation(clearWorkspaces)
+
+  const handleClear = async () => {
+    await clearMutation.mutateAsync({})
+    refetch()
+  }
 
   if (isLoading) {
     return (
@@ -43,6 +51,14 @@ function WorkspacesPage() {
     <div className="container mx-auto py-8 px-4">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Workspaces</h1>
+        <Button
+          variant="outline"
+          onClick={handleClear}
+          disabled={clearMutation.isPending || workspaces.length === 0}
+        >
+          <Trash2 className="h-4 w-4" />
+          Clear
+        </Button>
       </div>
       {workspaces.length === 0 ? (
         <div className="text-muted-foreground text-center py-8">


### PR DESCRIPTION
## Summary
- Add ClearWorkspaces RPC to proto definition for clearing all workspaces owned by the current user
- Implement Clear method in WorkspaceRepository and ClearWorkspaces handler in server
- Add Clear button to workspaces frontend page with disabled state when no workspaces exist

## Test plan
- [x] Added unit tests for ClearWorkspaces handler
- [x] Added permissions tests ensuring users can only clear their own workspaces
- [x] Verified all existing tests still pass
- [x] Built Go and frontend successfully