### PR TITLE
Set Max-Age on session cookie to fix mobile re-login

### DIFF
--- a/internal/apiauth/apiauth.go
+++ b/internal/apiauth/apiauth.go
@@ -3,6 +3,7 @@ package apiauth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -51,6 +52,9 @@ type Config struct {
 	PostLogoutURI string
 	EncryptionKey []byte
 	Scopes        []string
+	// SessionMaxAge sets the Max-Age (in seconds) for the session cookie.
+	// If 0, defaults to 30 days (2592000 seconds).
+	SessionMaxAge int
 	// KeyValidator validates xat_ API keys.
 	KeyValidator KeyValidator
 	// Disable authentication (for development only).
@@ -71,6 +75,8 @@ type Auth struct {
 	validator KeyValidator
 	// handler handles /auth/* routes (login, callback, logout)
 	handler http.Handler
+	// sessionMaxAge is the Max-Age (in seconds) for the session cookie
+	sessionMaxAge int
 }
 
 // New creates a new Auth instance with both cookie and bearer token support.
@@ -116,11 +122,16 @@ func New(ctx context.Context, cfg Config) (*Auth, error) {
 	if err != nil {
 		return nil, err
 	}
+	maxAge := cfg.SessionMaxAge
+	if maxAge == 0 {
+		maxAge = 60 * 60 * 24 * 30 // 30 days
+	}
 	return &Auth{
-		cookie:    authentication.Middleware(authN),
-		bearer:    middleware.New(authZ),
-		validator: cfg.KeyValidator,
-		handler:   authN,
+		cookie:        authentication.Middleware(authN),
+		bearer:        middleware.New(authZ),
+		validator:     cfg.KeyValidator,
+		handler:       authN,
+		sessionMaxAge: maxAge,
 	}, nil
 }
 
@@ -220,7 +231,73 @@ func (a *Auth) Handler() http.Handler {
 			http.NotFound(w, r)
 		})
 	}
-	return a.handler
+	return a.sessionCookieMaxAge(a.handler)
+}
+
+// sessionCookieMaxAge wraps a handler to set Max-Age on session cookies.
+// The zitadel-go library hardcodes MaxAge=0 (session cookie) on the
+// "zitadel.session" cookie. This middleware intercepts Set-Cookie headers
+// and adds Max-Age so the cookie persists across mobile browser restarts.
+func (a *Auth) sessionCookieMaxAge(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(&sessionCookieWriter{
+			ResponseWriter: w,
+			maxAge:         a.sessionMaxAge,
+		}, r)
+	})
+}
+
+// sessionCookieWriter intercepts Set-Cookie headers to add Max-Age to
+// the zitadel.session cookie when it's set without one.
+type sessionCookieWriter struct {
+	http.ResponseWriter
+	maxAge      int
+	wroteHeader bool
+}
+
+func (w *sessionCookieWriter) patchCookies() {
+	if w.wroteHeader {
+		return
+	}
+	w.wroteHeader = true
+	const cookieName = "zitadel.session"
+	var cookies []string
+	for _, v := range w.Header().Values("Set-Cookie") {
+		if isSessionCookie(v, cookieName) {
+			v = setMaxAge(v, w.maxAge)
+		}
+		cookies = append(cookies, v)
+	}
+	w.Header().Del("Set-Cookie")
+	for _, c := range cookies {
+		w.Header().Add("Set-Cookie", c)
+	}
+}
+
+func (w *sessionCookieWriter) WriteHeader(statusCode int) {
+	w.patchCookies()
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *sessionCookieWriter) Write(b []byte) (int, error) {
+	w.patchCookies()
+	return w.ResponseWriter.Write(b)
+}
+
+// isSessionCookie checks if a Set-Cookie header value is for the named cookie.
+func isSessionCookie(headerVal, name string) bool {
+	return strings.HasPrefix(headerVal, name+"=")
+}
+
+// setMaxAge adds Max-Age to a Set-Cookie header value only if it doesn't
+// already have one. If the cookie already has a Max-Age attribute (including
+// Max-Age=0 for deletion), it's left unchanged.
+func setMaxAge(headerVal string, maxAge int) string {
+	lower := strings.ToLower(headerVal)
+	if strings.Contains(lower, "max-age=") {
+		return headerVal
+	}
+	return headerVal + fmt.Sprintf("; Max-Age=%d", maxAge)
 }
 
 // attachDefaultUser returns middleware that attaches a default user to all requests.

--- a/internal/apiauth/apiauth_test.go
+++ b/internal/apiauth/apiauth_test.go
@@ -1,0 +1,104 @@
+package apiauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSessionCookieMaxAge(t *testing.T) {
+	tests := []struct {
+		name       string
+		maxAge     int
+		setCookies []*http.Cookie
+		wantMaxAge []int // expected Max-Age for each cookie, -2 means "check unchanged"
+	}{
+		{
+			name:   "adds Max-Age to session cookie",
+			maxAge: 2592000,
+			setCookies: []*http.Cookie{
+				{Name: "zitadel.session", Value: "encrypted", Path: "/", HttpOnly: true, Secure: true, SameSite: http.SameSiteLaxMode},
+			},
+			wantMaxAge: []int{2592000},
+		},
+		{
+			name:   "does not modify non-session cookies",
+			maxAge: 2592000,
+			setCookies: []*http.Cookie{
+				{Name: "other", Value: "value", Path: "/"},
+			},
+			wantMaxAge: []int{0},
+		},
+		{
+			name:   "preserves deletion cookie (MaxAge -1 serializes as Max-Age=0)",
+			maxAge: 2592000,
+			setCookies: []*http.Cookie{
+				{Name: "zitadel.session", Value: "", Path: "/", MaxAge: -1},
+			},
+			// Go's http.SetCookie serializes MaxAge:-1 as "Max-Age=0" in the header.
+			// http.Response.Cookies() parses "Max-Age=0" back as MaxAge:-1.
+			// Our middleware leaves cookies alone if they already have a Max-Age attribute.
+			wantMaxAge: []int{-1},
+		},
+		{
+			name:   "handles multiple cookies",
+			maxAge: 86400,
+			setCookies: []*http.Cookie{
+				{Name: "zitadel.session", Value: "encrypted", Path: "/", HttpOnly: true, Secure: true},
+				{Name: "other", Value: "value"},
+			},
+			wantMaxAge: []int{86400, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				for _, c := range tt.setCookies {
+					http.SetCookie(w, c)
+				}
+				w.WriteHeader(http.StatusFound)
+			})
+
+			auth := &Auth{sessionMaxAge: tt.maxAge}
+			handler := auth.sessionCookieMaxAge(inner)
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/auth/callback", nil)
+			handler.ServeHTTP(rec, req)
+
+			resp := rec.Result()
+			cookies := resp.Cookies()
+			assert.Equal(t, len(cookies), len(tt.wantMaxAge), "cookie count mismatch")
+			for i, c := range cookies {
+				assert.Equal(t, c.MaxAge, tt.wantMaxAge[i], "cookie %q MaxAge", c.Name)
+			}
+		})
+	}
+}
+
+func TestSessionCookieMaxAgeImplicitWrite(t *testing.T) {
+	// Test that cookies are patched even when WriteHeader is not explicitly called
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{
+			Name:  "zitadel.session",
+			Value: "encrypted",
+			Path:  "/",
+		})
+		w.Write([]byte("OK"))
+	})
+
+	auth := &Auth{sessionMaxAge: 2592000}
+	handler := auth.sessionCookieMaxAge(inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/auth/callback", nil)
+	handler.ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	cookies := resp.Cookies()
+	assert.Equal(t, len(cookies), 1)
+	assert.Equal(t, cookies[0].MaxAge, 2592000)
+}


### PR DESCRIPTION
## Problem

Users on mobile are forced to re-login after every period of inactivity. The zitadel-go library's `setSessionCookie()` method hardcodes `MaxAge: 0` on the `zitadel.session` cookie, making it a browser-session cookie. Mobile browsers (iOS Safari, Android Chrome) aggressively purge session cookies when the app is backgrounded or under memory pressure.

Since we use stateless encrypted cookie sessions (`WithCookieSession`), once the cookie is gone the session is unrecoverable.

## Root Cause

In `zitadel-go/v3@v3.25.0`, the `Authenticator.setSessionCookie()` method at `pkg/authentication/authenticate.go:260` hardcodes:

```go
http.SetCookie(w, &http.Cookie{
    Name:     a.sessionCookieName,
    Value:    value,
    MaxAge:   0,  // <-- session cookie, no persistence
    ...
})
```

The library provides no option to configure `MaxAge` on the session cookie.

## Fix

Added a `ResponseWriter` wrapper (`sessionCookieWriter`) that intercepts `Set-Cookie` headers on auth routes and adds `Max-Age=2592000` (30 days) to the `zitadel.session` cookie.

Key behaviors:
- Only modifies the `zitadel.session` cookie, leaves other cookies untouched
- Preserves deletion cookies (logout) by not modifying cookies that already have a `Max-Age` attribute
- Handles both explicit `WriteHeader` and implicit `Write` calls
- The max age is configurable via `Config.SessionMaxAge` (defaults to 30 days)
- `Secure`, `HttpOnly`, and `SameSite=Lax` attributes are preserved (set by zitadel-go)

## Validation

After this change, the `Set-Cookie` header for the session cookie will include:
- `Max-Age=2592000` (30 days)
- `SameSite=Lax` (preserved from zitadel-go)
- `Secure` and `HttpOnly` flags (preserved from zitadel-go)
- Logout still works (zitadel-go sets `Max-Age=0` for deletion, which our wrapper leaves alone)