### PR TITLE
Add version command

### DIFF
--- a/cmd/xagent/main.go
+++ b/cmd/xagent/main.go
@@ -26,6 +26,7 @@ func main() {
 			command.LogsCommand,
 			command.SetupCommand,
 			command.DownloadCommand,
+			command.VersionCommand,
 		},
 	}
 

--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -1,0 +1,39 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+
+	"github.com/urfave/cli/v3"
+)
+
+var VersionCommand = &cli.Command{
+	Name:  "version",
+	Usage: "Print the version",
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			fmt.Println("(unknown)")
+			return nil
+		}
+		version := info.Main.Version
+		if version == "" || version == "(devel)" {
+			// Try to get VCS info from build settings
+			for _, setting := range info.Settings {
+				if setting.Key == "vcs.revision" {
+					version = setting.Value
+					if len(version) > 8 {
+						version = version[:8]
+					}
+					break
+				}
+			}
+		}
+		if version == "" {
+			version = "(devel)"
+		}
+		fmt.Println(version)
+		return nil
+	},
+}


### PR DESCRIPTION
Adds `xagent version` command that outputs the current version using Go's `debug.BuildInfo`.

This uses the version information that Go automatically embeds in binaries since Go 1.18:

- When installed via `go install github.com/icholy/xagent@v0.0.6`, outputs `v0.0.6`
- When built from source, outputs pseudo-version like `v0.0.6-0.20260203-b7004d3+dirty`
- Falls back to truncated commit hash if version info is unavailable

No custom build-step injection needed.