### PR TITLE
Fix permission denied saving config in non-root containers

### DIFF
--- a/internal/containerbuild/builder.go
+++ b/internal/containerbuild/builder.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"path"
 	"strings"
 
 	"github.com/docker/docker/api/types/container"
@@ -15,10 +14,10 @@ import (
 
 // File is a file to copy into the container.
 type File struct {
-	Path    string // absolute path in the container (e.g. /usr/local/bin/xagent)
-	Data    []byte
-	Mode    int64
-	DirMode int64 // if non-zero, create parent directory with this mode
+	Path string // absolute path in the container (e.g. /usr/local/bin/xagent)
+	Data []byte
+	Mode int64
+	Dir  bool // if true, create a directory entry (Data is ignored)
 }
 
 // Builder holds the configuration for building a single container.
@@ -73,25 +72,18 @@ func (b *Builder) copyFiles(ctx context.Context, containerID string) error {
 	}
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
-	dirs := make(map[string]bool)
 	for _, f := range b.Files {
-		// Create parent directory entries if DirMode is specified.
-		if f.DirMode != 0 {
-			for dir := path.Dir(strings.TrimPrefix(f.Path, "/")); dir != "." && dir != ""; dir = path.Dir(dir) {
-				if dirs[dir] {
-					break
-				}
-				dirs[dir] = true
-				if err := tw.WriteHeader(&tar.Header{
-					Name:     dir + "/",
-					Mode:     f.DirMode,
-					Typeflag: tar.TypeDir,
-				}); err != nil {
-					return err
-				}
-			}
-		}
 		name := strings.TrimPrefix(f.Path, "/")
+		if f.Dir {
+			if err := tw.WriteHeader(&tar.Header{
+				Name:     name + "/",
+				Mode:     f.Mode,
+				Typeflag: tar.TypeDir,
+			}); err != nil {
+				return err
+			}
+			continue
+		}
 		if err := tw.WriteHeader(&tar.Header{
 			Name: name,
 			Mode: f.Mode,

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"path"
 	"strconv"
 	"time"
 
@@ -407,7 +408,8 @@ func (r *Runner) create(ctx context.Context, task *model.Task) (string, error) {
 		},
 		Files: []containerbuild.File{
 			{Path: "/usr/local/bin/xagent", Data: binData, Mode: 0755},
-			{Path: agent.ConfigPath(task.ID), Data: cfgData, Mode: 0666, DirMode: 01777},
+			{Path: path.Dir(agent.ConfigPath(task.ID)), Mode: 01777, Dir: true},
+			{Path: agent.ConfigPath(task.ID), Data: cfgData, Mode: 0666},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Add `DirMode` field to `containerbuild.File` struct to optionally create parent directory entries in the tar archive with specified permissions
- Set `DirMode` to `01777` (world-writable + sticky bit) for the config file so non-root container users can write to `/tmp/xagent/`

## Problem

When using Docker images with non-root default users (e.g. `mcr.microsoft.com/devcontainers/base:ubuntu-22.04` which defaults to the `vscode` user), the agent fails with:

```
ERROR: failed to save config: open /tmp/xagent/107.json.tmp: permission denied
```

The runner copies files into the container via `CopyToContainer` using tar headers that default `Uid`/`Gid` to 0 (root). The `/tmp/xagent/` directory ends up root-owned, so non-root users can't create files in it.

## Fix

The `DirMode` field lets callers specify permissions for parent directory entries in the tar archive. Setting it to `01777` mirrors the standard `/tmp` permissions (world-writable with sticky bit), allowing any user to create files while preventing deletion of other users' files.

Fixes #318