### PR TITLE
Include description in list_workspaces MCP tool response

### DIFF
--- a/internal/servermcp/servermcp.go
+++ b/internal/servermcp/servermcp.go
@@ -60,14 +60,16 @@ func (s *Server) listWorkspaces(ctx context.Context, req *mcp.CallToolRequest, i
 		return errorResult("failed to list workspaces: %v", err), nil, nil
 	}
 	type workspace struct {
-		Name     string `json:"name"`
-		RunnerID string `json:"runner_id"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		RunnerID    string `json:"runner_id"`
 	}
 	result := make([]workspace, len(resp.Workspaces))
 	for i, ws := range resp.Workspaces {
 		result[i] = workspace{
-			Name:     ws.Name,
-			RunnerID: ws.RunnerId,
+			Name:        ws.Name,
+			Description: ws.Description,
+			RunnerID:    ws.RunnerId,
 		}
 	}
 	return jsonResult(result), nil, nil


### PR DESCRIPTION
## Summary
- Added the `description` field to the `list_workspaces` MCP tool response
- The workspace description was already available in the protobuf response but wasn't being mapped to the MCP output struct

## Test plan
- [ ] Verify `list_workspaces` MCP tool returns description alongside name and runner_id