### PR TITLE
Link navbar icon to create task page

### DIFF
--- a/webui/src/routes/__root.tsx
+++ b/webui/src/routes/__root.tsx
@@ -39,7 +39,7 @@ function RootComponent() {
     <>
       <nav className="border-b">
         <div className="container mx-auto px-4 py-3 flex items-center gap-3 md:gap-6">
-          <Link to="/">
+          <Link to="/tasks/new">
             <img src={xagentIcon} alt="XAgent" className="h-8 w-8" />
           </Link>
           <div className="flex gap-2 md:gap-4">


### PR DESCRIPTION
## Summary

- Changes the XAgent icon in the navbar to navigate to `/tasks/new` (create task page) instead of `/` (home/task list)

## Test plan

- [ ] Click the XAgent icon in the navbar and verify it navigates to the create task page
- [ ] Verify other navigation links (Tasks, Events, Workspaces, Keys) still work correctly