### PR TITLE
Fix PR review comment event description

### DIFF
--- a/internal/webhook/github.go
+++ b/internal/webhook/github.go
@@ -194,7 +194,7 @@ func extractGitHubWebhookEvent(webhookEvent any) *githubWebhookEvent {
 		login := event.Comment.User.GetLogin()
 		number := event.PullRequest.GetNumber()
 		return &githubWebhookEvent{
-			description:    fmt.Sprintf("%s commented on PR #%d review", login, number),
+			description:    fmt.Sprintf("%s reviewed PR #%d", login, number),
 			data:           body,
 			url:            *event.PullRequest.HTMLURL,
 			githubUserID:   *event.Comment.User.ID,

--- a/internal/webhook/github_test.go
+++ b/internal/webhook/github_test.go
@@ -150,7 +150,7 @@ func TestExtractGitHubWebhookEvent(t *testing.T) {
 				},
 			},
 			expected: &githubWebhookEvent{
-				description:    "reviewer commented on PR #3 review",
+				description:    "reviewer reviewed PR #3",
 				data:           "xagent: fix this",
 				url:            "https://github.com/owner/repo/pull/3",
 				githubUserID:   789,


### PR DESCRIPTION
Change the event description for `PullRequestReviewCommentEvent` from `"commented on PR #N review"` to `"reviewed PR #N"` for consistency with `PullRequestReviewEvent` descriptions.