### PR TITLE
Remove duplicated error handling in OAuth authorize

### DIFF
--- a/webui/src/routes/oauth.authorize.tsx
+++ b/webui/src/routes/oauth.authorize.tsx
@@ -53,9 +53,7 @@ function OAuthAuthorizePage() {
       })
       if (!resp.ok) {
         const text = await resp.text()
-        setError(text || `Authorization failed (${resp.status})`)
-        setSubmitting(false)
-        return
+        throw new Error(text || `Authorization failed (${resp.status})`)
       }
       const data = await resp.json()
       window.location.href = data.redirect_uri


### PR DESCRIPTION
## Summary

- In `handleApprove`, the `!resp.ok` block manually called `setError()` and `setSubmitting(false)` instead of letting the catch block handle it
- Changed to throw an error so the existing catch block handles both error state and submitting state consistently

## Test plan

- Verify OAuth authorization flow still works when server returns a successful response
- Verify error is displayed correctly when server returns a non-ok response