### PR TITLE
Clear cached auth token from localStorage on logout

### DIFF
--- a/webui/src/routes/__root.tsx
+++ b/webui/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import { QueryClient } from '@tanstack/react-query'
 import { useQuery } from '@connectrpc/connect-query'
 import { getProfile } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
 import xagentIcon from '@/assets/icon.png'
+import { authTransport } from '@/lib/transport'
 
 // TanStack devtools check NODE_ENV and render nothing in production, but the
 // devtools code is still bundled. Use lazy loading with import.meta.env.DEV to
@@ -84,6 +85,7 @@ function RootComponent() {
               href="/auth/logout"
               className="text-muted-foreground hover:text-foreground transition-colors text-sm flex items-center gap-1.5"
               title="Logout"
+              onClick={() => authTransport.clearToken()}
             >
               <LogOut className="h-4 w-4" />
               <span className="hidden md:inline">Logout</span>


### PR DESCRIPTION
## Summary

- Clear the cached JWT token and org_id from localStorage when the user clicks the logout link
- Adds an `onClick` handler to the logout `<a>` tag that calls `authTransport.clearToken()` before navigation to `/auth/logout`

## Problem

The `AuthTransport` cached token in localStorage was not being cleared during logout. This caused stale JWT credentials to persist across logout/login cycles. After an org migration, users with old cached tokens containing `org_id: 0` experienced failed resource queries due to ownership mismatches, and logging out and back in didn't resolve the issue since the outdated token remained in localStorage.

## Test plan

- [ ] Log in to the application
- [ ] Verify `xagent_token` and `xagent_org_id` exist in localStorage
- [ ] Click the Logout button
- [ ] Verify both localStorage keys are removed before redirect to `/auth/logout`
- [ ] Log back in and verify a fresh token is issued

Fixes #348