### PR TITLE
Auto-generate private key in runner when not configured

### DIFF
--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/icholy/xagent/internal/agentauth"
 	"github.com/icholy/xagent/internal/common"
 	"github.com/icholy/xagent/internal/configfile"
 	"github.com/icholy/xagent/internal/runner"
@@ -106,7 +107,14 @@ var RunnerCommand = &cli.Command{
 			return fmt.Errorf("not authenticated, run setup first or provide -key flag")
 		}
 		if cfg.PrivateKey == nil {
-			return fmt.Errorf("no private key configured, run setup first")
+			key, err := agentauth.CreatePrivateKey()
+			if err != nil {
+				return fmt.Errorf("failed to generate private key: %w", err)
+			}
+			cfg.PrivateKey = key
+			if err := configfile.Save(cfg); err != nil {
+				return fmt.Errorf("failed to save config: %w", err)
+			}
 		}
 
 		workspaces, err := workspace.LoadConfig(configPath, nil)


### PR DESCRIPTION
## Summary

- Auto-generate an Ed25519 private key when the runner starts without one configured, instead of erroring with "run setup first"
- Saves the generated key to the config file for subsequent runs
- Simplifies deploying runners in Docker where running `xagent setup` interactively is impractical

The private key is only used locally for signing JWTs that authenticate agent containers to the runner's proxy socket, so there's no security reason it needs to come from `xagent setup`.