### PR TITLE
Add end-to-end test for OAuth 2.1 authorization code flow

### DIFF
--- a/internal/oauthflow/handlers_test.go
+++ b/internal/oauthflow/handlers_test.go
@@ -1,7 +1,6 @@
 package oauthflow_test
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -89,7 +88,7 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 	assert.Equal(t, location.Query().Get("state"), "test-state")
 
 	// Exchange authorization code for tokens using oauth2 client
-	ctx := context.Background()
+	ctx := t.Context()
 	token, err := oauthCfg.Exchange(ctx, code, oauth2.VerifierOption(verifier))
 	assert.NilError(t, err)
 	assert.Assert(t, token.AccessToken != "")


### PR DESCRIPTION
## Summary
- Adds `internal/oauthflow/handlers_test.go` with an end-to-end test covering the full OAuth 2.1 authorization code flow with PKCE
- Test exercises: client registration, PKCE challenge/verifier, app JWT authorization, code exchange, and refresh token rotation
- Pure HTTP handler tests with no database or external dependencies

## Test plan
- [x] `go test ./internal/oauthflow/ -v` passes