### PR TITLE
Use fixed socket path for agent proxy

### DIFF
--- a/internal/runner/proxy.go
+++ b/internal/runner/proxy.go
@@ -2,8 +2,6 @@ package runner
 
 import (
 	"crypto/ed25519"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -33,15 +31,15 @@ func NewProxy(serverURL string, auth xagentclient.TokenSource, privateKey ed2551
 		auth:       auth,
 		privateKey: privateKey,
 		log:        log,
-		socketPath: randomSocketPath(),
+		socketPath: socketPath(),
 	}
 }
 
-// randomSocketPath generates a random socket path in the system temp directory.
-func randomSocketPath() string {
-	var b [8]byte
-	rand.Read(b[:])
-	return filepath.Join(os.TempDir(), "xagent-"+hex.EncodeToString(b[:])+".sock")
+// socketPath returns a fixed socket path in the system temp directory.
+// Using a fixed path ensures that existing containers with bind mounts
+// to this socket can be restarted after a runner reboot.
+func socketPath() string {
+	return filepath.Join(os.TempDir(), "xagent.sock")
 }
 
 // SocketPath returns the path to the Unix socket.


### PR DESCRIPTION
## Summary

- Use a deterministic socket path (`/tmp/xagent.sock`) instead of a random one for the agent proxy
- Existing containers can now be restarted after a runner reboot without failing due to stale bind mounts

## Problem

After rebooting the server and restarting the runner, tasks failed to start with:

```
OCI runtime create failed: ... error mounting "/tmp/xagent-5f5d740ff1affa32.sock" to rootfs at "/var/run/xagent.sock": not a directory
```

The runner generated a new random socket path on each startup. Existing stopped containers still had bind mounts pointing to the old socket path, which no longer existed. Docker would create a directory at the missing path, causing a type mismatch with the container's mount target.

## Fix

Replace `randomSocketPath()` with a fixed path (`/tmp/xagent.sock`). Since there's a single proxy per runner shared by all tasks, the random path served no purpose. A fixed path ensures bind mounts remain valid across runner restarts, preserving container state and agent context.

Fixes #285