### PR TITLE
feat(runner): gate github token issuance behind workspace scopes

### DIFF
--- a/internal/agentmcp/filter.go
+++ b/internal/agentmcp/filter.go
@@ -169,8 +169,12 @@ func (p *AgentFilter) ListLogs(ctx context.Context, req *xagentv1.ListLogsReques
 }
 
 func (p *AgentFilter) CreateGitHubToken(ctx context.Context, req *xagentv1.CreateGitHubTokenRequest) (*xagentv1.CreateGitHubTokenResponse, error) {
-	if _, err := p.claims(ctx); err != nil {
+	claims, err := p.claims(ctx)
+	if err != nil {
 		return nil, err
+	}
+	if !claims.HasScope(agentauth.ScopeGitHubToken) {
+		return nil, errPermissionDenied("github token issuance is disabled for this workspace")
 	}
 	return p.client.CreateGitHubToken(ctx, req)
 }

--- a/internal/agentmcp/filter_test.go
+++ b/internal/agentmcp/filter_test.go
@@ -77,6 +77,35 @@ func TestAgentFilter_SubmitRunnerEvents_BatchMismatchAllOrNothing(t *testing.T) 
 	assert.Equal(t, connect.CodeOf(err), connect.CodePermissionDenied)
 }
 
+func TestAgentFilter_CreateGitHubToken_Allowed(t *testing.T) {
+	client := &xagentclient.ClientMock{
+		CreateGitHubTokenFunc: func(ctx context.Context, req *xagentv1.CreateGitHubTokenRequest) (*xagentv1.CreateGitHubTokenResponse, error) {
+			return &xagentv1.CreateGitHubTokenResponse{Token: "ghs_token"}, nil
+		},
+	}
+	filter := NewAgentFilter(client)
+
+	ctx := agentauth.ContextWithClaims(t.Context(), &agentauth.TaskClaims{TaskID: 42, Scopes: []string{agentauth.ScopeGitHubToken}})
+	resp, err := filter.CreateGitHubToken(ctx, &xagentv1.CreateGitHubTokenRequest{})
+	assert.NilError(t, err)
+	assert.Equal(t, resp.Token, "ghs_token")
+	assert.Equal(t, len(client.CreateGitHubTokenCalls()), 1)
+}
+
+func TestAgentFilter_CreateGitHubToken_Denied(t *testing.T) {
+	client := &xagentclient.ClientMock{
+		CreateGitHubTokenFunc: func(ctx context.Context, req *xagentv1.CreateGitHubTokenRequest) (*xagentv1.CreateGitHubTokenResponse, error) {
+			t.Fatal("underlying client must not be called when github token is disabled")
+			return nil, nil
+		},
+	}
+	filter := NewAgentFilter(client)
+
+	ctx := agentauth.ContextWithClaims(t.Context(), &agentauth.TaskClaims{TaskID: 42})
+	_, err := filter.CreateGitHubToken(ctx, &xagentv1.CreateGitHubTokenRequest{})
+	assert.Equal(t, connect.CodeOf(err), connect.CodePermissionDenied)
+}
+
 func TestAgentFilter_SubmitRunnerEvents_MissingClaims(t *testing.T) {
 	client := &xagentclient.ClientMock{
 		SubmitRunnerEventsFunc: func(ctx context.Context, req *xagentv1.SubmitRunnerEventsRequest) (*xagentv1.SubmitRunnerEventsResponse, error) {

--- a/internal/agentmcp/xmcp.go
+++ b/internal/agentmcp/xmcp.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
+	"github.com/icholy/xagent/internal/auth/agentauth"
 	"github.com/icholy/xagent/internal/model"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/xagentclient"
@@ -19,13 +21,19 @@ import (
 type Server struct {
 	client xagentclient.Client
 	task   *model.Task
+	scopes []string
 }
 
-func NewServer(client xagentclient.Client, task *model.Task) *Server {
+func NewServer(client xagentclient.Client, task *model.Task, scopes []string) *Server {
 	return &Server{
 		client: client,
 		task:   task,
+		scopes: scopes,
 	}
+}
+
+func (s *Server) hasScope(scope string) bool {
+	return slices.Contains(s.scopes, scope)
 }
 
 func (s *Server) log(ctx context.Context, format string, args ...any) {
@@ -81,11 +89,12 @@ func (s *Server) AddTools(server *mcp.Server) {
 		Description: "List logs for a child task",
 	}, s.listChildTaskLogs)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "get_github_token",
-		Description: "Get a short-lived GitHub App installation token for the current org. Fallback for shell-outs (e.g. a one-off `gh` invocation) that need a raw GITHUB_TOKEN — primary GitHub access goes through git (credential helper) and the github MCP server.",
-	}, s.getGitHubToken)
-
+	if s.hasScope(agentauth.ScopeGitHubToken) {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "get_github_token",
+			Description: "Get a short-lived GitHub App installation token for the current org. Fallback for shell-outs (e.g. a one-off `gh` invocation) that need a raw GITHUB_TOKEN — primary GitHub access goes through git (credential helper) and the github MCP server.",
+		}, s.getGitHubToken)
+	}
 }
 
 type createLinkInput struct {

--- a/internal/agentmcp/xmcp_test.go
+++ b/internal/agentmcp/xmcp_test.go
@@ -65,7 +65,7 @@ func TestGetMyTask(t *testing.T) {
 		ID:        123,
 		Runner:    "test-runner",
 		Workspace: "test-workspace",
-	})
+	}, nil)
 	session := setupTestSession(t, srv, nil)
 
 	// Call the tool through the MCP framework
@@ -111,7 +111,7 @@ func TestUpdateChildTask_ArchivedTask(t *testing.T) {
 	// Wrap client with AgentFilter to enforce authorization
 	filter := NewAgentFilter(client)
 	task := &model.Task{ID: parentTaskID, Runner: "test-runner", Workspace: "test-workspace"}
-	srv := NewServer(filter, task)
+	srv := NewServer(filter, task, nil)
 	session := setupTestSession(t, srv, &agentauth.TaskClaims{
 		TaskID:    parentTaskID,
 		Workspace: "test-workspace",
@@ -144,7 +144,7 @@ func TestGetGitHubToken(t *testing.T) {
 		},
 	}
 
-	srv := NewServer(client, &model.Task{ID: 123, Runner: "test-runner", Workspace: "test-workspace"})
+	srv := NewServer(client, &model.Task{ID: 123, Runner: "test-runner", Workspace: "test-workspace"}, []string{agentauth.ScopeGitHubToken})
 	session := setupTestSession(t, srv, nil)
 
 	result, err := session.CallTool(t.Context(), &mcp.CallToolParams{
@@ -168,7 +168,7 @@ func TestGetGitHubToken_Error(t *testing.T) {
 		},
 	}
 
-	srv := NewServer(client, &model.Task{ID: 123, Runner: "test-runner", Workspace: "test-workspace"})
+	srv := NewServer(client, &model.Task{ID: 123, Runner: "test-runner", Workspace: "test-workspace"}, []string{agentauth.ScopeGitHubToken})
 	session := setupTestSession(t, srv, nil)
 
 	result, err := session.CallTool(t.Context(), &mcp.CallToolParams{
@@ -181,6 +181,24 @@ func TestGetGitHubToken_Error(t *testing.T) {
 	text, ok := result.Content[0].(*mcp.TextContent)
 	assert.Assert(t, ok, "expected TextContent")
 	assert.Assert(t, strings.Contains(text.Text, "no installation linked"), "expected error message, got: %s", text.Text)
+}
+
+func TestGetGitHubToken_NotRegisteredWithoutScope(t *testing.T) {
+	client := &xagentclient.ClientMock{
+		CreateGitHubTokenFunc: func(ctx context.Context, req *xagentv1.CreateGitHubTokenRequest) (*xagentv1.CreateGitHubTokenResponse, error) {
+			t.Fatal("tool must not be callable when scope is absent")
+			return nil, nil
+		},
+	}
+
+	srv := NewServer(client, &model.Task{ID: 123, Runner: "test-runner", Workspace: "test-workspace"}, nil)
+	session := setupTestSession(t, srv, nil)
+
+	tools, err := session.ListTools(t.Context(), nil)
+	assert.NilError(t, err)
+	for _, tool := range tools.Tools {
+		assert.Assert(t, tool.Name != "get_github_token", "get_github_token should not be registered without scope")
+	}
 }
 
 func assertTextResult(t *testing.T, result *mcp.CallToolResult, want map[string]any) {

--- a/internal/auth/agentauth/token.go
+++ b/internal/auth/agentauth/token.go
@@ -4,16 +4,40 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"fmt"
+	"slices"
 
 	"github.com/golang-jwt/jwt/v4"
 )
 
+// Scopes grant tasks additional capabilities beyond their own task data.
+const (
+	// ScopeGitHubToken allows issuing GitHub App installation tokens via the
+	// CreateGitHubToken RPC.
+	ScopeGitHubToken = "github_token"
+)
+
+// ValidScope reports whether scope is a recognized capability scope.
+func ValidScope(scope string) bool {
+	switch scope {
+	case ScopeGitHubToken:
+		return true
+	default:
+		return false
+	}
+}
+
 // TaskClaims contains the JWT claims for a task's identity.
 type TaskClaims struct {
 	jwt.RegisteredClaims
-	TaskID    int64  `json:"task_id"`
-	Workspace string `json:"workspace"`
-	Runner    string `json:"runner"`
+	TaskID    int64    `json:"task_id"`
+	Workspace string   `json:"workspace"`
+	Runner    string   `json:"runner"`
+	Scopes    []string `json:"scopes,omitempty"`
+}
+
+// HasScope reports whether the claims include the given capability scope.
+func (c *TaskClaims) HasScope(scope string) bool {
+	return slices.Contains(c.Scopes, scope)
 }
 
 // CreatePrivateKey generates a new Ed25519 private key.

--- a/internal/command/mcp.go
+++ b/internal/command/mcp.go
@@ -43,6 +43,10 @@ var McpCommand = &cli.Command{
 			Usage:    "Authentication token",
 			Required: true,
 		},
+		&cli.StringSliceFlag{
+			Name:  "scope",
+			Usage: "Capability scope granted to the task (repeatable)",
+		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		server := mcp.NewServer(&mcp.Implementation{
@@ -56,7 +60,7 @@ var McpCommand = &cli.Command{
 			Runner:    cmd.String("runner"),
 			Workspace: cmd.String("workspace"),
 		}
-		agentmcp.NewServer(client, task).AddTools(server)
+		agentmcp.NewServer(client, task, cmd.StringSlice("scope")).AddTools(server)
 
 		return server.Run(ctx, &mcp.StdioTransport{})
 	},

--- a/internal/runner/proxy.go
+++ b/internal/runner/proxy.go
@@ -77,12 +77,14 @@ func (p *AgentProxy) Start() error {
 	return nil
 }
 
-// TaskToken creates a signed JWT for the given task.
-func (p *AgentProxy) TaskToken(task *model.Task) (string, error) {
+// TaskToken creates a signed JWT for the given task. scopes grant the task
+// additional capabilities (see agentauth scope constants).
+func (p *AgentProxy) TaskToken(task *model.Task, scopes []string) (string, error) {
 	return agentauth.SignToken(p.privateKey, &agentauth.TaskClaims{
 		TaskID:    task.ID,
 		Workspace: task.Workspace,
 		Runner:    task.Runner,
+		Scopes:    scopes,
 	})
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -375,7 +375,7 @@ func (r *Runner) create(ctx context.Context, task *model.Task) (string, error) {
 	}
 
 	// Generate JWT for this task
-	token, err := r.proxy.TaskToken(task)
+	token, err := r.proxy.TaskToken(task, ws.Scopes)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate token: %w", err)
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -402,17 +402,21 @@ func (r *Runner) create(ctx context.Context, task *model.Task) (string, error) {
 
 	// Build agent config
 	cfg := ws.AgentConfig()
+	mcpArgs := []string{
+		"mcp",
+		"--server", xagentclient.AgentSocketURL,
+		"--task", fmt.Sprint(task.ID),
+		"--runner", task.Runner,
+		"--workspace", task.Workspace,
+		"--token", token,
+	}
+	for _, scope := range ws.Scopes {
+		mcpArgs = append(mcpArgs, "--scope", scope)
+	}
 	cfg.McpServers["xagent"] = agent.McpServer{
 		Type:    "stdio",
 		Command: "/usr/local/bin/xagent",
-		Args: []string{
-			"mcp",
-			"--server", xagentclient.AgentSocketURL,
-			"--task", fmt.Sprint(task.ID),
-			"--runner", task.Runner,
-			"--workspace", task.Workspace,
-			"--token", token,
-		},
+		Args:    mcpArgs,
 	}
 	cfgData, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {

--- a/internal/runner/workspace/workspace.go
+++ b/internal/runner/workspace/workspace.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/docker/api/types/network"
 	"github.com/icholy/xagent/internal/agent"
+	"github.com/icholy/xagent/internal/auth/agentauth"
 	"github.com/icholy/xagent/internal/configfile"
 	"github.com/icholy/xagent/internal/x/expandvar"
 	"gopkg.in/yaml.v3"
@@ -83,6 +84,10 @@ type Workspace struct {
 	Container   Container `yaml:"container"`
 	Agent       Agent     `yaml:"agent"`
 	Commands    []string  `yaml:"commands"`
+	// Scopes grant agents in this workspace additional capabilities, such as
+	// "github_token" to issue GitHub App installation tokens. No scopes are
+	// granted unless explicitly listed.
+	Scopes []string `yaml:"scopes"`
 }
 
 type Agent struct {
@@ -144,6 +149,11 @@ func (w *Workspace) Validate() error {
 	}
 	if err := w.Agent.Validate(); err != nil {
 		return fmt.Errorf("agent: %w", err)
+	}
+	for _, scope := range w.Scopes {
+		if !agentauth.ValidScope(scope) {
+			return fmt.Errorf("unknown scope %q", scope)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Add a per-workspace `scopes` list that grants agents additional capabilities, replacing the previously unconditional access to GitHub token issuance.
- Scopes are carried in the task's signed JWT claim (`TaskClaims.Scopes`) and enforced at the runner's `AgentFilter`. The first scope, `github_token` (`agentauth.ScopeGitHubToken`), gates `CreateGitHubToken`.
- Opt-in by default: a workspace grants no scopes unless listed, so agents in workspaces without `github_token` get a `PermissionDenied` error from `get_github_token`.
- Workspace config validation rejects unknown scope names so typos fail loudly.

### Usage
```yaml
workspaces:
  my-workspace:
    scopes:
      - github_token
```

### Design notes
- Enforcement lives in the runner-side filter (the agent's RPC chokepoint), which is where workspace config is known — the C2 server has no concept of workspaces. Carrying the grant in the signed claim avoids plumbing workspace config into the proxy/filter.
- The `get_github_token` MCP tool stays registered and simply surfaces the `PermissionDenied` error when the scope is absent.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/agentmcp/...` (added allow/deny filter tests)
- [ ] Verify an agent in a workspace without `github_token` receives PermissionDenied, and one with it gets a token