### PR TITLE
Update local dev instructions for API key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ pnpm run dev
 ```
 
 The local server runs with `--no-auth`, but the runner still requires an API key.
-Create one in the local Web UI at http://localhost:5173/keys/new, then start the runner:
+Create one in the local Web UI at http://localhost:5173/ui/keys/new, then start the runner:
 
 ```bash
 xagent runner --server http://localhost:6464 -key <api-key>


### PR DESCRIPTION
## Summary

- Update the Local Development section in README to reflect that the runner now requires an API key due to the org JWT auth changes
- Add instructions to create an API key via the local Web UI and pass it with `-key` to the runner
- Add note about the private key requirement (`xagent setup` against production)
- Fix the FE directory name (`webapp` -> `webui`)
- Separate build commands into their own subsection for clarity