### PR TITLE
Replace deprecated docker/errdefs with containerd/errdefs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	connectrpc.com/connect v1.19.1
 	connectrpc.com/otelconnect v0.8.0
 	github.com/XSAM/otelsql v0.41.0
+	github.com/containerd/errdefs v1.0.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/go-cmp v0.7.0
@@ -56,7 +57,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cli/browser v1.3.0 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.18.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect

--- a/internal/dockerx/container.go
+++ b/internal/dockerx/container.go
@@ -8,8 +8,8 @@ import (
 	"errors"
 	"strings"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/errdefs"
 )
 
 // ErrNotRunning is returned when attempting to kill a container that is not running.
@@ -44,7 +44,7 @@ func ContainerWait(ctx context.Context, client ContainerWaiter, containerID stri
 // It returns ErrNotRunning if the container was not running.
 func ContainerKill(ctx context.Context, client ContainerKiller, containerID string, signal string) error {
 	if err := client.ContainerKill(ctx, containerID, signal); err != nil {
-		if errdefs.IsConflict(err) && strings.Contains(err.Error(), "is not running") {
+		if cerrdefs.IsConflict(err) && strings.Contains(err.Error(), "is not running") {
 			return ErrNotRunning
 		}
 		return err


### PR DESCRIPTION
## Summary
- Replace deprecated `github.com/docker/docker/errdefs` import with `github.com/containerd/errdefs` (aliased as `cerrdefs`) in `internal/dockerx/container.go`
- Update `errdefs.IsConflict()` call to use the new package
- Run `go mod tidy` to clean up dependencies

## Test plan
- [x] `go build ./internal/dockerx/` compiles successfully
- [x] `mise run test` — all tests pass