### PR TITLE
Add graceful server shutdown with signal handling

### DIFF
--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -2,9 +2,14 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/icholy/xagent/internal/apiauth"
 	"github.com/icholy/xagent/internal/deviceauth"
@@ -107,10 +112,34 @@ var ServerCommand = &cli.Command{
 			},
 		})
 
+		httpServer := &http.Server{
+			Addr:    addr,
+			Handler: srv.Handler(),
+		}
+
+		// Set up signal handler for graceful shutdown
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+		go func() {
+			sig := <-sigCh
+			slog.Info("received signal, shutting down", "signal", sig)
+
+			// Give active requests time to complete
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			if err := httpServer.Shutdown(shutdownCtx); err != nil {
+				slog.Error("shutdown error", "error", err)
+			}
+		}()
+
 		slog.Info("starting server", "addr", addr, "db", dbPath)
-		if err := http.ListenAndServe(addr, srv.Handler()); err != nil {
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			return fmt.Errorf("server error: %w", err)
 		}
+
+		slog.Info("server stopped")
 		return nil
 	},
 }


### PR DESCRIPTION
## Summary
- Handle SIGINT and SIGTERM signals to trigger graceful server shutdown
- Use `http.Server` with `Shutdown()` method instead of `http.ListenAndServe` for controlled termination
- Give active requests 30 seconds to complete before forceful shutdown

## Test plan
- [ ] Start server and send SIGTERM, verify clean shutdown message appears
- [ ] Start server with active connections, send SIGTERM, verify connections complete gracefully
- [ ] Verify server still starts and runs normally without signals