### PR TITLE
Add get_task and list_tasks tools to HTTP MCP server

### DIFF
--- a/internal/servermcp/servermcp.go
+++ b/internal/servermcp/servermcp.go
@@ -163,7 +163,6 @@ func (s *Server) getTask(ctx context.Context, req *mcp.CallToolRequest, input ge
 		Workspace    string        `json:"workspace"`
 		Runner       string        `json:"runner,omitempty"`
 		Status       string        `json:"status"`
-		Archived     bool          `json:"archived,omitempty"`
 		URL          string        `json:"url,omitempty"`
 		Instructions []instruction `json:"instructions"`
 		Logs         []logEntry    `json:"logs"`
@@ -178,7 +177,6 @@ func (s *Server) getTask(ctx context.Context, req *mcp.CallToolRequest, input ge
 		Workspace: task.Workspace,
 		Runner:    task.Runner,
 		Status:    task.Status.String(),
-		Archived:  task.Archived,
 	}
 	if s.baseURL != "" {
 		result.URL = fmt.Sprintf("%s/ui/tasks/%d", s.baseURL, task.Id)


### PR DESCRIPTION
## Summary

- Adds `get_task` tool that takes a task ID and returns full details (name, status, workspace, instructions, logs, links, and child tasks) by proxying to the `GetTaskDetails` and `ListLogs` RPCs
- Adds `list_tasks` tool that returns a summary of all tasks, proxying to the `ListTasks` RPC
- Both tools include a task URL (using `baseURL`) in their responses, matching the `create_task` pattern