### PR TITLE
Return error when socket removal fails

### DIFF
--- a/internal/xagentclient/unix.go
+++ b/internal/xagentclient/unix.go
@@ -1,6 +1,7 @@
 package xagentclient
 
 import (
+	"errors"
 	"net"
 	"net/http"
 	"os"
@@ -14,7 +15,9 @@ type UnixProxy struct {
 
 func NewUnixProxy(path string, handler http.Handler) (*UnixProxy, error) {
 	// Remove existing socket file
-	os.Remove(path)
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
 
 	listener, err := net.Listen("unix", path)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix socket removal to return errors instead of silently ignoring them
- Only ignore `os.ErrNotExist` errors (expected when socket doesn't exist)
- Makes permission denied errors visible at the source rather than later during `net.Listen`

Fixes #278