### PR TITLE
Pin tool versions in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,12 +1,12 @@
 [tools]
-node = "latest"
-go = "latest"
-sops = "latest"
-terraform = "latest"
-age = "latest"
-pnpm = "latest"
-flyctl = "latest"
-"ubi:terrastruct/d2" = "latest"
+node = "25.5.0"
+go = "1.25.6"
+sops = "3.11.0"
+terraform = "1.14.4"
+age = "1.3.1"
+pnpm = "10.28.2"
+flyctl = "0.4.6"
+"ubi:terrastruct/d2" = "0.7.1"
 
 [tasks.build]
 description = "Build xagent binaries for all architectures and webhook"


### PR DESCRIPTION
Replace `"latest"` with specific version numbers for all tools to ensure reproducible builds and avoid unexpected breakage from automatic version updates.

| Tool | Version |
|------|---------|
| node | 25.5.0 |
| go | 1.25.6 |
| sops | 3.11.0 |
| terraform | 1.14.4 |
| age | 1.3.1 |
| pnpm | 10.28.2 |
| flyctl | 0.4.6 |
| d2 | 0.7.1 |

Versions were resolved from what `mise` currently resolves `"latest"` to.