### PR TITLE
Use pre-built GHCR image for Fly deployment

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -2,7 +2,7 @@ app = "xagent"
 primary_region = "yyz"
 
 [build]
-  build-target = "server"
+  image = "ghcr.io/icholy/xagent-server:latest"
 
 [env]
   # Set these secrets via `fly secrets set`:


### PR DESCRIPTION
## Summary

- Switch `fly.toml` from building the server target via Dockerfile to pulling the published `ghcr.io/icholy/xagent-server:latest` image
- Leverages the Docker CI workflow (`.github/workflows/docker.yml`) that publishes images on version tags

## Test plan

- [ ] Verify `fly deploy` pulls and uses the GHCR image instead of building from source