### PR TITLE
Fix OAuth deny button to redirect with access_denied error

### DIFF
--- a/webui/src/routes/oauth.authorize.tsx
+++ b/webui/src/routes/oauth.authorize.tsx
@@ -134,7 +134,14 @@ function OAuthAuthorizePage() {
             </Button>
             <Button
               variant="outline"
-              onClick={() => window.close()}
+              onClick={() => {
+                const redirectUrl = new URL(redirectUri)
+                redirectUrl.searchParams.set('error', 'access_denied')
+                if (state) {
+                  redirectUrl.searchParams.set('state', state)
+                }
+                window.location.href = redirectUrl.toString()
+              }}
               disabled={submitting}
             >
               Deny


### PR DESCRIPTION
## Summary
- Replace `window.close()` on the OAuth authorize page's Deny button with a proper OAuth 2.1 error redirect
- Redirects back to `redirect_uri` with `error=access_denied` and includes `state` parameter if present
- `window.close()` doesn't work for tabs not opened by JavaScript, so this was effectively a no-op

## Test plan
- [ ] Navigate to the OAuth authorize page with valid params
- [ ] Click Deny and verify redirect to `redirect_uri?error=access_denied&state=...`
- [ ] Verify state parameter is omitted when not provided