### PR TITLE
Always fetch fresh token in OAuth authorize page

### DIFF
--- a/webui/src/routes/oauth.authorize.tsx
+++ b/webui/src/routes/oauth.authorize.tsx
@@ -33,12 +33,9 @@ function OAuthAuthorizePage() {
     setError(null)
     setSubmitting(true)
     try {
-      let token = authTransport.getToken()
-      if (!token) {
-        token = await authTransport.fetchToken()
-      }
+      const token = await authTransport.fetchToken()
       const body = new URLSearchParams({
-        token: token!,
+        token: token,
         client_id: clientId,
         redirect_uri: redirectUri,
         state,


### PR DESCRIPTION
The `handleApprove` function in the OAuth authorize page previously checked for a cached token via `authTransport.getToken()` and only called `fetchToken()` if it was null. This meant it could use an expired cached token, causing authorization failures.

Changed to always call `authTransport.fetchToken()` to ensure a fresh, valid token is used when submitting the OAuth approval. Also removed the unnecessary non-null assertion since `fetchToken()` returns `Promise<string>`.