### PR TITLE
Add tail flag example to README debugging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,19 @@ View container logs:
 xagent logs -f <taskid>
 ```
 
+Stream logs in real-time (useful for long-running tasks):
+
+```bash
+xagent logs -f --tail 100 <taskid>
+```
+
 Get a shell to a task container:
 
 ```bash
 xagent shell <taskid>
 ```
 
-List task containers
+List task containers:
 
 ```bash
 xagent containers


### PR DESCRIPTION
## Summary
- Added an example showing the `--tail` flag with `xagent logs` for streaming recent logs on long-running tasks
- Fixed minor punctuation inconsistency in the debugging section

## Test plan
- [x] Verified README renders correctly