### PR TITLE
Increase frontend polling interval to 6 seconds

### DIFF
--- a/webui/src/routes/events.$id.tsx
+++ b/webui/src/routes/events.$id.tsx
@@ -15,13 +15,13 @@ function EventDetail() {
   const { data: eventData, isLoading: eventLoading, error: eventError } = useQuery(
     getEvent,
     { id: eventId },
-    { refetchInterval: 3000 }
+    { refetchInterval: 6000 }
   )
 
   const { data: tasksData, isLoading: tasksLoading } = useQuery(
     listEventTasks,
     { eventId },
-    { refetchInterval: 3000 }
+    { refetchInterval: 6000 }
   )
 
   if (eventLoading) {

--- a/webui/src/routes/events.index.tsx
+++ b/webui/src/routes/events.index.tsx
@@ -30,7 +30,7 @@ export const Route = createFileRoute('/events/')({
 function EventsPage() {
   const [limit, setLimit] = useState(25)
   const { data, isLoading, error } = useQuery(listEvents, { limit }, {
-    refetchInterval: 3000,
+    refetchInterval: 6000,
   })
 
   if (isLoading) {

--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -48,13 +48,13 @@ function TaskDetail() {
   const { data, isLoading, error, refetch } = useQuery(
     getTaskDetails,
     { id: taskId },
-    { refetchInterval: 3000 }
+    { refetchInterval: 6000 }
   )
 
   const { data: logsData } = useQuery(
     listLogs,
     { taskId },
-    { refetchInterval: 3000 }
+    { refetchInterval: 6000 }
   )
 
   const updateMutation = useMutation(updateTask)

--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -33,7 +33,7 @@ function TasksPage() {
   const [searchQuery, setSearchQuery] = useState('')
 
   const { data, isLoading, error, refetch } = useQuery(listTasks, {}, {
-    refetchInterval: 3000,
+    refetchInterval: 6000,
   })
 
   if (isLoading) {

--- a/webui/src/routes/workspaces.index.tsx
+++ b/webui/src/routes/workspaces.index.tsx
@@ -31,7 +31,7 @@ const ALL_RUNNERS = '\x00'
 function WorkspacesPage() {
   const [selectedRunner, setSelectedRunner] = useState(ALL_RUNNERS)
   const { data, isLoading, error, refetch } = useQuery(listWorkspaces, {}, {
-    refetchInterval: 5000,
+    refetchInterval: 6000,
   })
   const clearMutation = useMutation(clearWorkspaces)
 


### PR DESCRIPTION
## Summary

- Update all `refetchInterval` values in the webui routes from 3000ms/5000ms to 6000ms
- Affects polling for tasks list, task details, logs, workspaces, events list, and event details

## Files Changed

- `webui/src/routes/tasks.index.tsx` - tasks list polling
- `webui/src/routes/tasks.$id.tsx` - task details and logs polling
- `webui/src/routes/workspaces.index.tsx` - workspaces list polling
- `webui/src/routes/events.index.tsx` - events list polling
- `webui/src/routes/events.$id.tsx` - event details polling