### PR TITLE
Log token refresh errors for debugging

### DIFF
--- a/internal/deviceauth/deviceauth.go
+++ b/internal/deviceauth/deviceauth.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"sync"
 	"time"
@@ -112,7 +113,9 @@ func (a *Auth) Token(ctx context.Context) (string, error) {
 	}
 	// Try to refresh
 	if a.token != nil && a.token.RefreshToken != "" {
-		if err := a.refresh(ctx); err == nil {
+		if err := a.refresh(ctx); err != nil {
+			slog.Error("token refresh failed", "error", err)
+		} else {
 			return a.token.AccessToken, nil
 		}
 	}


### PR DESCRIPTION
## Summary

Previously, when token refresh failed, the error was silently discarded and only a generic `ErrNoToken` was returned. This made it impossible to diagnose why the refresh failed.

Now the actual refresh error is logged using `slog.Error` before returning `ErrNoToken`, giving operators visibility into the root cause of token refresh failures.

## Changes

- Add `log/slog` import
- Log refresh errors with `slog.Error("token refresh failed", "error", err)` before returning `ErrNoToken`

## Test plan

- Build the package: `go build ./internal/deviceauth/...` ✅
- Manual testing: After deployment, token refresh failures will now appear in logs with the actual error message

Fixes #268