### PR TITLE
fix: move agent unix socket to /xagent.sock

### DIFF
--- a/.claude/skills/grpc/SKILL.md
+++ b/.claude/skills/grpc/SKILL.md
@@ -109,7 +109,7 @@ import "github.com/icholy/xagent/internal/xagentclient"
 client := xagentclient.New("http://localhost:6464")
 
 // Unix socket client (used inside containers)
-client := xagentclient.New("unix:///var/run/xagent.sock")
+client := xagentclient.New("unix:///xagent.sock")
 ```
 
 ### Making RPC calls

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ XAGENT is an async agent orchestrator using a botnet-style C2 (command & control
 - **Tasks** are the unit of work - contain workspace reference and prompts to execute
 - **Agents** run one-to-one with tasks inside containers named `xagent-{task-id}`
 - **Workspaces** define container config (image, volumes, env vars) and MCP servers in `workspaces.yaml`
-- Communication happens via Unix socket proxy at `/var/run/xagent.sock` inside containers
+- Communication happens via Unix socket proxy at `/xagent.sock` inside containers
 - Runner auto-injects an `xagent` MCP server (see below)
 
 ### MCP Server Tools

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -402,7 +402,7 @@ func (r *Runner) create(ctx context.Context, task *model.Task) (string, error) {
 		Command: "/usr/local/bin/xagent",
 		Args: []string{
 			"mcp",
-			"--server", "unix:///var/run/xagent.sock",
+			"--server", xagentclient.AgentSocketURL,
 			"--task", fmt.Sprint(task.ID),
 			"--runner", task.Runner,
 			"--workspace", task.Workspace,
@@ -430,17 +430,17 @@ func (r *Runner) create(ctx context.Context, task *model.Task) (string, error) {
 		},
 		Cmd: []string{
 			"/usr/local/bin/xagent", "driver",
-			"--server", "unix:///var/run/xagent.sock",
+			"--server", xagentclient.AgentSocketURL,
 			"--task", fmt.Sprint(task.ID),
 			"--token", token,
 		},
 		Env: []string{
 			fmt.Sprintf("XAGENT_TASK_ID=%d", task.ID),
 			fmt.Sprintf("XAGENT_TOKEN=%s", token),
-			"XAGENT_SERVER=unix:///var/run/xagent.sock",
+			"XAGENT_SERVER=" + xagentclient.AgentSocketURL,
 		},
 		Binds: []string{
-			r.proxy.SocketPath() + ":/var/run/xagent.sock",
+			r.proxy.SocketPath() + ":" + xagentclient.AgentSocketPath,
 		},
 		Files: []containerbuild.File{
 			{Path: "/usr/local/bin/xagent", Data: binData, Mode: 0755},

--- a/internal/xagentclient/client.go
+++ b/internal/xagentclient/client.go
@@ -19,6 +19,12 @@ const DefaultTimeout = 30 * time.Second
 // DefaultURL is the default xagent server URL.
 const DefaultURL = "https://xagent.choly.ca"
 
+// AgentSocketPath is the path of the proxy unix socket inside agent containers.
+const AgentSocketPath = "/xagent.sock"
+
+// AgentSocketURL is the unix-socket URL agents use to reach the proxy.
+const AgentSocketURL = "unix://" + AgentSocketPath
+
 type Client = xagentv1connect.XAgentServiceClient
 
 // Options configures the xagent client.


### PR DESCRIPTION
## Summary

- Docker 29.x rejects `CopyToContainer` on any container whose bind destination traverses a symlink. The workspace image has `/var/run -> /run`, so binding the proxy socket at `/var/run/xagent.sock` poisons the container: every subsequent file copy fails with `Error response from daemon: mkdirat var/run: file exists`, even tars that don't touch `var/run`.
- Bind at `/xagent.sock` instead. Root `/` is always a real directory across Debian, Ubuntu, Alpine, distroless, etc., so Docker can drop the mountpoint without symlink resolution.
- Centralize the path and URL as `xagentclient.AgentSocketPath` / `xagentclient.AgentSocketURL` so the four references stay in sync.

## Reproduction

```sh
docker create --name repro -v /tmp/foo.sock:/var/run/xagent.sock \
  ghcr.io/icholy/xagent-workspace-mise:latest sleep 60
echo hi > /tmp/single.txt
docker cp /tmp/single.txt repro:/tmp/single.txt
# Error response from daemon: mkdirat var/run: file exists
```

Switching the bind destination to `/run/xagent.sock` or `/xagent.sock` makes the copy succeed.

## Test plan

- [ ] `mise run build`
- [ ] Start the runner, kick a task in the `xagent` workspace, confirm the container starts and the agent connects to the proxy.