### PR TITLE
Refactor DeviceFlow to return access token

### DIFF
--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -1,10 +1,12 @@
 package command
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 
 	"github.com/icholy/xagent/internal/deviceauth"
+	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/xagentclient"
 	"github.com/urfave/cli/v3"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
@@ -35,18 +37,35 @@ var LoginCommand = &cli.Command{
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		serverAddr := cmd.String("server")
-		if err := deviceauth.DeviceFlow(ctx, deviceauth.DeviceFlowOptions{
+		accessToken, err := deviceauth.DeviceFlow(ctx, deviceauth.DeviceFlowOptions{
 			DiscoveryURL: deviceauth.DiscoveryURL(serverAddr),
-			ServerURL:    serverAddr,
-			TokenFile:    cmd.String("token-file"),
-			KeyName:      cmd.String("key-name"),
 			Display: func(resp *oidc.DeviceAuthorizationResponse) error {
 				fmt.Printf("\nTo authenticate, visit: %s\n\n", resp.VerificationURIComplete)
 				fmt.Println("Waiting for authentication...")
 				return nil
 			},
-		}); err != nil {
+		})
+		if err != nil {
 			return fmt.Errorf("authentication failed: %w", err)
+		}
+
+		// Use the short-lived OIDC token to create an API key
+		client := xagentclient.New(xagentclient.Options{
+			BaseURL:  serverAddr,
+			Token:    accessToken,
+			AuthType: "bearer",
+		})
+		resp, err := client.CreateKey(ctx, &xagentv1.CreateKeyRequest{
+			Name: cmp.Or(cmd.String("key-name"), "cli"),
+		})
+		if err != nil {
+			return fmt.Errorf("create API key: %w", err)
+		}
+
+		// Save the API key to the token file
+		token := &deviceauth.Token{APIKey: resp.RawToken}
+		if err := deviceauth.SaveToken(cmd.String("token-file"), token); err != nil {
+			return fmt.Errorf("save token: %w", err)
 		}
 
 		fmt.Println("Authentication successful!")

--- a/internal/deviceauth/deviceauth.go
+++ b/internal/deviceauth/deviceauth.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"time"
 
-	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
-	"github.com/icholy/xagent/internal/xagentclient"
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
@@ -57,23 +55,20 @@ type DeviceFlowOptions struct {
 	DiscoveryURL string // Full URL to the discovery endpoint
 	Issuer       string // ZITADEL issuer URL
 	ClientID     string // Native app client ID
-	ServerURL    string // Base URL of the xagent server (used to create API key)
-	TokenFile    string // Path to token storage file
-	KeyName      string // Name for the API key
 	Display      func(auth *oidc.DeviceAuthorizationResponse) error
 }
 
-// DeviceFlow initiates a device authorization flow and creates an API key.
-func DeviceFlow(ctx context.Context, opts DeviceFlowOptions) error {
+// DeviceFlow initiates a device authorization flow and returns the access token.
+func DeviceFlow(ctx context.Context, opts DeviceFlowOptions) (string, error) {
 	if opts.Display == nil {
-		return fmt.Errorf("DeviceFlow requires Display to be set")
+		return "", fmt.Errorf("DeviceFlow requires Display to be set")
 	}
 
 	// Fetch discovery config if DiscoveryURL is provided
 	if opts.DiscoveryURL != "" {
 		discovery, err := FetchDiscoveryConfig(opts.DiscoveryURL)
 		if err != nil {
-			return fmt.Errorf("fetch discovery config: %w", err)
+			return "", fmt.Errorf("fetch discovery config: %w", err)
 		}
 		if opts.ClientID == "" {
 			opts.ClientID = discovery.ClientID
@@ -81,7 +76,7 @@ func DeviceFlow(ctx context.Context, opts DeviceFlowOptions) error {
 		if opts.Issuer == "" {
 			issuer, err := discovery.Issuer()
 			if err != nil {
-				return fmt.Errorf("parse issuer: %w", err)
+				return "", fmt.Errorf("parse issuer: %w", err)
 			}
 			opts.Issuer = issuer
 		}
@@ -97,48 +92,22 @@ func DeviceFlow(ctx context.Context, opts DeviceFlowOptions) error {
 		scopes,
 	)
 	if err != nil {
-		return fmt.Errorf("create relying party: %w", err)
+		return "", fmt.Errorf("create relying party: %w", err)
 	}
 
 	deviceAuth, err := rp.DeviceAuthorization(ctx, scopes, provider, nil)
 	if err != nil {
-		return fmt.Errorf("device authorization: %w", err)
+		return "", fmt.Errorf("device authorization: %w", err)
 	}
 	if err := opts.Display(deviceAuth); err != nil {
-		return fmt.Errorf("display: %w", err)
+		return "", fmt.Errorf("display: %w", err)
 	}
 	interval := time.Duration(cmp.Or(deviceAuth.Interval, 5)) * time.Second
 	tokens, err := rp.DeviceAccessToken(ctx, deviceAuth.DeviceCode, interval, provider)
 	if err != nil {
-		return fmt.Errorf("device access token: %w", err)
+		return "", fmt.Errorf("device access token: %w", err)
 	}
 
-	// Use the short-lived OIDC token to create an API key
-	apiKey, err := createAPIKey(ctx, opts.ServerURL, opts.KeyName, tokens.AccessToken)
-	if err != nil {
-		return fmt.Errorf("create API key: %w", err)
-	}
-
-	token := &Token{APIKey: apiKey}
-	if err := SaveToken(opts.TokenFile, token); err != nil {
-		return fmt.Errorf("save token: %w", err)
-	}
-	return nil
-}
-
-// createAPIKey uses a short-lived OIDC bearer token to create an API key on the server.
-func createAPIKey(ctx context.Context, serverURL, keyName, accessToken string) (string, error) {
-	client := xagentclient.New(xagentclient.Options{
-		BaseURL:  serverURL,
-		Token:    accessToken,
-		AuthType: "bearer",
-	})
-	resp, err := client.CreateKey(ctx, &xagentv1.CreateKeyRequest{
-		Name: cmp.Or(keyName, "runner"),
-	})
-	if err != nil {
-		return "", err
-	}
-	return resp.RawToken, nil
+	return tokens.AccessToken, nil
 }
 


### PR DESCRIPTION
## Summary

- `DeviceFlow` now returns the OIDC access token (`string`) instead of internally creating an API key and saving it
- Removed `ServerURL`, `TokenFile`, and `KeyName` from `DeviceFlowOptions` since they are no longer needed
- Moved API key creation (via `CreateKey` RPC) and token file persistence into the login command action
- Removed the unexported `createAPIKey` helper from the `deviceauth` package