### PR TITLE
Use runner ID in socket path to avoid conflicts between runners

### DIFF
--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/icholy/xagent/internal/common"
@@ -112,6 +113,7 @@ var RunnerCommand = &cli.Command{
 			RunnerID:    runnerID,
 			Log:         log,
 			Auth:        cfg.Token,
+			SocketPath:  filepath.Join(os.TempDir(), fmt.Sprintf("xagent.%s.sock", runnerID)),
 		})
 		if err != nil {
 			return err

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -11,7 +11,6 @@ import (
 	"math"
 	"os"
 	"path"
-	"path/filepath"
 	"strconv"
 	"time"
 
@@ -51,7 +50,7 @@ type Options struct {
 	RunnerID    string
 	Log         *slog.Logger
 	Auth        string
-	SocketPath  string // defaults to /tmp/xagent.{RunnerID}.sock
+	SocketPath  string // defaults to /tmp/xagent.sock
 }
 
 func New(opts Options) (*Runner, error) {
@@ -68,18 +67,12 @@ func New(opts Options) (*Runner, error) {
 
 	log := cmp.Or(opts.Log, slog.Default())
 
-	// Default socket path includes runner ID to avoid conflicts between runners
-	socketPath := opts.SocketPath
-	if socketPath == "" {
-		socketPath = filepath.Join(os.TempDir(), fmt.Sprintf("xagent.%s.sock", opts.RunnerID))
-	}
-
 	proxy := NewProxy(AgentProxyOptions{
 		ServerURL:  opts.ServerURL,
 		Token:      opts.Auth,
 		PrivateKey: opts.PrivateKey,
 		Log:        log,
-		SocketPath: socketPath,
+		SocketPath: opts.SocketPath,
 	})
 	if err := proxy.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start proxy: %w", err)


### PR DESCRIPTION
## Summary

- Include the runner ID in the default Unix socket path (`/tmp/xagent.{runnerID}.sock`) so multiple runners on the same host don't conflict
- Previously all runners defaulted to `/tmp/xagent.sock`, causing the second runner to destroy the first runner's active socket via `os.RemoveAll`

Fixes #372