### PR TITLE
Make web UI responsive for mobile devices

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -13,6 +13,7 @@
         "@connectrpc/connect-query": "^2.2.0",
         "@connectrpc/connect-web": "^2.1.1",
         "@icholy/duration": "^5.1.0",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
@@ -1497,6 +1498,83 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/webui/package.json
+++ b/webui/package.json
@@ -16,6 +16,7 @@
     "@connectrpc/connect-query": "^2.2.0",
     "@connectrpc/connect-web": "^2.1.1",
     "@icholy/duration": "^5.1.0",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",

--- a/webui/src/components/ui/sheet.tsx
+++ b/webui/src/components/ui/sheet.tsx
@@ -1,0 +1,104 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <DialogPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right fixed inset-y-0 right-0 z-50 flex h-full w-3/4 max-w-sm flex-col gap-4 border-l p-6 shadow-lg transition-transform duration-200",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <X className="size-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetTitle,
+  SheetDescription,
+}

--- a/webui/src/routes/__root.tsx
+++ b/webui/src/routes/__root.tsx
@@ -1,9 +1,16 @@
 import { Outlet, createRootRouteWithContext, Link } from '@tanstack/react-router'
-import { LogOut } from 'lucide-react'
-import { lazy, Suspense } from 'react'
+import { LogOut, Menu } from 'lucide-react'
+import { lazy, Suspense, useState } from 'react'
 import { QueryClient } from '@tanstack/react-query'
 import { useQuery } from '@connectrpc/connect-query'
 import { getProfile } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
+import { Button } from '@/components/ui/button'
+import {
+  Sheet,
+  SheetTrigger,
+  SheetContent,
+  SheetTitle,
+} from '@/components/ui/sheet'
 import xagentIcon from '@/assets/icon.png'
 
 // TanStack devtools check NODE_ENV and render nothing in production, but the
@@ -32,8 +39,16 @@ export const Route = createRootRouteWithContext<{
   component: RootComponent,
 })
 
+const navLinks = [
+  { to: '/tasks' as const, label: 'Tasks' },
+  { to: '/events' as const, label: 'Events' },
+  { to: '/workspaces' as const, label: 'Workspaces' },
+  { to: '/keys' as const, label: 'API Keys' },
+]
+
 function RootComponent() {
   const { data: profileData } = useQuery(getProfile, {})
+  const [mobileOpen, setMobileOpen] = useState(false)
 
   return (
     <>
@@ -42,33 +57,19 @@ function RootComponent() {
           <Link to="/">
             <img src={xagentIcon} alt="XAgent" className="h-8 w-8" />
           </Link>
-          <div className="flex gap-4">
-            <Link
-              to="/tasks"
-              className="text-muted-foreground hover:text-foreground transition-colors [&.active]:text-foreground"
-            >
-              Tasks
-            </Link>
-            <Link
-              to="/events"
-              className="text-muted-foreground hover:text-foreground transition-colors [&.active]:text-foreground"
-            >
-              Events
-            </Link>
-            <Link
-              to="/workspaces"
-              className="text-muted-foreground hover:text-foreground transition-colors [&.active]:text-foreground"
-            >
-              Workspaces
-            </Link>
-            <Link
-              to="/keys"
-              className="text-muted-foreground hover:text-foreground transition-colors [&.active]:text-foreground"
-            >
-              API Keys
-            </Link>
+          {/* Desktop nav */}
+          <div className="hidden md:flex gap-4">
+            {navLinks.map((link) => (
+              <Link
+                key={link.to}
+                to={link.to}
+                className="text-muted-foreground hover:text-foreground transition-colors [&.active]:text-foreground"
+              >
+                {link.label}
+              </Link>
+            ))}
           </div>
-          <div className="ml-auto flex items-center gap-4">
+          <div className="ml-auto hidden md:flex items-center gap-4">
             {profileData?.profile?.email && (
               <span className="text-sm text-muted-foreground">
                 {profileData.profile.email}
@@ -81,6 +82,46 @@ function RootComponent() {
               <LogOut className="h-4 w-4" />
               Logout
             </a>
+          </div>
+          {/* Mobile hamburger */}
+          <div className="ml-auto md:hidden">
+            <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+              <SheetTrigger asChild>
+                <Button variant="ghost" size="icon">
+                  <Menu className="h-5 w-5" />
+                  <span className="sr-only">Open menu</span>
+                </Button>
+              </SheetTrigger>
+              <SheetContent>
+                <SheetTitle>Navigation</SheetTitle>
+                <div className="flex flex-col gap-4 mt-4">
+                  {navLinks.map((link) => (
+                    <Link
+                      key={link.to}
+                      to={link.to}
+                      className="text-foreground hover:text-primary transition-colors text-lg [&.active]:text-primary"
+                      onClick={() => setMobileOpen(false)}
+                    >
+                      {link.label}
+                    </Link>
+                  ))}
+                </div>
+                <div className="mt-auto pt-6 border-t flex flex-col gap-3">
+                  {profileData?.profile?.email && (
+                    <span className="text-sm text-muted-foreground truncate">
+                      {profileData.profile.email}
+                    </span>
+                  )}
+                  <a
+                    href="/auth/logout"
+                    className="text-muted-foreground hover:text-foreground transition-colors text-sm flex items-center gap-1.5"
+                  >
+                    <LogOut className="h-4 w-4" />
+                    Logout
+                  </a>
+                </div>
+              </SheetContent>
+            </Sheet>
           </div>
         </div>
       </nav>

--- a/webui/src/routes/events.$id.tsx
+++ b/webui/src/routes/events.$id.tsx
@@ -53,11 +53,11 @@ function EventDetail() {
   const taskIds = tasksData?.taskIds ?? []
 
   return (
-    <div className="container mx-auto py-8 px-4">
-      <h1 className="text-2xl font-bold mb-6">Event {String(event.id)}</h1>
+    <div className="container mx-auto py-4 px-3 md:py-8 md:px-4">
+      <h1 className="text-xl font-bold mb-6 md:text-2xl">Event {String(event.id)}</h1>
 
       <div className="space-y-6">
-        <div className="rounded-lg border p-6 space-y-4">
+        <div className="rounded-lg border p-4 md:p-6 space-y-4">
           <div>
             <h2 className="text-sm font-medium text-muted-foreground">Description</h2>
             <p className="mt-1">{event.description || '-'}</p>
@@ -98,7 +98,7 @@ function EventDetail() {
           )}
         </div>
 
-        <div className="rounded-lg border p-6">
+        <div className="rounded-lg border p-4 md:p-6">
           <h2 className="text-lg font-semibold mb-4">Associated Tasks</h2>
           {tasksLoading ? (
             <p className="text-muted-foreground">Loading tasks...</p>

--- a/webui/src/routes/events.index.tsx
+++ b/webui/src/routes/events.index.tsx
@@ -52,10 +52,10 @@ function EventsPage() {
   const events = data?.events ?? []
 
   return (
-    <div className="container mx-auto py-8 px-4">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Recent Events</h1>
-        <div className="flex items-center gap-4">
+    <div className="container mx-auto py-4 px-3 md:py-8 md:px-4">
+      <div className="flex flex-col gap-3 mb-6 md:flex-row md:items-center md:justify-between">
+        <h1 className="text-xl font-bold md:text-2xl">Recent Events</h1>
+        <div className="flex items-center gap-3 md:gap-4">
           <div className="flex items-center gap-2">
             <span className="text-sm text-muted-foreground">Show</span>
             <Select value={String(limit)} onValueChange={(value) => setLimit(Number(value))}>
@@ -83,21 +83,73 @@ function EventsPage() {
           No events found
         </div>
       ) : (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>ID</TableHead>
-              <TableHead>Description</TableHead>
-              <TableHead>Data</TableHead>
-              <TableHead>Created</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
+        <>
+          {/* Mobile card view */}
+          <div className="flex flex-col gap-3 md:hidden">
             {events.map((event) => (
-              <EventRow key={String(event.id)} event={event} />
+              <EventCard key={String(event.id)} event={event} />
             ))}
-          </TableBody>
-        </Table>
+          </div>
+          {/* Desktop table view */}
+          <div className="hidden md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Description</TableHead>
+                  <TableHead>Data</TableHead>
+                  <TableHead>Created</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {events.map((event) => (
+                  <EventRow key={String(event.id)} event={event} />
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function EventCard({ event }: { event: Event }) {
+  const dataContent = event.data || '-'
+  const truncatedData = dataContent.length > 100 ? dataContent.slice(0, 100) + '...' : dataContent
+
+  return (
+    <div className="rounded-lg border p-4 space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <Link
+          to="/events/$id"
+          params={{ id: String(event.id) }}
+          className="text-primary hover:underline font-medium"
+        >
+          {event.description || `Event ${event.id}`}
+        </Link>
+        <span className="text-xs text-muted-foreground shrink-0">
+          #{String(event.id)}
+        </span>
+      </div>
+      <div className="text-sm text-muted-foreground break-words">
+        {event.url ? (
+          <a
+            href={event.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+          >
+            {truncatedData}
+          </a>
+        ) : (
+          truncatedData
+        )}
+      </div>
+      {event.createdAt && (
+        <div className="text-xs text-muted-foreground">
+          <RelativeTime date={timestampDate(event.createdAt)} />
+        </div>
       )}
     </div>
   )
@@ -139,4 +191,3 @@ function EventRow({ event }: { event: Event }) {
     </TableRow>
   )
 }
-

--- a/webui/src/routes/events.new.tsx
+++ b/webui/src/routes/events.new.tsx
@@ -40,8 +40,8 @@ function CreateEventPage() {
   }
 
   return (
-    <div className="container mx-auto py-8 px-4 space-y-6">
-      <h1 className="text-2xl font-bold mb-6">Create Event</h1>
+    <div className="container mx-auto py-4 px-3 md:py-8 md:px-4 space-y-6">
+      <h1 className="text-xl font-bold mb-6 md:text-2xl">Create Event</h1>
 
       <Card>
         <CardContent className="pt-6">

--- a/webui/src/routes/keys.index.tsx
+++ b/webui/src/routes/keys.index.tsx
@@ -46,9 +46,9 @@ function KeysPage() {
   const keys = data?.keys ?? []
 
   return (
-    <div className="container mx-auto py-8 px-4">
+    <div className="container mx-auto py-4 px-3 md:py-8 md:px-4">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">API Keys</h1>
+        <h1 className="text-xl font-bold md:text-2xl">API Keys</h1>
         <Link to="/keys/new">
           <Button>
             <Plus className="h-4 w-4" />
@@ -61,26 +61,91 @@ function KeysPage() {
           No API keys found
         </div>
       ) : (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Name</TableHead>
-              <TableHead>Expires</TableHead>
-              <TableHead>Created</TableHead>
-              <TableHead></TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
+        <>
+          {/* Mobile card view */}
+          <div className="flex flex-col gap-3 md:hidden">
             {keys.map((key) => (
-              <KeyRow
-                key={key.id}
-                apiKey={key}
-                onDelete={refetch}
-              />
+              <KeyCard key={key.id} apiKey={key} onDelete={refetch} />
             ))}
-          </TableBody>
-        </Table>
+          </div>
+          {/* Desktop table view */}
+          <div className="hidden md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Expires</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {keys.map((key) => (
+                  <KeyRow
+                    key={key.id}
+                    apiKey={key}
+                    onDelete={refetch}
+                  />
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </>
       )}
+    </div>
+  )
+}
+
+function KeyCard({
+  apiKey,
+  onDelete,
+}: {
+  apiKey: Key
+  onDelete: () => void
+}) {
+  const deleteMutation = useMutation(deleteKey, {
+    onSuccess: () => onDelete(),
+  })
+
+  const isExpired = apiKey.expiresAt && timestampDate(apiKey.expiresAt) < new Date()
+
+  return (
+    <div className="rounded-lg border p-4 space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <span className="font-medium">{apiKey.name}</span>
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={() => deleteMutation.mutateAsync({ id: apiKey.id })}
+          disabled={deleteMutation.isPending}
+          className="shrink-0"
+        >
+          {deleteMutation.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Trash2 className="h-4 w-4" />
+          )}
+          Delete
+        </Button>
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+        <span>
+          Expires:{' '}
+          {apiKey.expiresAt ? (
+            <span className={isExpired ? 'text-destructive' : ''}>
+              {isExpired ? 'Expired ' : ''}
+              <RelativeTime date={timestampDate(apiKey.expiresAt)} />
+            </span>
+          ) : (
+            'Never'
+          )}
+        </span>
+        {apiKey.createdAt && (
+          <span>
+            Created: <RelativeTime date={timestampDate(apiKey.createdAt)} />
+          </span>
+        )}
+      </div>
     </div>
   )
 }

--- a/webui/src/routes/keys.new.tsx
+++ b/webui/src/routes/keys.new.tsx
@@ -40,8 +40,8 @@ function NewKeyPage() {
 
   if (created) {
     return (
-      <div className="container mx-auto py-8 px-4 space-y-6">
-        <h1 className="text-2xl font-bold mb-6">API Key Created</h1>
+      <div className="container mx-auto py-4 px-3 md:py-8 md:px-4 space-y-6">
+        <h1 className="text-xl font-bold mb-6 md:text-2xl">API Key Created</h1>
 
         <Card>
           <CardContent className="pt-6 space-y-4">
@@ -82,8 +82,8 @@ function NewKeyPage() {
   }
 
   return (
-    <div className="container mx-auto py-8 px-4 space-y-6">
-      <h1 className="text-2xl font-bold mb-6">Create API Key</h1>
+    <div className="container mx-auto py-4 px-3 md:py-8 md:px-4 space-y-6">
+      <h1 className="text-xl font-bold mb-6 md:text-2xl">Create API Key</h1>
 
       <Card>
         <CardContent className="pt-6">

--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -130,10 +130,10 @@ function TaskDetail() {
   const isMutating = archiveMutation.isPending || unarchiveMutation.isPending || cancelMutation.isPending || restartMutation.isPending
 
   return (
-    <div className="container mx-auto py-8 px-4 space-y-6">
-      <div className="flex justify-between items-start mb-6">
-        <h1 className="text-2xl font-bold">{task.name || `Unnamed - ${id}`}</h1>
-        <div className="flex gap-2">
+    <div className="container mx-auto py-4 px-3 md:py-8 md:px-4 space-y-6">
+      <div className="flex flex-col gap-3 md:flex-row md:justify-between md:items-start mb-6">
+        <h1 className="text-xl font-bold md:text-2xl break-words min-w-0">{task.name || `Unnamed - ${id}`}</h1>
+        <div className="flex flex-wrap gap-2 shrink-0">
           {canCancelTask(task) && (
             <Button
               variant="destructive"
@@ -183,7 +183,7 @@ function TaskDetail() {
 
       {/* Task Details */}
       <div className="rounded-lg border p-4">
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
+        <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm md:flex md:flex-wrap md:items-center md:gap-x-6 md:gap-y-2">
           <div className="flex items-center gap-2">
             <span className="text-muted-foreground">Runner:</span>
             <span>{task.runner}</span>
@@ -204,7 +204,7 @@ function TaskDetail() {
               </Link>
             </div>
           )}
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 col-span-2 md:col-span-1">
             <span className="text-muted-foreground">Status:</span>
             <StatusBadge task={task} />
             <CommandBadge task={task} />
@@ -225,14 +225,14 @@ function TaskDetail() {
 
       {/* Links */}
       {links.length > 0 && (
-        <div className="rounded-lg border p-6">
+        <div className="rounded-lg border p-4 md:p-6">
           <h2 className="text-lg font-semibold mb-4">Links</h2>
           <LinksSection links={links} />
         </div>
       )}
 
       {/* Instructions */}
-      <div className="rounded-lg border p-6">
+      <div className="rounded-lg border p-4 md:p-6">
         <h2 className="text-lg font-semibold mb-4">Instructions</h2>
         {task.instructions.length === 0 ? (
           <p className="text-muted-foreground">No instructions</p>
@@ -263,17 +263,17 @@ function TaskDetail() {
 
       {/* Child Tasks */}
       {children.length > 0 && (
-        <div className="rounded-lg border p-6">
+        <div className="rounded-lg border p-4 md:p-6">
           <h2 className="text-lg font-semibold mb-4">Child Tasks</h2>
-          <ChildTasksTable tasks={children} onUpdate={refetch} />
+          <ChildTasksSection tasks={children} onUpdate={refetch} />
         </div>
       )}
 
       {/* Events */}
       {events.length > 0 && (
-        <div className="rounded-lg border p-6">
+        <div className="rounded-lg border p-4 md:p-6">
           <h2 className="text-lg font-semibold mb-4">Events</h2>
-          <EventsTable
+          <EventsSection
             events={events}
             onUnlink={handleUnlinkEvent}
             isUnlinking={removeEventMutation.isPending}
@@ -282,9 +282,9 @@ function TaskDetail() {
       )}
 
       {/* Logs */}
-      <div className="rounded-lg border p-6">
+      <div className="rounded-lg border p-4 md:p-6">
         <h2 className="text-lg font-semibold mb-4">Logs</h2>
-        <LogsTable logs={logs} />
+        <LogsSection logs={logs} />
       </div>
     </div>
   )
@@ -315,12 +315,12 @@ function LinksSection({ links }: { links: TaskLink[] }) {
     <ul className="space-y-2">
       {links.map((link) => (
         <li key={String(link.id)} className="flex flex-col gap-1">
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <a
               href={link.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-primary hover:underline"
+              className="text-primary hover:underline break-all"
             >
               {link.title || link.url}
             </a>
@@ -344,25 +344,74 @@ function LinksSection({ links }: { links: TaskLink[] }) {
   )
 }
 
-function ChildTasksTable({ tasks, onUpdate }: { tasks: Task[]; onUpdate: () => void }) {
+function ChildTasksSection({ tasks, onUpdate }: { tasks: Task[]; onUpdate: () => void }) {
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Name</TableHead>
-          <TableHead>Runner</TableHead>
-          <TableHead>Workspace</TableHead>
-          <TableHead>Status</TableHead>
-          <TableHead>Created</TableHead>
-          <TableHead></TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
+    <>
+      {/* Mobile card view */}
+      <div className="flex flex-col gap-3 md:hidden">
         {tasks.map((task) => (
-          <ChildTaskRow key={String(task.id)} task={task} onUpdate={onUpdate} />
+          <ChildTaskCard key={String(task.id)} task={task} onUpdate={onUpdate} />
         ))}
-      </TableBody>
-    </Table>
+      </div>
+      {/* Desktop table view */}
+      <div className="hidden md:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Runner</TableHead>
+              <TableHead>Workspace</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {tasks.map((task) => (
+              <ChildTaskRow key={String(task.id)} task={task} onUpdate={onUpdate} />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </>
+  )
+}
+
+function ChildTaskCard({ task, onUpdate }: { task: Task; onUpdate: () => void }) {
+  const archiveMutation = useMutation(archiveTask, { onSuccess: () => onUpdate() })
+
+  return (
+    <div className="rounded-lg border p-3 space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <Link
+          to="/tasks/$id"
+          params={{ id: String(task.id) }}
+          className="text-primary hover:underline font-medium break-words min-w-0"
+        >
+          {task.name || `Unnamed - ${task.id}`}
+        </Link>
+        {canArchiveTask(task) && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => archiveMutation.mutateAsync({ id: task.id })}
+            disabled={archiveMutation.isPending}
+            className="shrink-0"
+          >
+            {archiveMutation.isPending && <Loader2 className="mr-1 h-3 w-3 animate-spin" />}
+            Archive
+          </Button>
+        )}
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <StatusBadge task={task} />
+        <CommandBadge task={task} />
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+        {task.workspace && <span>{task.workspace}</span>}
+        {task.createdAt && <RelativeTime date={timestampDate(task.createdAt)} />}
+      </div>
+    </div>
   )
 }
 
@@ -412,7 +461,7 @@ function ChildTaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) 
   )
 }
 
-function EventsTable({
+function EventsSection({
   events,
   onUnlink,
   isUnlinking,
@@ -422,34 +471,34 @@ function EventsTable({
   isUnlinking: boolean
 }) {
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>ID</TableHead>
-          <TableHead>Description</TableHead>
-          <TableHead>Data</TableHead>
-          <TableHead>Created</TableHead>
-          <TableHead></TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
+    <>
+      {/* Mobile card view */}
+      <div className="flex flex-col gap-3 md:hidden">
         {events.map((event) => {
           const dataContent = event.data || '-'
           const truncatedData = dataContent.length > 100 ? dataContent.slice(0, 100) + '...' : dataContent
 
           return (
-            <TableRow key={String(event.id)}>
-              <TableCell>{String(event.id)}</TableCell>
-              <TableCell>
+            <div key={String(event.id)} className="rounded-lg border p-3 space-y-2">
+              <div className="flex items-start justify-between gap-2">
                 <Link
                   to="/events/$id"
                   params={{ id: String(event.id) }}
-                  className="text-primary hover:underline"
+                  className="text-primary hover:underline font-medium"
                 >
-                  {event.description || '-'}
+                  {event.description || `Event ${event.id}`}
                 </Link>
-              </TableCell>
-              <TableCell className="max-w-xs truncate">
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => onUnlink(event.id)}
+                  disabled={isUnlinking}
+                  className="shrink-0"
+                >
+                  Remove
+                </Button>
+              </div>
+              <div className="text-sm text-muted-foreground break-words">
                 {event.url ? (
                   <a
                     href={event.url}
@@ -462,46 +511,94 @@ function EventsTable({
                 ) : (
                   truncatedData
                 )}
-              </TableCell>
-              <TableCell className="text-muted-foreground">
-                {event.createdAt ? <RelativeTime date={timestampDate(event.createdAt)} /> : '-'}
-              </TableCell>
-              <TableCell>
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={() => onUnlink(event.id)}
-                  disabled={isUnlinking}
-                >
-                  Remove
-                </Button>
-              </TableCell>
-            </TableRow>
+              </div>
+              {event.createdAt && (
+                <div className="text-xs text-muted-foreground">
+                  <RelativeTime date={timestampDate(event.createdAt)} />
+                </div>
+              )}
+            </div>
           )
         })}
-      </TableBody>
-    </Table>
+      </div>
+      {/* Desktop table view */}
+      <div className="hidden md:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead>Data</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {events.map((event) => {
+              const dataContent = event.data || '-'
+              const truncatedData = dataContent.length > 100 ? dataContent.slice(0, 100) + '...' : dataContent
+
+              return (
+                <TableRow key={String(event.id)}>
+                  <TableCell>{String(event.id)}</TableCell>
+                  <TableCell>
+                    <Link
+                      to="/events/$id"
+                      params={{ id: String(event.id) }}
+                      className="text-primary hover:underline"
+                    >
+                      {event.description || '-'}
+                    </Link>
+                  </TableCell>
+                  <TableCell className="max-w-xs truncate">
+                    {event.url ? (
+                      <a
+                        href={event.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary hover:underline"
+                      >
+                        {truncatedData}
+                      </a>
+                    ) : (
+                      truncatedData
+                    )}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {event.createdAt ? <RelativeTime date={timestampDate(event.createdAt)} /> : '-'}
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => onUnlink(event.id)}
+                      disabled={isUnlinking}
+                    >
+                      Remove
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </>
   )
 }
 
-function LogsTable({ logs }: { logs: LogEntry[] }) {
+function LogsSection({ logs }: { logs: LogEntry[] }) {
   if (logs.length === 0) {
     return <div className="text-muted-foreground">No logs yet.</div>
   }
 
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Type</TableHead>
-          <TableHead>Content</TableHead>
-          <TableHead>Created</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
+    <>
+      {/* Mobile card view */}
+      <div className="flex flex-col gap-3 md:hidden">
         {logs.map((log, index) => (
-          <TableRow key={index}>
-            <TableCell>
+          <div key={index} className="rounded-lg border p-3 space-y-2">
+            <div className="flex items-center justify-between gap-2">
               <Badge
                 variant="outline"
                 className={
@@ -510,16 +607,52 @@ function LogsTable({ logs }: { logs: LogEntry[] }) {
               >
                 {log.type}
               </Badge>
-            </TableCell>
-            <TableCell className="whitespace-pre-wrap break-words">
+              {log.createdAt && (
+                <span className="text-xs text-muted-foreground">
+                  <RelativeTime date={timestampDate(log.createdAt)} />
+                </span>
+              )}
+            </div>
+            <div className="whitespace-pre-wrap break-words text-sm">
               {log.content}
-            </TableCell>
-            <TableCell className="text-muted-foreground">
-              {log.createdAt ? <RelativeTime date={timestampDate(log.createdAt)} /> : '-'}
-            </TableCell>
-          </TableRow>
+            </div>
+          </div>
         ))}
-      </TableBody>
-    </Table>
+      </div>
+      {/* Desktop table view */}
+      <div className="hidden md:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Type</TableHead>
+              <TableHead>Content</TableHead>
+              <TableHead>Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {logs.map((log, index) => (
+              <TableRow key={index}>
+                <TableCell>
+                  <Badge
+                    variant="outline"
+                    className={
+                      logTypeStyles[log.type] ?? 'bg-gray-100 text-gray-600'
+                    }
+                  >
+                    {log.type}
+                  </Badge>
+                </TableCell>
+                <TableCell className="whitespace-pre-wrap break-words">
+                  {log.content}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {log.createdAt ? <RelativeTime date={timestampDate(log.createdAt)} /> : '-'}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </>
   )
 }

--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -66,10 +66,10 @@ function TasksPage() {
   const hiddenCount = allTasks.filter(isChildTask).length
 
   return (
-    <div className="container mx-auto py-8 px-4">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Tasks</h1>
-        <div className="flex items-center gap-4">
+    <div className="container mx-auto py-4 px-3 md:py-8 md:px-4">
+      <div className="flex flex-col gap-3 mb-6 md:flex-row md:items-center md:justify-between">
+        <h1 className="text-xl font-bold md:text-2xl">Tasks</h1>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
           <div className="flex items-center gap-2">
             <Label htmlFor="show-child-tasks" className="text-sm text-muted-foreground cursor-pointer">
               Show child tasks{hiddenCount > 0 && !showChildTasks && ` (${hiddenCount} hidden)`}
@@ -80,31 +80,33 @@ function TasksPage() {
               onCheckedChange={setShowChildTasks}
             />
           </div>
-          <div className="relative">
-            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-            <Input
-              type="text"
-              placeholder="Search tasks..."
-              className="pl-8 pr-8 w-48"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-            />
-            {searchQuery && (
-              <button
-                type="button"
-                onClick={() => setSearchQuery('')}
-                className="absolute right-2.5 top-2.5 h-4 w-4 text-muted-foreground hover:text-foreground"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            )}
+          <div className="flex items-center gap-3">
+            <div className="relative flex-1 sm:flex-initial">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                type="text"
+                placeholder="Search tasks..."
+                className="pl-8 pr-8 w-full sm:w-48"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+              {searchQuery && (
+                <button
+                  type="button"
+                  onClick={() => setSearchQuery('')}
+                  className="absolute right-2.5 top-2.5 h-4 w-4 text-muted-foreground hover:text-foreground"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+            <Link to="/tasks/new">
+              <Button>
+                <Plus className="h-4 w-4" />
+                Task
+              </Button>
+            </Link>
           </div>
-          <Link to="/tasks/new">
-            <Button>
-              <Plus className="h-4 w-4" />
-              Task
-            </Button>
-          </Link>
         </div>
       </div>
       {tasks.length === 0 ? (
@@ -112,24 +114,74 @@ function TasksPage() {
           No tasks found
         </div>
       ) : (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Name</TableHead>
-              <TableHead>Runner</TableHead>
-              <TableHead>Workspace</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Created</TableHead>
-              <TableHead></TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
+        <>
+          {/* Mobile card view */}
+          <div className="flex flex-col gap-3 md:hidden">
             {tasks.map((task) => (
-              <TaskRow key={String(task.id)} task={task} onUpdate={refetch} />
+              <TaskCard key={String(task.id)} task={task} onUpdate={refetch} />
             ))}
-          </TableBody>
-        </Table>
+          </div>
+          {/* Desktop table view */}
+          <div className="hidden md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Runner</TableHead>
+                  <TableHead>Workspace</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tasks.map((task) => (
+                  <TaskRow key={String(task.id)} task={task} onUpdate={refetch} />
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </>
       )}
+    </div>
+  )
+}
+
+function TaskCard({ task, onUpdate }: { task: Task; onUpdate: () => void }) {
+  const archiveMutation = useMutation(archiveTask, { onSuccess: () => onUpdate() })
+
+  return (
+    <div className={cn('rounded-lg border p-4 space-y-2', isChildTask(task) && 'bg-muted/30')}>
+      <div className="flex items-start justify-between gap-2">
+        <Link
+          to="/tasks/$id"
+          params={{ id: String(task.id) }}
+          className="text-primary hover:underline font-medium break-words min-w-0"
+        >
+          {task.name || `Unnamed - ${task.id}`}
+        </Link>
+        {canArchiveTask(task) && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => archiveMutation.mutateAsync({ id: task.id })}
+            disabled={archiveMutation.isPending}
+            className="shrink-0"
+          >
+            {archiveMutation.isPending && <Loader2 className="mr-1 h-3 w-3 animate-spin" />}
+            Archive
+          </Button>
+        )}
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <StatusBadge task={task} />
+        <CommandBadge task={task} />
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+        {task.workspace && <span>{task.workspace}</span>}
+        {task.runner && <span>{task.runner}</span>}
+        {task.createdAt && <RelativeTime date={timestampDate(task.createdAt)} />}
+      </div>
     </div>
   )
 }
@@ -179,4 +231,3 @@ function TaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) {
     </TableRow>
   )
 }
-

--- a/webui/src/routes/tasks.new.tsx
+++ b/webui/src/routes/tasks.new.tsx
@@ -67,8 +67,8 @@ function NewTaskPage() {
   }
 
   return (
-    <div className="container mx-auto py-8 px-4 space-y-6">
-      <h1 className="text-2xl font-bold mb-6">Create New Task</h1>
+    <div className="container mx-auto py-4 px-3 md:py-8 md:px-4 space-y-6">
+      <h1 className="text-xl font-bold mb-6 md:text-2xl">Create New Task</h1>
 
       <Card>
         <CardContent className="pt-6">

--- a/webui/src/routes/workspaces.index.tsx
+++ b/webui/src/routes/workspaces.index.tsx
@@ -63,12 +63,12 @@ function WorkspacesPage() {
   const workspaces = allWorkspaces.filter((w) => selectedRunner === ALL_RUNNERS || w.runnerId === selectedRunner)
 
   return (
-    <div className="container mx-auto py-8 px-4">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Workspaces</h1>
-        <div className="flex items-center gap-4">
+    <div className="container mx-auto py-4 px-3 md:py-8 md:px-4">
+      <div className="flex flex-col gap-3 mb-6 md:flex-row md:items-center md:justify-between">
+        <h1 className="text-xl font-bold md:text-2xl">Workspaces</h1>
+        <div className="flex items-center gap-3 md:gap-4">
           <Select value={selectedRunner} onValueChange={setSelectedRunner}>
-            <SelectTrigger className="w-48">
+            <SelectTrigger className="w-full sm:w-48">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -84,6 +84,7 @@ function WorkspacesPage() {
             variant="outline"
             onClick={handleClear}
             disabled={clearMutation.isPending || allWorkspaces.length === 0}
+            className="shrink-0"
           >
             {clearMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
             Clear
@@ -95,32 +96,53 @@ function WorkspacesPage() {
           No workspaces registered
         </div>
       ) : (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Name</TableHead>
-              <TableHead>Runner</TableHead>
-              <TableHead>Last Updated</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
+        <>
+          {/* Mobile card view */}
+          <div className="flex flex-col gap-3 md:hidden">
             {workspaces.map((workspace) => (
-              <TableRow key={workspace.name}>
-                <TableCell className="font-medium">{workspace.name}</TableCell>
-                <TableCell className="text-muted-foreground font-mono text-sm">
+              <div key={workspace.name} className="rounded-lg border p-4 space-y-1">
+                <div className="font-medium">{workspace.name}</div>
+                <div className="text-sm text-muted-foreground font-mono">
                   {workspace.runnerId || '-'}
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  {workspace.updatedAt ? (
+                </div>
+                {workspace.updatedAt && (
+                  <div className="text-xs text-muted-foreground">
                     <RelativeTime date={timestampDate(workspace.updatedAt)} />
-                  ) : (
-                    '-'
-                  )}
-                </TableCell>
-              </TableRow>
+                  </div>
+                )}
+              </div>
             ))}
-          </TableBody>
-        </Table>
+          </div>
+          {/* Desktop table view */}
+          <div className="hidden md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Runner</TableHead>
+                  <TableHead>Last Updated</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {workspaces.map((workspace) => (
+                  <TableRow key={workspace.name}>
+                    <TableCell className="font-medium">{workspace.name}</TableCell>
+                    <TableCell className="text-muted-foreground font-mono text-sm">
+                      {workspace.runnerId || '-'}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {workspace.updatedAt ? (
+                        <RelativeTime date={timestampDate(workspace.updatedAt)} />
+                      ) : (
+                        '-'
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

Makes the web UI fully usable on mobile devices by adding responsive layouts across all pages.

### Changes

**Mobile navigation**
- Hamburger menu button (visible below 768px) opens a slide-out Sheet with nav links, user email, and logout
- Desktop horizontal nav hidden on small screens
- New `Sheet` component added (using `@radix-ui/react-dialog`)

**Card-based mobile views for all data tables**
- Tasks list: card view with name, status badges, workspace, runner, and created time
- Task detail: child tasks, events, and logs all render as stacked cards on mobile
- Events list: card view with description, data preview, and timestamp
- Workspaces list: card view with name, runner, and last updated
- API Keys list: card view with name, expiry, and created time
- Desktop table views preserved at `md:` (768px) and above

**Responsive page headers**
- Title + controls stack vertically on mobile, horizontal on desktop
- Fixed-width inputs (`w-48`, `w-20`) become full-width on mobile
- Action button groups wrap naturally on small screens

**Task detail page**
- Title and action buttons stack vertically on mobile
- Task metadata uses 2-column CSS grid on mobile, flex-wrap on desktop
- Section padding reduced on mobile (`p-4` vs `p-6`)
- Links section uses `break-all` for long URLs

**Typography and spacing**
- Responsive heading sizes (`text-xl` mobile, `text-2xl` desktop)
- Reduced page padding on mobile (`py-4 px-3` vs `py-8 px-4`)
- Applied consistently to all pages including form pages

## Test plan

- [ ] Test on iPhone SE (375px) in Chrome DevTools
- [ ] Test on iPhone 14 (390px) in Chrome DevTools
- [ ] Test on iPad (768px) - should show desktop layout
- [ ] Verify hamburger menu opens/closes, nav links work
- [ ] Verify all list pages show card views on mobile, tables on desktop
- [ ] Verify task detail page is readable on mobile
- [ ] Verify form pages (new task, new event, new key) work on mobile
- [ ] Verify desktop layout is unchanged

Closes #309