### PR TITLE
Replace --token-file with --token flag in task subcommands

### DIFF
--- a/internal/command/task.go
+++ b/internal/command/task.go
@@ -1,6 +1,11 @@
 package command
 
-import "github.com/urfave/cli/v3"
+import (
+	"fmt"
+
+	"github.com/icholy/xagent/internal/xagentclient"
+	"github.com/urfave/cli/v3"
+)
 
 var TaskCommand = &cli.Command{
 	Name:  "task",
@@ -11,4 +16,18 @@ var TaskCommand = &cli.Command{
 		TaskUpdateCommand,
 		TaskDeleteCommand,
 	},
+}
+
+var tokenFlag = &cli.StringFlag{
+	Name:    "token",
+	Usage:   "Authentication token (e.g. API key)",
+	Sources: cli.EnvVars("XAGENT_TOKEN"),
+}
+
+func tokenSourceFromCmd(cmd *cli.Command) (xagentclient.TokenSource, error) {
+	token := cmd.String("token")
+	if token == "" {
+		return nil, fmt.Errorf("token is required (set --token or XAGENT_TOKEN)")
+	}
+	return xagentclient.StaticTokenSource(token), nil
 }

--- a/internal/command/task_create.go
+++ b/internal/command/task_create.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/icholy/xagent/internal/deviceauth"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/xagentclient"
 	"github.com/urfave/cli/v3"
@@ -23,12 +22,7 @@ var TaskCreateCommand = &cli.Command{
 			Value:   xagentclient.DefaultURL,
 			Sources: cli.EnvVars("XAGENT_SERVER"),
 		},
-		&cli.StringFlag{
-			Name:    "token-file",
-			Usage:   "Path to authentication token file",
-			Value:   "data/token.json",
-			Sources: cli.EnvVars("XAGENT_TOKEN_FILE"),
-		},
+		tokenFlag,
 		&cli.StringFlag{
 			Name:    "name",
 			Aliases: []string{"n"},
@@ -54,14 +48,11 @@ var TaskCreateCommand = &cli.Command{
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		serverURL := cmd.String("server")
-		auth, err := deviceauth.New(deviceauth.Options{
-			DiscoveryURL: deviceauth.DiscoveryURL(serverURL),
-			TokenFile:    cmd.String("token-file"),
-		})
+		tokenSource, err := tokenSourceFromCmd(cmd)
 		if err != nil {
-			return fmt.Errorf("failed to initialize auth: %w", err)
+			return err
 		}
-		client := xagentclient.New(serverURL, auth)
+		client := xagentclient.New(serverURL, tokenSource)
 
 		texts := cmd.StringSlice("instruction")
 		instructions := make([]*xagentv1.Instruction, len(texts))

--- a/internal/command/task_delete.go
+++ b/internal/command/task_delete.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/icholy/xagent/internal/deviceauth"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/xagentclient"
 	"github.com/urfave/cli/v3"
@@ -23,12 +22,7 @@ var TaskDeleteCommand = &cli.Command{
 			Value:   xagentclient.DefaultURL,
 			Sources: cli.EnvVars("XAGENT_SERVER"),
 		},
-		&cli.StringFlag{
-			Name:    "token-file",
-			Usage:   "Path to authentication token file",
-			Value:   "data/token.json",
-			Sources: cli.EnvVars("XAGENT_TOKEN_FILE"),
-		},
+		tokenFlag,
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		taskIDStr := cmd.Args().First()
@@ -41,14 +35,11 @@ var TaskDeleteCommand = &cli.Command{
 		}
 
 		serverURL := cmd.String("server")
-		auth, err := deviceauth.New(deviceauth.Options{
-			DiscoveryURL: deviceauth.DiscoveryURL(serverURL),
-			TokenFile:    cmd.String("token-file"),
-		})
+		tokenSource, err := tokenSourceFromCmd(cmd)
 		if err != nil {
-			return fmt.Errorf("failed to initialize auth: %w", err)
+			return err
 		}
-		client := xagentclient.New(serverURL, auth)
+		client := xagentclient.New(serverURL, tokenSource)
 		if _, err := client.DeleteTask(ctx, &xagentv1.DeleteTaskRequest{Id: taskID}); err != nil {
 			return fmt.Errorf("failed to delete task: %w", err)
 		}

--- a/internal/command/task_list.go
+++ b/internal/command/task_list.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/icholy/xagent/internal/deviceauth"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/xagentclient"
 	"github.com/urfave/cli/v3"
@@ -24,23 +23,15 @@ var TaskListCommand = &cli.Command{
 			Value:   xagentclient.DefaultURL,
 			Sources: cli.EnvVars("XAGENT_SERVER"),
 		},
-		&cli.StringFlag{
-			Name:    "token-file",
-			Usage:   "Path to authentication token file",
-			Value:   "data/token.json",
-			Sources: cli.EnvVars("XAGENT_TOKEN_FILE"),
-		},
+		tokenFlag,
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		serverURL := cmd.String("server")
-		auth, err := deviceauth.New(deviceauth.Options{
-			DiscoveryURL: deviceauth.DiscoveryURL(serverURL),
-			TokenFile:    cmd.String("token-file"),
-		})
+		tokenSource, err := tokenSourceFromCmd(cmd)
 		if err != nil {
-			return fmt.Errorf("failed to initialize auth: %w", err)
+			return err
 		}
-		client := xagentclient.New(serverURL, auth)
+		client := xagentclient.New(serverURL, tokenSource)
 
 		resp, err := client.ListTasks(ctx, &xagentv1.ListTasksRequest{})
 		if err != nil {

--- a/internal/command/task_update.go
+++ b/internal/command/task_update.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/icholy/xagent/internal/deviceauth"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/xagentclient"
 	"github.com/urfave/cli/v3"
@@ -23,12 +22,7 @@ var TaskUpdateCommand = &cli.Command{
 			Value:   xagentclient.DefaultURL,
 			Sources: cli.EnvVars("XAGENT_SERVER"),
 		},
-		&cli.StringFlag{
-			Name:    "token-file",
-			Usage:   "Path to authentication token file",
-			Value:   "data/token.json",
-			Sources: cli.EnvVars("XAGENT_TOKEN_FILE"),
-		},
+		tokenFlag,
 		&cli.StringFlag{
 			Name:    "name",
 			Aliases: []string{"n"},
@@ -69,14 +63,11 @@ var TaskUpdateCommand = &cli.Command{
 		}
 
 		serverURL := cmd.String("server")
-		auth, err := deviceauth.New(deviceauth.Options{
-			DiscoveryURL: deviceauth.DiscoveryURL(serverURL),
-			TokenFile:    cmd.String("token-file"),
-		})
+		tokenSource, err := tokenSourceFromCmd(cmd)
 		if err != nil {
-			return fmt.Errorf("failed to initialize auth: %w", err)
+			return err
 		}
-		client := xagentclient.New(serverURL, auth)
+		client := xagentclient.New(serverURL, tokenSource)
 		if _, err := client.UpdateTask(ctx, &xagentv1.UpdateTaskRequest{
 			Id:              taskID,
 			Name:            name,

--- a/internal/xagentclient/transport.go
+++ b/internal/xagentclient/transport.go
@@ -10,6 +10,13 @@ type TokenSource interface {
 	Token(ctx context.Context) (string, error)
 }
 
+// StaticTokenSource returns a fixed token.
+type StaticTokenSource string
+
+func (s StaticTokenSource) Token(_ context.Context) (string, error) {
+	return string(s), nil
+}
+
 // AuthTransport injects Bearer tokens into requests.
 type AuthTransport struct {
 	Transport http.RoundTripper


### PR DESCRIPTION
## Summary

- Task subcommands (`create`, `list`, `update`, `delete`) now accept `--token` flag (sourced from `XAGENT_TOKEN` env var) for direct token authentication
- Replaces the `--token-file` / `XAGENT_TOKEN_FILE` approach that the runner uses
- Adds `StaticTokenSource` to `xagentclient` for passing raw tokens without the device auth flow
- Runner and other long-running services continue to use `--token-file`

## Usage

```bash
# Using environment variable
export XAGENT_TOKEN=xat_abc123...
xagent task list

# Using flag
xagent task create --token xat_abc123... -r runner1 -i "do something"
```