### PR TITLE
Remove unused GetOrgMember query and store method

### DIFF
--- a/internal/store/org.go
+++ b/internal/store/org.go
@@ -115,17 +115,6 @@ func (s *Store) ListOrgMembersWithUsers(ctx context.Context, tx *sql.Tx, orgID i
 	return members, nil
 }
 
-func (s *Store) GetOrgMember(ctx context.Context, tx *sql.Tx, orgID int64, userID string) (*model.OrgMember, error) {
-	row, err := s.q(tx).GetOrgMember(ctx, sqlc.GetOrgMemberParams{
-		OrgID:  orgID,
-		UserID: userID,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return toModelOrgMember(row), nil
-}
-
 func (s *Store) IsOrgMember(ctx context.Context, tx *sql.Tx, orgID int64, userID string) (bool, error) {
 	return s.q(tx).IsOrgMember(ctx, sqlc.IsOrgMemberParams{
 		OrgID:  orgID,

--- a/internal/store/sql/queries/org.sql
+++ b/internal/store/sql/queries/org.sql
@@ -46,11 +46,6 @@ JOIN users u ON om.user_id = u.id
 WHERE om.org_id = $1
 ORDER BY om.created_at;
 
--- name: GetOrgMember :one
-SELECT org_id, user_id, role, created_at
-FROM org_members
-WHERE org_id = $1 AND user_id = $2;
-
 -- name: IsOrgMember :one
 SELECT EXISTS(
     SELECT 1 FROM org_members om

--- a/internal/store/sqlc/org.sql.go
+++ b/internal/store/sqlc/org.sql.go
@@ -87,29 +87,6 @@ func (q *Queries) GetOrg(ctx context.Context, id int64) (Org, error) {
 	return i, err
 }
 
-const getOrgMember = `-- name: GetOrgMember :one
-SELECT org_id, user_id, role, created_at
-FROM org_members
-WHERE org_id = $1 AND user_id = $2
-`
-
-type GetOrgMemberParams struct {
-	OrgID  int64  `json:"org_id"`
-	UserID string `json:"user_id"`
-}
-
-func (q *Queries) GetOrgMember(ctx context.Context, arg GetOrgMemberParams) (OrgMember, error) {
-	row := q.db.QueryRowContext(ctx, getOrgMember, arg.OrgID, arg.UserID)
-	var i OrgMember
-	err := row.Scan(
-		&i.OrgID,
-		&i.UserID,
-		&i.Role,
-		&i.CreatedAt,
-	)
-	return i, err
-}
-
 const isOrgMember = `-- name: IsOrgMember :one
 SELECT EXISTS(
     SELECT 1 FROM org_members om


### PR DESCRIPTION
## Summary

- Remove the unused `GetOrgMember` SQL query from `internal/store/sql/queries/org.sql`
- Remove the `GetOrgMember` store wrapper method from `internal/store/org.go`
- Remove the generated sqlc code (`const`, `Params` struct, and method) from `internal/store/sqlc/org.sql.go`

None of these were called anywhere in the codebase.

Closes #352