### PR TITLE
fix: return 401 for invalid Bearer tokens

### DIFF
--- a/internal/auth/apiauth/apiauth.go
+++ b/internal/auth/apiauth/apiauth.go
@@ -298,6 +298,13 @@ func (a *Auth) RequireAuth() func(http.Handler) http.Handler {
 						next.ServeHTTP(w, r)
 						return
 					}
+					// If a Bearer token was supplied but invalid/expired, return 401
+					// rather than falling through to cookie auth (which would return a
+					// redirect). OAuth clients like n8n only refresh on a 401 response.
+					if strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+						http.Error(w, "invalid or expired token", http.StatusUnauthorized)
+						return
+					}
 					a.cookie.RequireAuthentication()(a.attachUserInfo(next)).ServeHTTP(w, r)
 				}
 			}


### PR DESCRIPTION
## Summary

OAuth MCP clients (n8n, Claude.ai) only refresh access tokens reactively on an HTTP 401 response. When an app JWT expired, `RequireAuth` fell through to the zitadel cookie middleware, which returns a redirect for cookieless requests. The client never saw a 401, so it never refreshed and the connection died at the 5-minute TTL.

This change returns 401 directly when an `Authorization: Bearer` header is present but the token is invalid/expired, instead of falling through to cookie auth. Cookie auth still applies when no `Authorization` header is present.

A follow-up proposal (see task #589) will simplify the dispatch further by routing on the Bearer prefix and removing the `X-Auth-Type` header.

## Test plan

- [ ] Manually verify n8n MCP connection survives past 5 minutes (reactive refresh fires on 401)
- [ ] Confirm cookieless API requests with an expired Bearer get a 401, not a redirect
- [ ] Confirm browser cookie auth still works for the Web UI
- [ ] Existing CLI flow with `xat_` API keys unaffected