### PR TITLE
Reject user-identity operations for API key auth

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -101,12 +101,16 @@ func (s *Server) Handler() http.Handler {
 			RedirectURL:  s.baseURL + "/github/callback",
 			Log:          s.log,
 			OnSuccess: func(w http.ResponseWriter, r *http.Request, ghUser *github.User) {
-				user := apiauth.Caller(r.Context())
-				if user == nil {
+				caller := apiauth.Caller(r.Context())
+				if caller == nil {
 					http.Error(w, "not authenticated", http.StatusUnauthorized)
 					return
 				}
-				if err := s.store.LinkGitHubAccount(r.Context(), nil, user.ID, ghUser.GetID(), ghUser.GetLogin()); err != nil {
+				if caller.ID == "" {
+					http.Error(w, "this operation requires a user identity", http.StatusForbidden)
+					return
+				}
+				if err := s.store.LinkGitHubAccount(r.Context(), nil, caller.ID, ghUser.GetID(), ghUser.GetLogin()); err != nil {
 					http.Error(w, "failed to link GitHub account", http.StatusInternalServerError)
 					return
 				}


### PR DESCRIPTION
## Summary

API key authentication (`storeKeyValidator.ValidateKey`) returns a `UserInfo` with only `OrgID` and `Name` populated, leaving the `ID` field as an empty string. The GitHub OAuth callback handler used `user.ID` without checking if it was empty, which would pass an empty string to `LinkGitHubAccount`.

This PR:
- Adds an empty ID guard in the GitHub OAuth callback, returning 403 Forbidden
- Renames the local `user` variable to `caller` for consistency with the rest of the codebase

Fixes #362