### PR TITLE
Fix settings icon missing active state in top bar

### DIFF
--- a/webui/src/routes/__root.tsx
+++ b/webui/src/routes/__root.tsx
@@ -114,7 +114,7 @@ function RootComponent() {
             )}
             <Link
               to="/settings"
-              className="text-muted-foreground hover:text-foreground transition-colors"
+              className="text-muted-foreground hover:text-foreground transition-colors [&.active]:text-foreground"
               title="Settings"
             >
               <Settings className="h-4 w-4" />


### PR DESCRIPTION
## Summary

The settings gear icon in the navigation bar was missing the `[&.active]:text-foreground` Tailwind class that all other nav links (Tasks, Events, Workspaces, Members, Keys) use to indicate the active route. This made it difficult to tell when the settings page was selected.

## Changes

Added the `[&.active]:text-foreground` class to the Settings `<Link>` component in `webui/src/routes/__root.tsx` to match the styling of all other navigation links.

## Test plan

- Navigate to the Settings page and verify the gear icon changes from muted to foreground color
- Navigate to other pages and verify the gear icon returns to muted color
- Verify other nav links still show active states correctly