### PR TITLE
Refactor deviceauth: separate token loading from device flow

### DIFF
--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -35,7 +35,7 @@ var LoginCommand = &cli.Command{
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		serverAddr := cmd.String("server")
-		auth, err := deviceauth.New(deviceauth.Options{
+		if err := deviceauth.DeviceFlow(ctx, deviceauth.DeviceFlowOptions{
 			DiscoveryURL: deviceauth.DiscoveryURL(serverAddr),
 			ServerURL:    serverAddr,
 			TokenFile:    cmd.String("token-file"),
@@ -45,12 +45,7 @@ var LoginCommand = &cli.Command{
 				fmt.Println("Waiting for authentication...")
 				return nil
 			},
-		})
-		if err != nil {
-			return fmt.Errorf("failed to initialize auth: %w", err)
-		}
-
-		if err := auth.DeviceFlow(ctx); err != nil {
+		}); err != nil {
 			return fmt.Errorf("authentication failed: %w", err)
 		}
 

--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -99,11 +99,9 @@ var RunnerCommand = &cli.Command{
 			log = slog.New(handler)
 		}
 
-		auth, err := deviceauth.New(deviceauth.Options{
-			TokenFile: cmd.String("token-file"),
-		})
+		auth, err := deviceauth.LoadToken(cmd.String("token-file"))
 		if err != nil {
-			return fmt.Errorf("failed to initialize auth: %w", err)
+			return fmt.Errorf("failed to load token: %w", err)
 		}
 
 		workspaces, err := workspace.LoadConfig(configPath, nil)

--- a/internal/command/task_create.go
+++ b/internal/command/task_create.go
@@ -54,14 +54,11 @@ var TaskCreateCommand = &cli.Command{
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		serverURL := cmd.String("server")
-		auth, err := deviceauth.New(deviceauth.Options{
-			DiscoveryURL: deviceauth.DiscoveryURL(serverURL),
-			TokenFile:    cmd.String("token-file"),
-		})
+		token, err := deviceauth.LoadToken(cmd.String("token-file"))
 		if err != nil {
-			return fmt.Errorf("failed to initialize auth: %w", err)
+			return fmt.Errorf("failed to load token: %w", err)
 		}
-		client := xagentclient.New(xagentclient.Options{BaseURL: serverURL, Source: auth})
+		client := xagentclient.New(xagentclient.Options{BaseURL: serverURL, Source: token})
 
 		texts := cmd.StringSlice("instruction")
 		instructions := make([]*xagentv1.Instruction, len(texts))

--- a/internal/command/task_delete.go
+++ b/internal/command/task_delete.go
@@ -41,14 +41,11 @@ var TaskDeleteCommand = &cli.Command{
 		}
 
 		serverURL := cmd.String("server")
-		auth, err := deviceauth.New(deviceauth.Options{
-			DiscoveryURL: deviceauth.DiscoveryURL(serverURL),
-			TokenFile:    cmd.String("token-file"),
-		})
+		token, err := deviceauth.LoadToken(cmd.String("token-file"))
 		if err != nil {
-			return fmt.Errorf("failed to initialize auth: %w", err)
+			return fmt.Errorf("failed to load token: %w", err)
 		}
-		client := xagentclient.New(xagentclient.Options{BaseURL: serverURL, Source: auth})
+		client := xagentclient.New(xagentclient.Options{BaseURL: serverURL, Source: token})
 		if _, err := client.DeleteTask(ctx, &xagentv1.DeleteTaskRequest{Id: taskID}); err != nil {
 			return fmt.Errorf("failed to delete task: %w", err)
 		}

--- a/internal/command/task_list.go
+++ b/internal/command/task_list.go
@@ -33,14 +33,11 @@ var TaskListCommand = &cli.Command{
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		serverURL := cmd.String("server")
-		auth, err := deviceauth.New(deviceauth.Options{
-			DiscoveryURL: deviceauth.DiscoveryURL(serverURL),
-			TokenFile:    cmd.String("token-file"),
-		})
+		token, err := deviceauth.LoadToken(cmd.String("token-file"))
 		if err != nil {
-			return fmt.Errorf("failed to initialize auth: %w", err)
+			return fmt.Errorf("failed to load token: %w", err)
 		}
-		client := xagentclient.New(xagentclient.Options{BaseURL: serverURL, Source: auth})
+		client := xagentclient.New(xagentclient.Options{BaseURL: serverURL, Source: token})
 
 		resp, err := client.ListTasks(ctx, &xagentv1.ListTasksRequest{})
 		if err != nil {

--- a/internal/command/task_update.go
+++ b/internal/command/task_update.go
@@ -69,14 +69,11 @@ var TaskUpdateCommand = &cli.Command{
 		}
 
 		serverURL := cmd.String("server")
-		auth, err := deviceauth.New(deviceauth.Options{
-			DiscoveryURL: deviceauth.DiscoveryURL(serverURL),
-			TokenFile:    cmd.String("token-file"),
-		})
+		token, err := deviceauth.LoadToken(cmd.String("token-file"))
 		if err != nil {
-			return fmt.Errorf("failed to initialize auth: %w", err)
+			return fmt.Errorf("failed to load token: %w", err)
 		}
-		client := xagentclient.New(xagentclient.Options{BaseURL: serverURL, Source: auth})
+		client := xagentclient.New(xagentclient.Options{BaseURL: serverURL, Source: token})
 		if _, err := client.UpdateTask(ctx, &xagentv1.UpdateTaskRequest{
 			Id:              taskID,
 			Name:            name,

--- a/internal/deviceauth/deviceauth.go
+++ b/internal/deviceauth/deviceauth.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sync"
 	"time"
 
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
@@ -16,6 +15,9 @@ import (
 )
 
 var scopes = []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail}
+
+// ErrNoToken is returned when no valid token is available
+var ErrNoToken = fmt.Errorf("no valid token available, run login to authenticate")
 
 // Token stores the API key
 type Token struct {
@@ -27,141 +29,123 @@ func (t *Token) Valid() bool {
 	return t != nil && t.APIKey != ""
 }
 
-// Options configures the Auth client
-type Options struct {
-	DiscoveryURL string // Full URL to the discovery endpoint (e.g., http://localhost:6464/device/config)
-	Issuer       string // ZITADEL issuer URL (e.g., https://instance.zitadel.cloud)
-	ClientID     string // Native app client ID
-	ServerURL    string // Base URL of the xagent server (used to create API key)
-	TokenFile    string // Path to token storage file
-	KeyName      string // Name for the API key (e.g., "runner-<hostname>")
-	Display      func(auth *oidc.DeviceAuthorizationResponse) error
-}
-
-// Auth handles device authorization flow and API key management
-type Auth struct {
-	config   Options
-	provider rp.RelyingParty
-	token    *Token
-	mu       sync.RWMutex
-	once     sync.Once
-	err      error
-}
-
-// New creates a new Auth client. The provider is initialized lazily on first use.
-func New(config Options) (*Auth, error) {
-	if config.TokenFile == "" {
-		return nil, fmt.Errorf("deviceauth.New called with empty TokenFile")
-	}
-	a := &Auth{config: config}
-	if err := a.load(); err != nil {
-		return nil, fmt.Errorf("load token file: %w", err)
-	}
-	return a, nil
-}
-
-// init initializes the OIDC provider. It is called lazily via once.Do().
-func (a *Auth) init(ctx context.Context) error {
-	a.once.Do(func() {
-		// Fetch discovery config if DiscoveryURL is provided
-		if a.config.DiscoveryURL != "" {
-			discovery, err := FetchDiscoveryConfig(a.config.DiscoveryURL)
-			if err != nil {
-				a.err = fmt.Errorf("fetch discovery config: %w", err)
-				return
-			}
-			if a.config.ClientID == "" {
-				a.config.ClientID = discovery.ClientID
-			}
-			if a.config.Issuer == "" {
-				issuer, err := discovery.Issuer()
-				if err != nil {
-					a.err = fmt.Errorf("parse issuer: %w", err)
-					return
-				}
-				a.config.Issuer = issuer
-			}
-		}
-		provider, err := rp.NewRelyingPartyOIDC(
-			ctx,
-			a.config.Issuer,
-			a.config.ClientID,
-			"",
-			// dummy value, we don't actually use this.
-			"http://localhost",
-			scopes,
-		)
-		if err != nil {
-			a.err = fmt.Errorf("create relying party: %w", err)
-			return
-		}
-		a.provider = provider
-	})
-	return a.err
-}
-
-// ErrNoToken is returned when no valid token is available
-var ErrNoToken = fmt.Errorf("no valid token available, run login to authenticate")
-
-// Token returns the API key.
-// Returns ErrNoToken if no API key exists.
-func (a *Auth) Token(_ context.Context) (string, error) {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	if a.token.Valid() {
-		return a.token.APIKey, nil
+// Token implements xagentclient.TokenSource.
+func (t *Token) Token(_ context.Context) (string, error) {
+	if t.Valid() {
+		return t.APIKey, nil
 	}
 	return "", ErrNoToken
 }
 
-// DeviceFlow initiates a device authorization flow and creates an API key.
-func (a *Auth) DeviceFlow(ctx context.Context) error {
-	if a.config.Display == nil {
-		return fmt.Errorf("DeviceFlow requires Display to be set")
+// LoadToken reads a token from a JSON file.
+// Returns a non-nil Token even if the file doesn't exist (with an empty API key).
+func LoadToken(path string) (*Token, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Token{}, nil
+		}
+		return nil, err
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if err := a.init(ctx); err != nil {
+	var token Token
+	if err := json.Unmarshal(data, &token); err != nil {
+		return nil, err
+	}
+	return &token, nil
+}
+
+// SaveToken writes a token to a JSON file.
+func SaveToken(path string, token *Token) error {
+	data, err := json.MarshalIndent(token, "", "  ")
+	if err != nil {
 		return err
 	}
-	deviceAuth, err := rp.DeviceAuthorization(ctx, scopes, a.provider, nil)
+	return os.WriteFile(path, data, 0600)
+}
+
+// DeviceFlowOptions configures the device authorization flow.
+type DeviceFlowOptions struct {
+	DiscoveryURL string // Full URL to the discovery endpoint
+	Issuer       string // ZITADEL issuer URL
+	ClientID     string // Native app client ID
+	ServerURL    string // Base URL of the xagent server (used to create API key)
+	TokenFile    string // Path to token storage file
+	KeyName      string // Name for the API key
+	Display      func(auth *oidc.DeviceAuthorizationResponse) error
+}
+
+// DeviceFlow initiates a device authorization flow and creates an API key.
+func DeviceFlow(ctx context.Context, opts DeviceFlowOptions) error {
+	if opts.Display == nil {
+		return fmt.Errorf("DeviceFlow requires Display to be set")
+	}
+
+	// Fetch discovery config if DiscoveryURL is provided
+	if opts.DiscoveryURL != "" {
+		discovery, err := FetchDiscoveryConfig(opts.DiscoveryURL)
+		if err != nil {
+			return fmt.Errorf("fetch discovery config: %w", err)
+		}
+		if opts.ClientID == "" {
+			opts.ClientID = discovery.ClientID
+		}
+		if opts.Issuer == "" {
+			issuer, err := discovery.Issuer()
+			if err != nil {
+				return fmt.Errorf("parse issuer: %w", err)
+			}
+			opts.Issuer = issuer
+		}
+	}
+
+	provider, err := rp.NewRelyingPartyOIDC(
+		ctx,
+		opts.Issuer,
+		opts.ClientID,
+		"",
+		// dummy value, we don't actually use this.
+		"http://localhost",
+		scopes,
+	)
+	if err != nil {
+		return fmt.Errorf("create relying party: %w", err)
+	}
+
+	deviceAuth, err := rp.DeviceAuthorization(ctx, scopes, provider, nil)
 	if err != nil {
 		return fmt.Errorf("device authorization: %w", err)
 	}
-	if err := a.config.Display(deviceAuth); err != nil {
+	if err := opts.Display(deviceAuth); err != nil {
 		return fmt.Errorf("display: %w", err)
 	}
 	interval := time.Duration(cmp.Or(deviceAuth.Interval, 5)) * time.Second
-	tokens, err := rp.DeviceAccessToken(ctx, deviceAuth.DeviceCode, interval, a.provider)
+	tokens, err := rp.DeviceAccessToken(ctx, deviceAuth.DeviceCode, interval, provider)
 	if err != nil {
 		return fmt.Errorf("device access token: %w", err)
 	}
 
 	// Use the short-lived OIDC token to create an API key
-	apiKey, err := a.createAPIKey(ctx, tokens.AccessToken)
+	apiKey, err := createAPIKey(ctx, opts.ServerURL, opts.KeyName, tokens.AccessToken)
 	if err != nil {
 		return fmt.Errorf("create API key: %w", err)
 	}
 
-	a.token = &Token{
-		APIKey: apiKey,
-	}
-	if err := a.save(); err != nil {
+	token := &Token{APIKey: apiKey}
+	if err := SaveToken(opts.TokenFile, token); err != nil {
 		return fmt.Errorf("save token: %w", err)
 	}
 	return nil
 }
 
 // createAPIKey uses a short-lived OIDC bearer token to create an API key on the server.
-func (a *Auth) createAPIKey(ctx context.Context, accessToken string) (string, error) {
+func createAPIKey(ctx context.Context, serverURL, keyName, accessToken string) (string, error) {
 	client := xagentclient.New(xagentclient.Options{
-		BaseURL:  a.config.ServerURL,
+		BaseURL:  serverURL,
 		Source:   staticTokenSource(accessToken),
 		AuthType: "bearer",
 	})
-	keyName := cmp.Or(a.config.KeyName, "runner")
 	resp, err := client.CreateKey(ctx, &xagentv1.CreateKeyRequest{
-		Name: keyName,
+		Name: cmp.Or(keyName, "runner"),
 	})
 	if err != nil {
 		return "", err
@@ -173,33 +157,4 @@ type staticTokenSource string
 
 func (s staticTokenSource) Token(_ context.Context) (string, error) {
 	return string(s), nil
-}
-
-// load the token from a file
-func (a *Auth) load() error {
-	data, err := os.ReadFile(a.config.TokenFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	var token Token
-	if err := json.Unmarshal(data, &token); err != nil {
-		return err
-	}
-	a.token = &token
-	return nil
-}
-
-// save the token to a file
-func (a *Auth) save() error {
-	if a.config.TokenFile == "" {
-		return nil
-	}
-	data, err := json.MarshalIndent(a.token, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(a.config.TokenFile, data, 0600)
 }


### PR DESCRIPTION
## Summary

- Replace the `Auth` struct with standalone functions: `LoadToken`, `SaveToken`, and `DeviceFlow`
- `Token` type now implements `xagentclient.TokenSource` directly
- Callers that only need to read a token file (runner, task commands) now call `LoadToken()` instead of constructing an `Auth` struct with unused OIDC configuration
- Only the `login` command uses the `DeviceFlow` function

## Motivation

The `Auth` struct mixed two unrelated concerns: reading an API key from a token file and running the OIDC device authorization flow. Most callers only needed the former but were forced to create the full `Auth` struct. This refactoring makes the separation explicit with simple functions.