### PR TITLE
fix(agent): only mention child task tools when scope is granted

### DIFF
--- a/internal/agent/PROMPT.md
+++ b/internal/agent/PROMPT.md
@@ -1,0 +1,29 @@
+{{- if .Started -}}
+The task was updated. Check xagent:get_my_task and continue.
+{{- else -}}
+Use xagent:get_my_task to fetch your task instructions and execute them.
+If the task does not have a name, use xagent:update_my_task to set one.
+
+Each instruction has a 'text' field with the task and an optional 'url' field with the source URL.
+If you have questions, problems, or take no action, respond on the platform from the most recent instruction or event url.
+When responding on external platforms, always suffix your message with (task {id}) with your task id.
+
+The task may have linked events. Events provide additional context such as GitHub webhooks or external triggers.
+Events are routed to tasks that have a link with subscribe=true matching the event URL.
+When creating links with xagent:create_link, ALWAYS set subscribe=true for resources you create (PRs, issues, comments), even if the task is complete. Others may respond and you'll need to handle those responses. Only use subscribe=false for reference links to external resources you didn't create.
+
+{{- if .HasChildTasksScope}}
+Use xagent:update_child_task to delegate work to child tasks.
+Only use xagent:create_child_task when explicitly instructed to create a new task.
+{{- end}}
+
+When done, use xagent:create_link for any URLs you created (PRs, issues, etc).
+Always use web URLs that users can visit, not API URLs.
+Use xagent:report to log important observations.
+
+Your text responses are NOT visible to users - only tool calls matter.
+{{- end -}}
+{{- if .Prompt}}
+
+{{ .Prompt }}
+{{- end -}}

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 )
 
 var ConfigDir = "/tmp/xagent"
@@ -19,6 +20,7 @@ type Config struct {
 	Verbose    bool                 `json:"verbose,omitempty"`
 	McpServers map[string]McpServer `json:"mcp_servers,omitempty"`
 	Commands   []string             `json:"commands,omitempty"`
+	Scopes     []string             `json:"scopes,omitempty"`
 	Claude     *ClaudeOptions       `json:"claude,omitempty"`
 	Codex      *CodexOptions        `json:"codex,omitempty"`
 	Copilot    *CopilotOptions      `json:"copilot,omitempty"`
@@ -57,6 +59,10 @@ func (m *McpServer) Validate() error {
 		return fmt.Errorf("unknown type: %s", m.Type)
 	}
 	return nil
+}
+
+func (c *Config) hasScope(scope string) bool {
+	return slices.Contains(c.Scopes, scope)
 }
 
 func ConfigPath(taskID int64) string {

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"log/slog"
 	"os"
@@ -9,7 +10,9 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"text/template"
 
+	"github.com/icholy/xagent/internal/auth/agentauth"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/xagentclient"
 )
@@ -88,33 +91,9 @@ func (d *Driver) Run(ctx context.Context) error {
 	defer a.Close()
 
 	// Bootstrap prompt
-	var prompt string
-	if cfg.Started {
-		prompt = "The task was updated. Check xagent:get_my_task and continue."
-	} else {
-		prompt = strings.Join([]string{
-			"Use xagent:get_my_task to fetch your task instructions and execute them.",
-			"If the task does not have a name, use xagent:update_my_task to set one.",
-			"",
-			"Each instruction has a 'text' field with the task and an optional 'url' field with the source URL.",
-			"If you have questions, problems, or take no action, respond on the platform from the most recent instruction or event url.",
-			"When responding on external platforms, always suffix your message with (task {id}) with your task id.",
-			"",
-			"The task may have linked events. Events provide additional context such as GitHub webhooks or external triggers.",
-			"Events are routed to tasks that have a link with subscribe=true matching the event URL.",
-			"When creating links with xagent:create_link, ALWAYS set subscribe=true for resources you create (PRs, issues, comments), even if the task is complete. Others may respond and you'll need to handle those responses. Only use subscribe=false for reference links to external resources you didn't create.",
-			"Use xagent:update_child_task to delegate work to child tasks.",
-			"",
-			"When done, use xagent:create_link for any URLs you created (PRs, issues, etc).",
-			"Always use web URLs that users can visit, not API URLs.",
-			"Use xagent:report to log important observations.",
-			"Only use xagent:create_child_task when explicitly instructed to create a new task.",
-			"",
-			"Your text responses are NOT visible to users - only tool calls matter.",
-		}, "\n")
-	}
-	if cfg.Prompt != "" {
-		prompt = prompt + "\n\n" + cfg.Prompt
+	prompt, err := cfg.prompt()
+	if err != nil {
+		return fmt.Errorf("failed to build prompt: %w", err)
 	}
 
 	if err := a.Prompt(ctx, prompt, cfg.Started); err != nil {
@@ -133,4 +112,27 @@ func (d *Driver) Run(ctx context.Context) error {
 
 	d.Log.Info("Task completed successfully.")
 	return nil
+}
+
+//go:embed PROMPT.md
+var promptText string
+
+var promptTemplate = template.Must(template.New("prompt").Parse(promptText))
+
+// prompt builds the bootstrap prompt sent to the agent.
+func (c *Config) prompt() (string, error) {
+	var b strings.Builder
+	err := promptTemplate.Execute(&b, struct {
+		Started            bool
+		HasChildTasksScope bool
+		Prompt             string
+	}{
+		Started:            c.Started,
+		HasChildTasksScope: c.hasScope(agentauth.ScopeChildTasks),
+		Prompt:             c.Prompt,
+	})
+	if err != nil {
+		return "", err
+	}
+	return b.String(), nil
 }

--- a/internal/agent/driver_test.go
+++ b/internal/agent/driver_test.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/icholy/xagent/internal/auth/agentauth"
+	"gotest.tools/v3/assert"
+)
+
+func TestConfigPrompt_WithoutChildTasksScope(t *testing.T) {
+	cfg := &Config{}
+	got, err := cfg.prompt()
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(got, "xagent:get_my_task"))
+	assert.Assert(t, !strings.Contains(got, "update_child_task"), "child task tools should not be mentioned without scope")
+	assert.Assert(t, !strings.Contains(got, "create_child_task"), "child task tools should not be mentioned without scope")
+}
+
+func TestConfigPrompt_WithChildTasksScope(t *testing.T) {
+	cfg := &Config{Scopes: []string{agentauth.ScopeChildTasks}}
+	got, err := cfg.prompt()
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(got, "Use xagent:update_child_task to delegate work to child tasks."))
+	assert.Assert(t, strings.Contains(got, "Only use xagent:create_child_task when explicitly instructed to create a new task."))
+}
+
+func TestConfigPrompt_Started(t *testing.T) {
+	cfg := &Config{Started: true}
+	got, err := cfg.prompt()
+	assert.NilError(t, err)
+	assert.Equal(t, got, "The task was updated. Check xagent:get_my_task and continue.")
+}
+
+func TestConfigPrompt_WorkspacePromptAppended(t *testing.T) {
+	cfg := &Config{Started: true, Prompt: "Custom workspace instructions."}
+	got, err := cfg.prompt()
+	assert.NilError(t, err)
+	assert.Equal(t, got, "The task was updated. Check xagent:get_my_task and continue.\n\nCustom workspace instructions.")
+}

--- a/internal/runner/workspace/workspace.go
+++ b/internal/runner/workspace/workspace.go
@@ -307,6 +307,7 @@ func (w *Workspace) AgentConfig() agent.Config {
 		Verbose:    w.Agent.Verbose,
 		McpServers: make(map[string]agent.McpServer),
 		Commands:   w.Commands,
+		Scopes:     w.Scopes,
 	}
 	if w.Agent.Claude != nil {
 		cfg.Claude = &agent.ClaudeOptions{


### PR DESCRIPTION
## Summary
- The agent bootstrap prompt unconditionally told every agent to use `xagent:update_child_task` and `xagent:create_child_task`, but those tools are now hidden unless the workspace grants the `child_tasks` scope (#672). Agents in non-scoped workspaces were instructed to use tools they don't have.
- Carry the workspace `Scopes` into `agent.Config` and gate the child-task prompt lines on the `child_tasks` scope.
- Moved the bootstrap prompt out of Go and into `internal/agent/PROMPT.md`, embedded via `go:embed` and rendered with `text/template`. `(*Config).prompt()` renders it; child-task guidance is gated by `{{ if .ChildTasks }}` and the optional per-workspace prompt is appended via `{{ if .Prompt }}`.
- Added `(*Config).hasScope()` to compute the template's `ChildTasks` flag.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/agent/...` — new `driver_test.go` covers: tools hidden without scope, shown with scope, the "started" prompt, and the workspace-prompt suffix (exact-match assertions validate template whitespace trimming)
- [x] `gofmt` clean
- [x] Manually dumped both scope variants to confirm clean rendering (no stray/duplicated blank lines)