### PR TITLE
Remove unused imports in tasks.index.tsx

### DIFF
--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -2,10 +2,10 @@ import { useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useQuery, useMutation } from '@connectrpc/connect-query'
 import { useLocalStorage } from 'usehooks-ts'
-import { listTasks, archiveTask, unarchiveTask } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
+import { listTasks, archiveTask } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
 import type { Task } from '@/gen/xagent/v1/xagent_pb'
 import { timestampDate } from '@bufbuild/protobuf/wkt'
-import { canArchiveTask, canUnarchiveTask, isChildTask } from '@/lib/task'
+import { canArchiveTask, isChildTask } from '@/lib/task'
 import {
   Table,
   TableBody,


### PR DESCRIPTION
## Summary

- Remove unused `unarchiveTask` import from connect-query generated code
- Remove unused `canUnarchiveTask` import from `@/lib/task`

These unused imports were causing TS6133 errors in the FE pipeline build.