### PR TITLE
Fix OAuth approve button loading state resetting prematurely

### DIFF
--- a/webui/src/routes/oauth.authorize.tsx
+++ b/webui/src/routes/oauth.authorize.tsx
@@ -54,13 +54,13 @@ function OAuthAuthorizePage() {
       if (!resp.ok) {
         const text = await resp.text()
         setError(text || `Authorization failed (${resp.status})`)
+        setSubmitting(false)
         return
       }
       const data = await resp.json()
       window.location.href = data.redirect_uri
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Unknown error')
-    } finally {
       setSubmitting(false)
     }
   }


### PR DESCRIPTION
## Summary

- Fix the OAuth authorize page's Approve button reverting from loading state before the redirect happens
- The `finally` block was always calling `setSubmitting(false)`, even on successful authorization when `window.location.href` redirect was pending
- Moved `setSubmitting(false)` to only the error paths (failed response and caught exceptions) so the button stays in loading state until navigation occurs

## Test plan

- Navigate to the OAuth authorize page with valid parameters
- Click "Approve" and verify the button stays in "Authorizing..." state until redirect
- Verify that on error (e.g. invalid redirect_uri), the button correctly reverts to "Approve"