### PR TITLE
Fix org selector not showing selection on first login

### DIFF
--- a/webui/src/lib/transport.ts
+++ b/webui/src/lib/transport.ts
@@ -5,6 +5,12 @@ const ORG_ID_KEY = "xagent_org_id";
 
 class AuthTransport {
   private refreshPromise: Promise<string> | null = null;
+  private events = new EventTarget();
+
+  subscribe(listener: () => void): () => void {
+    this.events.addEventListener("change", listener);
+    return () => this.events.removeEventListener("change", listener);
+  }
 
   getToken(): string | null {
     return localStorage.getItem(TOKEN_KEY);
@@ -17,11 +23,13 @@ class AuthTransport {
   private storeToken(token: string, orgId: string): void {
     localStorage.setItem(TOKEN_KEY, token);
     localStorage.setItem(ORG_ID_KEY, orgId);
+    this.events.dispatchEvent(new Event("change"));
   }
 
   clearToken(): void {
     localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem(ORG_ID_KEY);
+    this.events.dispatchEvent(new Event("change"));
   }
 
   async fetchToken(orgId?: string): Promise<string> {

--- a/webui/src/routes/__root.tsx
+++ b/webui/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 import { Outlet, createRootRouteWithContext, Link } from '@tanstack/react-router'
 import { LogOut, Settings } from 'lucide-react'
-import { lazy, Suspense, useState } from 'react'
+import { lazy, Suspense, useSyncExternalStore } from 'react'
 import { QueryClient, useQueryClient } from '@tanstack/react-query'
 import { useQuery } from '@connectrpc/connect-query'
 import { getProfile } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
@@ -45,11 +45,13 @@ function RootComponent() {
   const queryClient = useQueryClient()
 
   const orgs = profileData?.orgs ?? []
-  const [currentOrgId, setCurrentOrgId] = useState(() => authTransport.getOrgId())
+  const currentOrgId = useSyncExternalStore(
+    (cb) => authTransport.subscribe(cb),
+    () => authTransport.getOrgId(),
+  )
 
   const handleOrgSwitch = async (orgId: string) => {
     await authTransport.fetchToken(orgId)
-    setCurrentOrgId(authTransport.getOrgId())
     await queryClient.invalidateQueries()
   }
 


### PR DESCRIPTION
## Summary

- On first login, the org selector dropdown appeared empty because `currentOrgId` was captured once at mount time via `useState(() => authTransport.getOrgId())`, which returned `"0"` when localStorage had no `org_id`
- The auth transport's initial token fetch (triggered by the profile query) resolves `org_id=0` to the user's default org and stores the result in localStorage, but the stale React state was never updated to reflect this
- Fixed by reading `currentOrgId` directly from localStorage on each render instead of caching it in `useState`. By the time `profileData` arrives and triggers a re-render, the correct org ID is already in localStorage

## Test plan

- [ ] Clear localStorage (or use incognito) and log in fresh — verify the org selector shows the default org
- [ ] Switch orgs via the dropdown — verify the switch still works correctly
- [ ] Refresh the page — verify the previously selected org persists