### PR TITLE
Add architecture section link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ xagent containers
 ```
 
 
+## Architecture
+
+See [CLAUDE.md](CLAUDE.md) for detailed architecture documentation.
+
 ## Local Development
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds an "Architecture" section to the README that links to CLAUDE.md for detailed documentation

## Test plan
- [x] Verify the link renders correctly in GitHub markdown
