### PR TITLE
Move private key generation from Runner to AgentProxy

### DIFF
--- a/internal/runner/proxy.go
+++ b/internal/runner/proxy.go
@@ -26,15 +26,21 @@ type AgentProxy struct {
 	socketPath string
 }
 
-// NewProxy creates a new Proxy.
-func NewProxy(serverURL string, auth xagentclient.TokenSource, privateKey ed25519.PrivateKey, log *slog.Logger) *AgentProxy {
+// NewProxy creates a new Proxy. The secretFile is the path to the Ed25519
+// private key used for signing and verifying agent tokens. If the file does
+// not exist, a new key is generated and saved.
+func NewProxy(serverURL string, auth xagentclient.TokenSource, secretFile string, log *slog.Logger) (*AgentProxy, error) {
+	privateKey, err := agentauth.LoadOrCreatePrivateKey(secretFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load private key: %w", err)
+	}
 	return &AgentProxy{
 		serverURL:  serverURL,
 		auth:       auth,
 		privateKey: privateKey,
 		log:        log,
 		socketPath: randomSocketPath(),
-	}
+	}, nil
 }
 
 // randomSocketPath generates a random socket path in the system temp directory.
@@ -47,6 +53,11 @@ func randomSocketPath() string {
 // SocketPath returns the path to the Unix socket.
 func (p *AgentProxy) SocketPath() string {
 	return p.socketPath
+}
+
+// SignToken creates a JWT signed with the proxy's private key.
+func (p *AgentProxy) SignToken(claims *agentauth.TaskClaims) (string, error) {
+	return agentauth.SignToken(p.privateKey, claims)
 }
 
 // Start creates and starts the proxy.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"cmp"
 	"context"
-	"crypto/ed25519"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -36,7 +35,6 @@ type Runner struct {
 	docker      *client.Client
 	client      xagentclient.Client
 	proxy       *AgentProxy
-	privateKey  ed25519.PrivateKey
 	prebuiltDir string
 	workspaces  *workspace.Config
 	runnerID    string
@@ -62,12 +60,6 @@ func New(opts Options) (*Runner, error) {
 		return nil, fmt.Errorf("failed to create docker client: %w", err)
 	}
 
-	// Load or create private key
-	privateKey, err := agentauth.LoadOrCreatePrivateKey(opts.SecretFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load private key: %w", err)
-	}
-
 	// Use math.MaxInt64 if no limit is set (concurrency <= 0)
 	concurrency := int64(opts.Concurrency)
 	if concurrency <= 0 {
@@ -76,7 +68,10 @@ func New(opts Options) (*Runner, error) {
 
 	log := cmp.Or(opts.Log, slog.Default())
 
-	proxy := NewProxy(opts.ServerURL, opts.Auth, privateKey, log)
+	proxy, err := NewProxy(opts.ServerURL, opts.Auth, opts.SecretFile, log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create proxy: %w", err)
+	}
 	if err := proxy.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start proxy: %w", err)
 	}
@@ -85,7 +80,6 @@ func New(opts Options) (*Runner, error) {
 		docker:      docker,
 		client:      xagentclient.New(opts.ServerURL, opts.Auth),
 		proxy:       proxy,
-		privateKey:  privateKey,
 		prebuiltDir: opts.PrebuiltDir,
 		workspaces:  opts.Workspaces,
 		runnerID:    opts.RunnerID,
@@ -356,7 +350,7 @@ func (r *Runner) create(ctx context.Context, task *model.Task) (string, error) {
 	}
 
 	// Generate JWT for this task
-	token, err := agentauth.SignToken(r.privateKey, &agentauth.TaskClaims{
+	token, err := r.proxy.SignToken(&agentauth.TaskClaims{
 		TaskID:    task.ID,
 		Workspace: task.Workspace,
 		Runner:    task.Runner,


### PR DESCRIPTION
## Summary

- `AgentProxy.NewProxy` now accepts a `secretFile` path instead of a pre-loaded `ed25519.PrivateKey`, and calls `agentauth.LoadOrCreatePrivateKey` internally
- Added `AgentProxy.SignToken` method so the Runner can sign JWTs via the proxy instead of holding its own key
- Removed the `privateKey` field from `Runner` — the proxy is now the single owner of the private key