### PR TITLE
Remove default socket path from proxy

### DIFF
--- a/internal/runner/proxy.go
+++ b/internal/runner/proxy.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
-	"path/filepath"
 
 	"github.com/icholy/xagent/internal/agentauth"
 	"github.com/icholy/xagent/internal/model"
@@ -31,14 +29,11 @@ type AgentProxyOptions struct {
 	Token      string
 	PrivateKey ed25519.PrivateKey
 	Log        *slog.Logger
-	SocketPath string // defaults to /tmp/xagent.sock
+	SocketPath string
 }
 
 // NewProxy creates a new Proxy.
 func NewProxy(opts AgentProxyOptions) *AgentProxy {
-	if opts.SocketPath == "" {
-		opts.SocketPath = filepath.Join(os.TempDir(), "xagent.sock")
-	}
 	return &AgentProxy{
 		serverURL:  opts.ServerURL,
 		token:      opts.Token,

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -51,7 +51,7 @@ type Options struct {
 	RunnerID    string
 	Log         *slog.Logger
 	Auth        string
-	SocketPath  string // defaults to /tmp/xagent.sock
+	SocketPath  string
 }
 
 var reRunnerID = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)


### PR DESCRIPTION
## Summary
- Remove dead defaulting logic in `NewProxy` that falls back to `/tmp/xagent.sock` when no socket path is provided
- Remove the now-inaccurate `// defaults to /tmp/xagent.sock` comments from `AgentProxyOptions.SocketPath` and `Options.SocketPath`
- Remove unused `os` and `path/filepath` imports from `proxy.go`

The socket path is explicitly set at all call sites (`internal/command/runner.go` and `internal/runner/runner_test.go`), so the default was unreachable.