### PR TITLE
Add bin option to Claude and Copilot agent configs

### DIFF
--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -54,7 +54,12 @@ func (a *ClaudeAgent) Prompt(ctx context.Context, prompt string, resume bool) er
 
 	args = append(args, "--print", prompt)
 
-	cmd := exec.CommandContext(ctx, "claude", args...)
+	bin := "claude"
+	if a.options != nil && a.options.Bin != "" {
+		bin = a.options.Bin
+	}
+
+	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Dir = a.cwd
 	cmd.Stderr = os.Stderr
 

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -55,7 +55,12 @@ func (a *CopilotAgent) Prompt(ctx context.Context, prompt string, resume bool) e
 
 	args = append(args, "--prompt", prompt)
 
-	cmd := exec.CommandContext(ctx, "copilot", args...)
+	bin := "copilot"
+	if a.options != nil && a.options.Bin != "" {
+		bin = a.options.Bin
+	}
+
+	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Dir = a.cwd
 	cmd.Stderr = os.Stderr
 

--- a/internal/agent/interface.go
+++ b/internal/agent/interface.go
@@ -55,11 +55,13 @@ type Options struct {
 // ClaudeOptions contains Claude-specific agent options.
 type ClaudeOptions struct {
 	Model string
+	Bin   string
 }
 
 // CopilotOptions contains Copilot-specific agent options.
 type CopilotOptions struct {
 	Model string
+	Bin   string
 }
 
 // CursorOptions contains Cursor-specific agent options.

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -98,11 +98,13 @@ type Agent struct {
 // ClaudeConfig contains Claude-specific agent configuration.
 type ClaudeConfig struct {
 	Model string `yaml:"model"`
+	Bin   string `yaml:"bin"`
 }
 
 // CopilotConfig contains Copilot-specific agent configuration.
 type CopilotConfig struct {
 	Model string `yaml:"model"`
+	Bin   string `yaml:"bin"`
 }
 
 // CursorConfig contains Cursor-specific agent configuration.
@@ -280,11 +282,13 @@ func (w *Workspace) AgentConfig() agent.Config {
 	if w.Agent.Claude != nil {
 		cfg.Claude = &agent.ClaudeOptions{
 			Model: w.Agent.Claude.Model,
+			Bin:   w.Agent.Claude.Bin,
 		}
 	}
 	if w.Agent.Copilot != nil {
 		cfg.Copilot = &agent.CopilotOptions{
 			Model: w.Agent.Copilot.Model,
+			Bin:   w.Agent.Copilot.Bin,
 		}
 	}
 	if w.Agent.Cursor != nil {


### PR DESCRIPTION
## Summary
- Add a `bin` field to `ClaudeConfig`/`ClaudeOptions` and `CopilotConfig`/`CopilotOptions`, matching the existing pattern in `CursorConfig`
- When set, the agent uses the specified binary path instead of the default command name (`claude` or `copilot`)
- Wire the field through workspace config → agent config conversion

## Usage

```yaml
workspaces:
  my-workspace:
    agent:
      type: claude
      claude:
        model: opus
        bin: /usr/local/bin/claude-custom
```

## Test plan
- [x] `go build` succeeds for all modified packages
- [ ] Verify Claude agent uses custom bin when configured
- [ ] Verify Copilot agent uses custom bin when configured
- [ ] Verify default behavior unchanged when bin is not set