### PR TITLE
Include task URL in create_task MCP tool response

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -126,7 +126,7 @@ func (s *Server) Handler() http.Handler {
 		})
 	}
 	// MCP endpoint (protected by auth middleware)
-	mux.Handle("/mcp", alice.New(s.auth.RequireAuth(), s.auth.AttachUserInfo()).Then(servermcp.New(s).Handler()))
+	mux.Handle("/mcp", alice.New(s.auth.RequireAuth(), s.auth.AttachUserInfo()).Then(servermcp.New(s, s.baseURL).Handler()))
 	// React UI (SPA with client-side routing, protected by cookie auth)
 	mux.Handle("/ui/", http.StripPrefix("/ui", s.auth.RequireAuth()(WebUI())))
 	mux.Handle("/", http.RedirectHandler("/ui/", http.StatusFound))

--- a/internal/servermcp/servermcp.go
+++ b/internal/servermcp/servermcp.go
@@ -16,11 +16,12 @@ import (
 // Connect RPC service. It exposes list_workspaces and create_task tools.
 type Server struct {
 	service xagentv1connect.XAgentServiceHandler
+	baseURL string
 }
 
 // New creates a new MCP server backed by the given service handler.
-func New(service xagentv1connect.XAgentServiceHandler) *Server {
-	return &Server{service: service}
+func New(service xagentv1connect.XAgentServiceHandler, baseURL string) *Server {
+	return &Server{service: service, baseURL: baseURL}
 }
 
 // Handler returns an http.Handler that serves the MCP Streamable HTTP
@@ -97,13 +98,18 @@ func (s *Server) createTask(ctx context.Context, req *mcp.CallToolRequest, input
 		Name      string `json:"name"`
 		Workspace string `json:"workspace"`
 		Status    string `json:"status"`
+		URL       string `json:"url,omitempty"`
 	}
-	return jsonResult(taskResult{
+	result := taskResult{
 		ID:        resp.Task.Id,
 		Name:      resp.Task.Name,
 		Workspace: resp.Task.Workspace,
 		Status:    resp.Task.Status.String(),
-	}), nil, nil
+	}
+	if s.baseURL != "" {
+		result.URL = fmt.Sprintf("%s/ui/tasks/%d", s.baseURL, resp.Task.Id)
+	}
+	return jsonResult(result), nil, nil
 }
 
 func errorResult(format string, args ...any) *mcp.CallToolResult {


### PR DESCRIPTION
## Summary

- Adds a `url` field to the `create_task` MCP tool response containing the frontend URL for the created task (format: `{baseURL}/ui/tasks/{id}`)
- Passes the server's existing `--base-url` config to the MCP server
- When base URL is not configured, the `url` field is omitted from the response

## Changes

- `internal/servermcp/servermcp.go`: Add `baseURL` field to `Server` struct, include `url` in task creation response
- `internal/server/server.go`: Pass `baseURL` when constructing the MCP server