### PR TITLE
Fix proposal template bullet points for Status and Issue

### DIFF
--- a/.claude/skills/proposal/SKILL.md
+++ b/.claude/skills/proposal/SKILL.md
@@ -19,8 +19,8 @@ GitHub issues describe problems. Proposals describe solutions. This skill turns 
 ```markdown
 # Title
 
-Status: accepted|rejected|pending
-Issue: #NNN
+- Status: accepted|rejected|pending
+- Issue: #NNN
 
 ## Problem
 


### PR DESCRIPTION
## Summary

- Fix the proposal skill template where Status and Issue fields render on the same line in markdown
- Changed plain text lines to bullet points (`- Status: ...`, `- Issue: ...`) so they render correctly

## Test plan

- [ ] Verify the template in `.claude/skills/proposal/SKILL.md` renders Status and Issue on separate lines