### PR TITLE
Remove log upload when updating task name via MCP

### DIFF
--- a/internal/xmcp/xmcp.go
+++ b/internal/xmcp/xmcp.go
@@ -168,7 +168,6 @@ func (s *Server) updateMyTask(ctx context.Context, req *mcp.CallToolRequest, inp
 		return errorResult("failed to update task: %v", err), nil, nil
 	}
 
-	s.log(ctx, "updated task name: %s", input.Name)
 	return textResult("Task updated"), nil, nil
 }
 


### PR DESCRIPTION
## Summary
- Remove the `s.log()` call in `updateMyTask` that uploaded a log entry to the server every time the task name was updated via MCP

## Test plan
- Verify the MCP `update_my_task` tool still updates the task name successfully
- Confirm no log entry is uploaded when updating the name