### PR TITLE
Include username and PR/issue number in webhook event descriptions

### DIFF
--- a/internal/webhook/github.go
+++ b/internal/webhook/github.go
@@ -160,16 +160,18 @@ func extractGitHubWebhookEvent(webhookEvent any) *githubWebhookEvent {
 		if !strings.HasPrefix(body, "xagent:") {
 			return nil
 		}
-		description := "A comment was made on an issue"
+		login := event.Comment.User.GetLogin()
+		number := event.Issue.GetNumber()
+		description := fmt.Sprintf("%s commented on issue #%d", login, number)
 		if event.Issue.IsPullRequest() {
-			description = "A comment was made on a pull request"
+			description = fmt.Sprintf("%s commented on PR #%d", login, number)
 		}
 		return &githubWebhookEvent{
 			description:    description,
 			data:           body,
 			url:            *event.Issue.HTMLURL,
 			githubUserID:   *event.Comment.User.ID,
-			githubUsername: event.Comment.User.GetLogin(),
+			githubUsername: login,
 		}
 
 	case *github.PullRequestReviewCommentEvent:
@@ -182,12 +184,14 @@ func extractGitHubWebhookEvent(webhookEvent any) *githubWebhookEvent {
 		if !strings.HasPrefix(body, "xagent:") {
 			return nil
 		}
+		login := event.Comment.User.GetLogin()
+		number := event.PullRequest.GetNumber()
 		return &githubWebhookEvent{
-			description:    "A review comment was made on a pull request",
+			description:    fmt.Sprintf("%s commented on PR #%d review", login, number),
 			data:           body,
 			url:            *event.PullRequest.HTMLURL,
 			githubUserID:   *event.Comment.User.ID,
-			githubUsername: event.Comment.User.GetLogin(),
+			githubUsername: login,
 		}
 
 	case *github.PullRequestReviewEvent:
@@ -201,12 +205,14 @@ func extractGitHubWebhookEvent(webhookEvent any) *githubWebhookEvent {
 		if !strings.HasPrefix(body, "xagent:") {
 			return nil
 		}
+		login := event.Review.User.GetLogin()
+		number := event.PullRequest.GetNumber()
 		return &githubWebhookEvent{
-			description:    "A review was submitted on a pull request",
+			description:    fmt.Sprintf("%s reviewed PR #%d", login, number),
 			data:           body,
 			url:            *event.PullRequest.HTMLURL,
 			githubUserID:   *event.Review.User.ID,
-			githubUsername: event.Review.User.GetLogin(),
+			githubUsername: login,
 		}
 	}
 

--- a/internal/webhook/github_test.go
+++ b/internal/webhook/github_test.go
@@ -77,11 +77,12 @@ func TestExtractGitHubWebhookEvent(t *testing.T) {
 					},
 				},
 				Issue: &github.Issue{
+					Number:  github.Ptr(1),
 					HTMLURL: github.Ptr("https://github.com/owner/repo/issues/1"),
 				},
 			},
 			expected: &githubWebhookEvent{
-				description:    "A comment was made on an issue",
+				description:    "testuser commented on issue #1",
 				data:           "xagent: do something",
 				url:            "https://github.com/owner/repo/issues/1",
 				githubUserID:   123,
@@ -99,12 +100,13 @@ func TestExtractGitHubWebhookEvent(t *testing.T) {
 					},
 				},
 				Issue: &github.Issue{
+					Number:           github.Ptr(2),
 					HTMLURL:          github.Ptr("https://github.com/owner/repo/pull/2"),
 					PullRequestLinks: &github.PullRequestLinks{},
 				},
 			},
 			expected: &githubWebhookEvent{
-				description:    "A comment was made on a pull request",
+				description:    "pruser commented on PR #2",
 				data:           "xagent: review this",
 				url:            "https://github.com/owner/repo/pull/2",
 				githubUserID:   456,
@@ -143,11 +145,12 @@ func TestExtractGitHubWebhookEvent(t *testing.T) {
 					},
 				},
 				PullRequest: &github.PullRequest{
+					Number:  github.Ptr(3),
 					HTMLURL: github.Ptr("https://github.com/owner/repo/pull/3"),
 				},
 			},
 			expected: &githubWebhookEvent{
-				description:    "A review comment was made on a pull request",
+				description:    "reviewer commented on PR #3 review",
 				data:           "xagent: fix this",
 				url:            "https://github.com/owner/repo/pull/3",
 				githubUserID:   789,
@@ -187,11 +190,12 @@ func TestExtractGitHubWebhookEvent(t *testing.T) {
 					},
 				},
 				PullRequest: &github.PullRequest{
+					Number:  github.Ptr(4),
 					HTMLURL: github.Ptr("https://github.com/owner/repo/pull/4"),
 				},
 			},
 			expected: &githubWebhookEvent{
-				description:    "A review was submitted on a pull request",
+				description:    "lead reviewed PR #4",
 				data:           "xagent: please address comments",
 				url:            "https://github.com/owner/repo/pull/4",
 				githubUserID:   101,
@@ -253,11 +257,12 @@ func TestExtractGitHubWebhookEvent(t *testing.T) {
 					},
 				},
 				Issue: &github.Issue{
+					Number:  github.Ptr(1),
 					HTMLURL: github.Ptr("https://github.com/owner/repo/issues/1"),
 				},
 			},
 			expected: &githubWebhookEvent{
-				description:    "A comment was made on an issue",
+				description:    "testuser commented on issue #1",
 				data:           "xagent: trimmed",
 				url:            "https://github.com/owner/repo/issues/1",
 				githubUserID:   123,
@@ -336,6 +341,7 @@ func TestHandleGitHubWebhookRoutesToTask(t *testing.T) {
 			},
 		},
 		Issue: &github.Issue{
+			Number:           github.Ptr(10),
 			HTMLURL:          github.Ptr("https://github.com/owner/repo/pull/10"),
 			PullRequestLinks: &github.PullRequestLinks{},
 		},
@@ -427,6 +433,7 @@ func TestHandleGitHubWebhookRoutesToMultipleOrgs(t *testing.T) {
 			},
 		},
 		Issue: &github.Issue{
+			Number:           github.Ptr(42),
 			HTMLURL:          github.Ptr(prURL),
 			PullRequestLinks: &github.PullRequestLinks{},
 		},


### PR DESCRIPTION
## Summary

- Update GitHub webhook event descriptions to include the username and issue/PR number instead of generic text
- Before: `"A comment was made on a pull request"`
- After: `"icholy commented on PR #123"`

All three webhook event types are updated:
- Issue comments → `"{user} commented on issue #{n}"` or `"{user} commented on PR #{n}"`
- PR review comments → `"{user} commented on PR #{n} review"`
- PR reviews → `"{user} reviewed PR #{n}"`

## Test plan

- [x] Updated all test expectations in `TestExtractGitHubWebhookEvent`
- [x] All 14 unit test cases pass