### PR TITLE
Rename tokenfile.Token to tokenfile.File

### DIFF
--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -64,7 +64,7 @@ var LoginCommand = &cli.Command{
 		}
 
 		// Save the API key to the token file
-		token := &tokenfile.Token{APIKey: resp.RawToken}
+		token := &tokenfile.File{APIKey: resp.RawToken}
 		if err := tokenfile.Save(cmd.String("token-file"), token); err != nil {
 			return fmt.Errorf("save token: %w", err)
 		}

--- a/internal/tokenfile/tokenfile.go
+++ b/internal/tokenfile/tokenfile.go
@@ -5,27 +5,27 @@ import (
 	"os"
 )
 
-// Token stores the API key.
-type Token struct {
+// File stores the API key.
+type File struct {
 	APIKey string `json:"api_key"`
 }
 
 // Valid reports whether the token has a non-empty API key.
-func (t *Token) Valid() bool {
+func (t *File) Valid() bool {
 	return t != nil && t.APIKey != ""
 }
 
 // Load reads a token from a JSON file.
-// Returns a non-nil Token even if the file doesn't exist (with an empty API key).
-func Load(path string) (*Token, error) {
+// Returns a non-nil File even if the file doesn't exist (with an empty API key).
+func Load(path string) (*File, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &Token{}, nil
+			return &File{}, nil
 		}
 		return nil, err
 	}
-	var token Token
+	var token File
 	if err := json.Unmarshal(data, &token); err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func Load(path string) (*Token, error) {
 }
 
 // Save writes a token to a JSON file.
-func Save(path string, token *Token) error {
+func Save(path string, token *File) error {
 	data, err := json.MarshalIndent(token, "", "  ")
 	if err != nil {
 		return err


### PR DESCRIPTION
Rename `tokenfile.Token` type to `tokenfile.File` for clarity, since the package is already named `tokenfile` and `tokenfile.File` reads more naturally than `tokenfile.Token`.

Updated all references in `internal/tokenfile/tokenfile.go` and `internal/command/login.go`.