### PR TITLE
Update pnpm from v9 to v10 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Update pnpm version from 9 to 10 in the GitHub Actions CI workflow
- The local `mise.toml` already uses `pnpm = "latest"` which resolves to v10
- The lockfile format (v9.0) is compatible with pnpm 10 — no lockfile changes needed

## Test plan
- [x] Verified `pnpm install --frozen-lockfile` works with pnpm 10
- [x] Verified `vite build` succeeds
- [ ] CI pipeline should pass with pnpm 10