### PR TITLE
Include changed fields in UpdateTask audit log

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -332,10 +332,8 @@ func (s *Server) UpdateTask(ctx context.Context, req *xagentv1.UpdateTaskRequest
 			task.Name = req.Name
 			changed = append(changed, "name")
 		}
-		if len(req.AddInstructions) > 0 {
-			for _, inst := range req.AddInstructions {
-				task.Instructions = append(task.Instructions, model.InstructionFromProto(inst))
-			}
+		for _, inst := range req.AddInstructions {
+			task.Instructions = append(task.Instructions, model.InstructionFromProto(inst))
 			changed = append(changed, "instructions")
 		}
 		if req.Start {


### PR DESCRIPTION
## Summary

- Track which fields (name, instructions, status) are modified during `UpdateTask` and include them in the audit log message
- Format changes from `"Foo updated task"` to `"Foo updated task: name, instructions, status"` listing only the fields that were actually changed
- Falls back to the generic message if no fields were changed

## Test plan

- [ ] Verify build passes
- [ ] Update a task's name and check audit log says "updated task: name"
- [ ] Add instructions and check audit log says "updated task: instructions"
- [ ] Start a task and check audit log says "updated task: status"
- [ ] Combine multiple changes and verify all fields listed