### PR TITLE
Set default runner concurrency to 5

### DIFF
--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -57,7 +57,7 @@ var RunnerCommand = &cli.Command{
 		&cli.IntFlag{
 			Name:  "concurrency",
 			Usage: "Maximum number of concurrent tasks (0 for unlimited)",
-			Value: 0,
+			Value: 5,
 		},
 		&cli.StringFlag{
 			Name:  "id",


### PR DESCRIPTION
Change the default value of the `--concurrency` flag from `0` (unlimited) to `5`. This provides a safer default that limits the number of concurrent tasks a runner will process.

The flag still supports `0` for unlimited concurrency when explicitly set.