### PR TITLE
Remove manual docker pull from up:test task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -39,10 +39,7 @@ run = "sops -d --output-type dotenv sops.env.yml > .env"
 
 [tasks."up:test"]
 description = "Start postgres via docker compose"
-run = [
-	"docker compose up -d --wait postgres",
-	"docker pull alpine:latest",
-]
+run = "docker compose up -d --wait postgres"
 
 [tasks.migrate]
 description = "Run database migrations"


### PR DESCRIPTION
## Summary
- Remove the `docker pull alpine:latest` step from the `up:test` mise task since the runner now auto-pulls images before creating containers (PR #393)
- Simplify `run` from an array to a plain string since only one command remains