### PR TITLE
Fix proxy socket path for containerized runner

### DIFF
--- a/examples/runner/docker-compose.yml
+++ b/examples/runner/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./config:/etc/xagent
+      - /tmp/xagent:/tmp/xagent
     depends_on:
       - registry
 

--- a/internal/command/runner.go
+++ b/internal/command/runner.go
@@ -130,7 +130,7 @@ var RunnerCommand = &cli.Command{
 			RunnerID:    runnerID,
 			Log:         log,
 			Auth:        cfg.Token,
-			SocketPath:  filepath.Join(os.TempDir(), fmt.Sprintf("xagent.%s.sock", runnerID)),
+			SocketPath:  filepath.Join(os.TempDir(), "xagent", runnerID+".sock"),
 		})
 		if err != nil {
 			return err

--- a/internal/xagentclient/unix.go
+++ b/internal/xagentclient/unix.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 )
 
 type UnixProxy struct {
@@ -13,6 +14,11 @@ type UnixProxy struct {
 }
 
 func NewUnixProxy(path string, handler http.Handler) (*UnixProxy, error) {
+	// Ensure parent directory exists
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, err
+	}
+
 	// Remove existing socket file or directory (Docker creates a directory
 	// if the socket path doesn't exist when bind mounting).
 	if err := os.RemoveAll(path); err != nil {


### PR DESCRIPTION
## Summary
- Move proxy socket from `/tmp/xagent.{id}.sock` to `/tmp/xagent/{id}.sock` so it can be shared via a single bind mount
- Create socket parent directory automatically in `NewUnixProxy`
- Update example docker-compose to bind-mount `/tmp/xagent` between runner container and host

## Context
When the runner runs inside a Docker container (as in `examples/runner/`), workspace containers are created as sibling containers on the host via the mounted Docker socket. The proxy socket exists inside the runner container but the bind-mount path references the host filesystem, causing `connection refused` errors.

## Test plan
- [ ] Run `examples/runner/` setup and verify workspace containers can connect to the proxy socket
- [ ] Verify runner works outside of Docker (socket dir created automatically)