### PR TITLE
Fix org display not updating on OAuth authorize page

### DIFF
--- a/webui/src/routes/oauth.authorize.tsx
+++ b/webui/src/routes/oauth.authorize.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { useQuery } from '@connectrpc/connect-query'
 import { getProfile } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
 import { authTransport } from '@/lib/transport'
+import { useOrgId } from '@/hooks/use-org-id'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 
@@ -25,7 +26,7 @@ function OAuthAuthorizePage() {
 
   const profile = profileData?.profile
   const orgs = profileData?.orgs ?? []
-  const currentOrgId = authTransport.getOrgId()
+  const currentOrgId = useOrgId()
   const currentOrg = orgs.find((o) => String(o.id) === currentOrgId)
 
   const handleApprove = async () => {


### PR DESCRIPTION
## Summary
- Replace non-reactive `authTransport.getOrgId()` with the `useOrgId()` hook on the OAuth authorize page
- The consent card now re-renders when the user switches orgs via the nav org switcher, correctly showing which org they're granting access to

## Test plan
- [ ] Navigate to `/oauth/authorize` with valid OAuth params
- [ ] Switch org using the nav org switcher
- [ ] Verify the "Organization:" field in the consent card updates to reflect the newly selected org