### PR TITLE
Fix task archiving and cancellation logic

### DIFF
--- a/internal/model/task.go
+++ b/internal/model/task.go
@@ -239,8 +239,12 @@ func (t *Task) applyRunnerEventFailed() bool {
 
 // Archive transitions the task to archived status.
 // Returns true if the transition is valid and was applied.
-// Only valid from completed, failed, or cancelled status.
+// Only valid from completed, failed, or cancelled status, and only if there is no pending command.
 func (t *Task) Archive() bool {
+	// Cannot archive if there's a pending command - the runner might pick it up
+	if t.Command != "" {
+		return false
+	}
 	switch t.Status {
 	case TaskStatusCompleted, TaskStatusFailed, TaskStatusCancelled:
 		t.Status = TaskStatusArchived
@@ -254,6 +258,7 @@ func (t *Task) Archive() bool {
 // Returns true if the transition is valid and was applied.
 // For running or restarting tasks: sets status to cancelling, command to stop, increments version.
 // For pending tasks: sets status to cancelled directly (no runner action needed).
+// For terminal states with a pending command: clears the command to prevent runner from picking it up.
 func (t *Task) Cancel() bool {
 	switch t.Status {
 	case TaskStatusRunning, TaskStatusRestarting:
@@ -263,7 +268,15 @@ func (t *Task) Cancel() bool {
 		return true
 	case TaskStatusPending:
 		t.Status = TaskStatusCancelled
+		t.Command = ""
 		return true
+	case TaskStatusCompleted, TaskStatusFailed, TaskStatusCancelled:
+		// Allow cancelling if there's a pending command to clear
+		if t.Command != "" {
+			t.Command = ""
+			return true
+		}
+		return false
 	default:
 		return false
 	}

--- a/internal/model/task_test.go
+++ b/internal/model/task_test.go
@@ -399,6 +399,24 @@ func TestTask_Archive(t *testing.T) {
 			after:  Task{Status: TaskStatusArchived},
 			want:   false,
 		},
+		{
+			name:   "from completed with command fails",
+			before: Task{Status: TaskStatusCompleted, Command: TaskCommandStart},
+			after:  Task{Status: TaskStatusCompleted, Command: TaskCommandStart},
+			want:   false,
+		},
+		{
+			name:   "from failed with command fails",
+			before: Task{Status: TaskStatusFailed, Command: TaskCommandRestart},
+			after:  Task{Status: TaskStatusFailed, Command: TaskCommandRestart},
+			want:   false,
+		},
+		{
+			name:   "from cancelled with command fails",
+			before: Task{Status: TaskStatusCancelled, Command: TaskCommandStart},
+			after:  Task{Status: TaskStatusCancelled, Command: TaskCommandStart},
+			want:   false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -431,16 +449,34 @@ func TestTask_Cancel(t *testing.T) {
 			want:   true,
 		},
 		{
-			name:   "from completed fails",
+			name:   "from pending with command clears command",
+			before: Task{Status: TaskStatusPending, Command: TaskCommandStart},
+			after:  Task{Status: TaskStatusCancelled},
+			want:   true,
+		},
+		{
+			name:   "from completed fails without command",
 			before: Task{Status: TaskStatusCompleted},
 			after:  Task{Status: TaskStatusCompleted},
 			want:   false,
 		},
 		{
-			name:   "from failed fails",
+			name:   "from completed with command clears command",
+			before: Task{Status: TaskStatusCompleted, Command: TaskCommandStart},
+			after:  Task{Status: TaskStatusCompleted},
+			want:   true,
+		},
+		{
+			name:   "from failed fails without command",
 			before: Task{Status: TaskStatusFailed},
 			after:  Task{Status: TaskStatusFailed},
 			want:   false,
+		},
+		{
+			name:   "from failed with command clears command",
+			before: Task{Status: TaskStatusFailed, Command: TaskCommandRestart},
+			after:  Task{Status: TaskStatusFailed},
+			want:   true,
 		},
 		{
 			name:   "from restarting succeeds",
@@ -455,10 +491,16 @@ func TestTask_Cancel(t *testing.T) {
 			want:   false,
 		},
 		{
-			name:   "from cancelled fails",
+			name:   "from cancelled fails without command",
 			before: Task{Status: TaskStatusCancelled},
 			after:  Task{Status: TaskStatusCancelled},
 			want:   false,
+		},
+		{
+			name:   "from cancelled with command clears command",
+			before: Task{Status: TaskStatusCancelled, Command: TaskCommandStart},
+			after:  Task{Status: TaskStatusCancelled},
+			want:   true,
 		},
 		{
 			name:   "from archived fails",

--- a/webui/src/lib/task.ts
+++ b/webui/src/lib/task.ts
@@ -1,6 +1,6 @@
 import type { Task } from '@/gen/xagent/v1/xagent_pb'
 
-type TaskLike = Pick<Task, 'status'>
+type TaskLike = Pick<Task, 'status' | 'command'>
 type TaskWithParent = Pick<Task, 'parent'>
 
 export function isChildTask(task: TaskWithParent): boolean {
@@ -8,11 +8,15 @@ export function isChildTask(task: TaskWithParent): boolean {
 }
 
 export function canArchiveTask(task: TaskLike): boolean {
-  return task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled'
+  const isTerminal = task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled'
+  const hasCommand = task.command !== ''
+  return isTerminal && !hasCommand
 }
 
 export function canCancelTask(task: TaskLike): boolean {
-  return task.status === 'pending' || task.status === 'running' || task.status === 'restarting'
+  const isActive = task.status === 'pending' || task.status === 'running' || task.status === 'restarting'
+  const hasCommand = task.command !== ''
+  return isActive || hasCommand
 }
 
 export function canRestartTask(task: TaskLike): boolean {


### PR DESCRIPTION
## Summary

- Prevent archiving tasks that have a pending command (start/restart/stop) since the runner might pick them up before the archive completes
- Allow cancelling tasks in terminal states (completed/failed/cancelled) when they have a pending command, to clear the command and prevent unintended restarts

## Changes

**Backend (`internal/model/task.go`):**
- `Archive()` now returns `false` if the task has a non-empty command
- `Cancel()` now allows cancelling terminal state tasks (completed/failed/cancelled) if they have a pending command, clearing the command

**Frontend (`webui/src/lib/task.ts`):**
- `canArchiveTask()` now checks that `command` is empty before allowing archive
- `canCancelTask()` now returns `true` for terminal state tasks with a pending command

## Test plan

- [x] Backend unit tests updated and passing
- [x] Frontend TypeScript compiles successfully
- [ ] Manual testing: Verify archive button is disabled for tasks with pending commands
- [ ] Manual testing: Verify cancel button is enabled for completed/failed/cancelled tasks with pending commands