### PR TITLE
proposal: OAuth 2.1 for MCP endpoint

### DIFF
--- a/proposals/mcp-oauth.md
+++ b/proposals/mcp-oauth.md
@@ -191,9 +191,9 @@ default:
 
 ### New Package
 
-`internal/mcpauth/` containing:
+`internal/oauthflow/` containing:
 
-- `mcpauth.go` -- `Server` struct, `Options`, `New()` constructor
+- `oauthflow.go` -- `Server` struct, `Options`, `New()` constructor
 - `code.go` -- auth code JWT claims, sign/verify helpers
 - `handlers.go` -- HTTP handlers for all 4 endpoints
 
@@ -211,15 +211,15 @@ All dependencies are existing types. No new store queries or proto changes. `Key
 ### Route Registration in `server.go`
 
 ```go
-mcpOAuth := mcpauth.New(mcpauth.Options{
+oauthFlow := oauthflow.New(mcpauth.Options{
     AppKey:  appKey,
     BaseURL: s.baseURL,
 })
-mux.HandleFunc("/.well-known/oauth-authorization-server", mcpOAuth.HandleMetadata)
-mux.HandleFunc("/.well-known/oauth-protected-resource", mcpOAuth.HandleResourceMetadata)
-mux.HandleFunc("/oauth/register", mcpOAuth.HandleRegister)
-mux.HandleFunc("/oauth/authorize", mcpOAuth.HandleAuthorize)
-mux.HandleFunc("/oauth/token", mcpOAuth.HandleToken)
+mux.HandleFunc("/.well-known/oauth-authorization-server", oauthFlow.HandleMetadata)
+mux.HandleFunc("/.well-known/oauth-protected-resource", oauthFlow.HandleResourceMetadata)
+mux.HandleFunc("/oauth/register", oauthFlow.HandleRegister)
+mux.HandleFunc("/oauth/authorize", oauthFlow.HandleAuthorize)
+mux.HandleFunc("/oauth/token", oauthFlow.HandleToken)
 ```
 
 All routes are public -- no auth middleware needed. The `/oauth/authorize` POST authenticates via the app JWT in the request body.


### PR DESCRIPTION
## Summary

Design proposal for adding OAuth 2.1 authorization code flow to the MCP endpoint, enabling xagent to be used as a Claude.ai custom connector.

- Adds `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource` discovery endpoints
- Adds `/oauth/authorize` (frontend form where user enters API key) and `/oauth/token` (exchanges auth code for app JWT)
- Reuses existing `KeyValidator`, `SignAppToken`, and `VerifyAppToken` infrastructure
- No database migrations, no Zitadel dependency

Related to #417

## Test plan

- [ ] Review proposal for completeness and correctness
- [ ] Validate against MCP auth spec (3/26 and 6/18 versions)
- [ ] Confirm feasibility of SPA routing for `/oauth/authorize` outside `/ui/` prefix