### PR TITLE
Extract internal/tokenfile package from deviceauth

### DIFF
--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/icholy/xagent/internal/deviceauth"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
+	"github.com/icholy/xagent/internal/tokenfile"
 	"github.com/icholy/xagent/internal/xagentclient"
 	"github.com/urfave/cli/v3"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
@@ -63,8 +64,8 @@ var LoginCommand = &cli.Command{
 		}
 
 		// Save the API key to the token file
-		token := &deviceauth.Token{APIKey: resp.RawToken}
-		if err := deviceauth.SaveToken(cmd.String("token-file"), token); err != nil {
+		token := &tokenfile.Token{APIKey: resp.RawToken}
+		if err := tokenfile.Save(cmd.String("token-file"), token); err != nil {
 			return fmt.Errorf("save token: %w", err)
 		}
 

--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/icholy/xagent/internal/common"
-	"github.com/icholy/xagent/internal/deviceauth"
 	"github.com/icholy/xagent/internal/runner"
+	"github.com/icholy/xagent/internal/tokenfile"
 	"github.com/icholy/xagent/internal/workspace"
 	"github.com/icholy/xagent/internal/xagentclient"
 	"github.com/urfave/cli/v3"
@@ -99,7 +99,7 @@ var RunnerCommand = &cli.Command{
 			log = slog.New(handler)
 		}
 
-		token, err := deviceauth.LoadToken(cmd.String("token-file"))
+		token, err := tokenfile.Load(cmd.String("token-file"))
 		if err != nil {
 			return fmt.Errorf("failed to load token: %w", err)
 		}

--- a/internal/command/task_create.go
+++ b/internal/command/task_create.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/icholy/xagent/internal/deviceauth"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
+	"github.com/icholy/xagent/internal/tokenfile"
 	"github.com/icholy/xagent/internal/xagentclient"
 	"github.com/urfave/cli/v3"
 )
@@ -54,7 +54,7 @@ var TaskCreateCommand = &cli.Command{
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		serverURL := cmd.String("server")
-		token, err := deviceauth.LoadToken(cmd.String("token-file"))
+		token, err := tokenfile.Load(cmd.String("token-file"))
 		if err != nil {
 			return fmt.Errorf("failed to load token: %w", err)
 		}

--- a/internal/command/task_delete.go
+++ b/internal/command/task_delete.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/icholy/xagent/internal/deviceauth"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
+	"github.com/icholy/xagent/internal/tokenfile"
 	"github.com/icholy/xagent/internal/xagentclient"
 	"github.com/urfave/cli/v3"
 )
@@ -41,7 +41,7 @@ var TaskDeleteCommand = &cli.Command{
 		}
 
 		serverURL := cmd.String("server")
-		token, err := deviceauth.LoadToken(cmd.String("token-file"))
+		token, err := tokenfile.Load(cmd.String("token-file"))
 		if err != nil {
 			return fmt.Errorf("failed to load token: %w", err)
 		}

--- a/internal/command/task_list.go
+++ b/internal/command/task_list.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/icholy/xagent/internal/deviceauth"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
+	"github.com/icholy/xagent/internal/tokenfile"
 	"github.com/icholy/xagent/internal/xagentclient"
 	"github.com/urfave/cli/v3"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -33,7 +33,7 @@ var TaskListCommand = &cli.Command{
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		serverURL := cmd.String("server")
-		token, err := deviceauth.LoadToken(cmd.String("token-file"))
+		token, err := tokenfile.Load(cmd.String("token-file"))
 		if err != nil {
 			return fmt.Errorf("failed to load token: %w", err)
 		}

--- a/internal/command/task_update.go
+++ b/internal/command/task_update.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/icholy/xagent/internal/deviceauth"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
+	"github.com/icholy/xagent/internal/tokenfile"
 	"github.com/icholy/xagent/internal/xagentclient"
 	"github.com/urfave/cli/v3"
 )
@@ -69,7 +69,7 @@ var TaskUpdateCommand = &cli.Command{
 		}
 
 		serverURL := cmd.String("server")
-		token, err := deviceauth.LoadToken(cmd.String("token-file"))
+		token, err := tokenfile.Load(cmd.String("token-file"))
 		if err != nil {
 			return fmt.Errorf("failed to load token: %w", err)
 		}

--- a/internal/deviceauth/deviceauth.go
+++ b/internal/deviceauth/deviceauth.go
@@ -3,9 +3,7 @@ package deviceauth
 import (
 	"cmp"
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
@@ -13,42 +11,6 @@ import (
 )
 
 var scopes = []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail}
-
-// Token stores the API key
-type Token struct {
-	APIKey string `json:"api_key"`
-}
-
-// Valid reports whether the token has a non-empty API key
-func (t *Token) Valid() bool {
-	return t != nil && t.APIKey != ""
-}
-
-// LoadToken reads a token from a JSON file.
-// Returns a non-nil Token even if the file doesn't exist (with an empty API key).
-func LoadToken(path string) (*Token, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return &Token{}, nil
-		}
-		return nil, err
-	}
-	var token Token
-	if err := json.Unmarshal(data, &token); err != nil {
-		return nil, err
-	}
-	return &token, nil
-}
-
-// SaveToken writes a token to a JSON file.
-func SaveToken(path string, token *Token) error {
-	data, err := json.MarshalIndent(token, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(path, data, 0600)
-}
 
 // DeviceFlowOptions configures the device authorization flow.
 type DeviceFlowOptions struct {

--- a/internal/tokenfile/tokenfile.go
+++ b/internal/tokenfile/tokenfile.go
@@ -1,0 +1,42 @@
+package tokenfile
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// Token stores the API key.
+type Token struct {
+	APIKey string `json:"api_key"`
+}
+
+// Valid reports whether the token has a non-empty API key.
+func (t *Token) Valid() bool {
+	return t != nil && t.APIKey != ""
+}
+
+// Load reads a token from a JSON file.
+// Returns a non-nil Token even if the file doesn't exist (with an empty API key).
+func Load(path string) (*Token, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Token{}, nil
+		}
+		return nil, err
+	}
+	var token Token
+	if err := json.Unmarshal(data, &token); err != nil {
+		return nil, err
+	}
+	return &token, nil
+}
+
+// Save writes a token to a JSON file.
+func Save(path string, token *Token) error {
+	data, err := json.MarshalIndent(token, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}


### PR DESCRIPTION
## Summary
- Extract `Token` type, `Load`, and `Save` functions from `internal/deviceauth` into a new `internal/tokenfile` package
- Update all callers in `internal/command/` to import from `tokenfile` instead of `deviceauth`
- `deviceauth` package now only contains device authorization flow logic

## Changes
- **New**: `internal/tokenfile/tokenfile.go` - `Token` type, `Load()`, `Save()` functions
- **Modified**: `internal/deviceauth/deviceauth.go` - removed token-related code
- **Modified**: `internal/command/login.go` - uses `tokenfile.Token` and `tokenfile.Save`
- **Modified**: `internal/command/runner.go`, `task_list.go`, `task_create.go`, `task_update.go`, `task_delete.go` - use `tokenfile.Load`