### PR TITLE
Rename "API Keys" to "Keys" in web UI

### DIFF
--- a/webui/src/routes/__root.tsx
+++ b/webui/src/routes/__root.tsx
@@ -65,7 +65,7 @@ function RootComponent() {
               to="/keys"
               className="text-muted-foreground hover:text-foreground transition-colors [&.active]:text-foreground"
             >
-              API Keys
+              Keys
             </Link>
           </div>
           <div className="ml-auto flex items-center gap-4">

--- a/webui/src/routes/keys.index.tsx
+++ b/webui/src/routes/keys.index.tsx
@@ -48,7 +48,7 @@ function KeysPage() {
   return (
     <div className="container mx-auto py-8 px-4">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">API Keys</h1>
+        <h1 className="text-2xl font-bold">Keys</h1>
         <Link to="/keys/new">
           <Button>
             <Plus className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- Renamed "API Keys" to "Keys" in the navigation link and page heading

## Changes
- `webui/src/routes/__root.tsx`: Nav link text
- `webui/src/routes/keys.index.tsx`: Page heading text