### PR TITLE
Add 1-hour grace period to container pruning

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -522,8 +522,8 @@ func (r *Runner) Prune(ctx context.Context) error {
 			r.log.Error("failed to get task", "task", taskID, "error", err)
 			continue
 		}
-		// Remove container if task is archived or deleted
-		if connect.CodeOf(err) == connect.CodeNotFound || resp.Task.Archived {
+		// Remove container if task is deleted, or archived and not updated for an hour
+		if connect.CodeOf(err) == connect.CodeNotFound || (resp.Task.Archived && time.Since(resp.Task.UpdatedAt.AsTime()) > time.Hour) {
 			if err := r.docker.ContainerRemove(ctx, c.ID, container.RemoveOptions{Force: true}); err != nil {
 				r.log.Error("failed to remove container", "task", taskID, "error", err)
 			} else {


### PR DESCRIPTION
## Summary

- Containers for archived tasks are now only pruned if the task hasn't been updated in the last hour
- Deleted tasks (not found) are still pruned immediately
- This gives time to un-archive a task and resume work without losing the container

## Changes

In `internal/runner/runner.go`, the `Prune()` function's removal condition changed from:

```go
if connect.CodeOf(err) == connect.CodeNotFound || resp.Task.Archived {
```

to:

```go
if connect.CodeOf(err) == connect.CodeNotFound || (resp.Task.Archived && time.Since(resp.Task.UpdatedAt.AsTime()) > time.Hour) {
```