### PR TITLE
Filter settings page orgs to only show owned orgs

### DIFF
--- a/webui/src/routes/settings.tsx
+++ b/webui/src/routes/settings.tsx
@@ -122,7 +122,8 @@ function ProfileCard() {
 
 function OrgsCard() {
   const { data: profileData, refetch } = useQuery(getProfile, {})
-  const orgs = profileData?.orgs ?? []
+  const userId = profileData?.profile?.id
+  const orgs = (profileData?.orgs ?? []).filter((org) => org.owner === userId)
 
   return (
     <Card>


### PR DESCRIPTION
## Summary
- Filter the orgs list on the Settings page to only show organizations where the current user is the owner
- The `OrgsCard` component was previously showing all orgs the user is a member of, which exposed delete buttons for orgs they don't own

## Changes
- `webui/src/routes/settings.tsx`: Filter `profileData.orgs` by comparing `org.owner` against `profileData.profile.id`

Fixes #366