### PR TITLE
Disable auth in docker-compose server service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
 
   server:
     build: .
+    command: ["./xagent", "server", "--no-auth"]
     ports:
       - "6464:6464"
     env_file: .env


### PR DESCRIPTION
Adds `--no-auth` flag to the server command in docker-compose so the setup runs without authentication by default. When `--no-auth` is enabled, all requests are authenticated as a default dev user (`dev@localhost`).