### PR TITLE
Remove redundant "updated task name" log from MCP

### DIFF
--- a/internal/xmcp/xmcp.go
+++ b/internal/xmcp/xmcp.go
@@ -167,8 +167,6 @@ func (s *Server) updateMyTask(ctx context.Context, req *mcp.CallToolRequest, inp
 	if err != nil {
 		return errorResult("failed to update task: %v", err), nil, nil
 	}
-
-	s.log(ctx, "updated task name: %s", input.Name)
 	return textResult("Task updated"), nil, nil
 }
 


### PR DESCRIPTION
## Summary

- Remove the `s.log(ctx, "updated task name: %s", input.Name)` call from the MCP `updateMyTask` handler
- The `UpdateTask` RPC handler already creates an audit log entry when a task is updated, making this MCP-level log redundant

## Test plan

- [x] Build passes