### PR TITLE
Rename 'xagent run' subcommand to 'xagent driver'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Use `create_link` with `notify=true` for resources that may need follow-up (PRs 
 ```
 xagent server     # Start C2 server
 xagent runner     # Start container orchestrator
-xagent run        # Run agent (inside container, started by runner)
+xagent driver     # Run agent (inside container, started by runner)
 xagent mcp        # MCP server for tool integration
 xagent task       # Task CRUD (list, create, update, delete)
 xagent containers # List xagent containers

--- a/cmd/xagent/main.go
+++ b/cmd/xagent/main.go
@@ -14,7 +14,7 @@ func main() {
 		Name:  "xagent",
 		Usage: "Async agent orchestrator for Claude Code",
 		Commands: []*cli.Command{
-			command.RunCommand,
+			command.DriverCommand,
 			command.ServerCommand,
 			command.RunnerCommand,
 			command.TaskCommand,

--- a/internal/command/driver.go
+++ b/internal/command/driver.go
@@ -16,8 +16,8 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-var RunCommand = &cli.Command{
-	Name:  "run",
+var DriverCommand = &cli.Command{
+	Name:  "driver",
 	Usage: "Run an agent for a task",
 	Flags: []cli.Flag{
 		&cli.StringFlag{

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -420,7 +420,7 @@ func (r *Runner) create(ctx context.Context, task *model.Task) (string, error) {
 			"xagent.task": fmt.Sprint(task.ID),
 		},
 		Cmd: []string{
-			"/usr/local/bin/xagent", "run",
+			"/usr/local/bin/xagent", "driver",
 			"--server", "unix:///var/run/xagent.sock",
 			"--task", fmt.Sprint(task.ID),
 			"--token", token,


### PR DESCRIPTION
## Summary
- Renames the `xagent run` CLI subcommand to `xagent driver` to match the naming in the architecture diagram
- Renames `RunCommand` variable to `DriverCommand` and `run.go` to `driver.go`
- Updates the runner's container command invocation from `xagent run` to `xagent driver`
- Updates CLAUDE.md CLI subcommands documentation

## Test plan
- [x] `mise run build` succeeds
- [x] `go vet ./...` passes