### PR TITLE
proposal: server bootstrap for docker compose

### DIFF
--- a/proposals/server-bootstrap.md
+++ b/proposals/server-bootstrap.md
@@ -1,7 +1,7 @@
 # Server Bootstrap for Docker Compose
 
 - Status: pending
-- Issue: TBD
+- Issue: https://github.com/icholy/xagent/issues/411
 
 ## Problem
 


### PR DESCRIPTION
Related to #411

## Summary

Design proposal for auto-provisioning an org and API key when the server starts with `--no-auth`, enabling `docker compose up` to work out of the box without manual setup steps.

### Key design points:

- New `--bootstrap-api-key` flag / `XAGENT_BOOTSTRAP_API_KEY` env var on the server
- Server creates an API key (idempotently) using the provided raw value when starting with `--no-auth`
- Runner auto-generates an ephemeral Ed25519 private key when none is configured
- Docker compose shares the bootstrap key between server and runner via environment
- Works with zero configuration using a static default dev key

### Changes needed:

- `internal/command/server.go`: add `--bootstrap-api-key` flag and bootstrap logic
- `internal/command/runner.go`: auto-generate private key when missing
- `docker-compose.yml`: add runner service and shared bootstrap key env var