### PR TITLE
feat(server): route actionable task notifications to runners

### DIFF
--- a/internal/eventrouter/eventrouter.go
+++ b/internal/eventrouter/eventrouter.go
@@ -16,7 +16,7 @@ import (
 // InputEvent represents a parsed webhook event ready for routing.
 type InputEvent struct {
 	Source      string
-	Type       string
+	Type        string
 	Description string
 	Data        string
 	URL         string
@@ -74,16 +74,6 @@ func (r *Router) Route(ctx context.Context, input InputEvent) (int, error) {
 				r.Log.Error("failed to attach event to task", "event_id", event.ID, "task_id", link.TaskID, "error", err)
 				continue
 			}
-			r.publish(ctx, model.Notification{
-				Type: "change",
-				Resources: []model.NotificationResource{
-					{Action: "updated", Type: "task", ID: link.TaskID},
-					{Action: "updated", Type: "event", ID: event.ID},
-					{Action: "appended", Type: "task_logs", ID: link.TaskID},
-				},
-				OrgID: orgID,
-				Time:  time.Now(),
-			})
 			n++
 		}
 	}
@@ -121,9 +111,15 @@ func (r *Router) publish(ctx context.Context, n model.Notification) {
 	}
 }
 
-// attach associates an event with a task, starts the task, and logs the action.
+// attach associates an event with a task, starts the task, logs the action,
+// and publishes a change notification.
 func (r *Router) attach(ctx context.Context, taskID int64, event *model.Event) error {
-	return r.Store.WithTx(ctx, nil, func(tx *sql.Tx) error {
+	notification := model.Notification{
+		Type:  "change",
+		OrgID: event.OrgID,
+		Time:  time.Now(),
+	}
+	err := r.Store.WithTx(ctx, nil, func(tx *sql.Tx) error {
 		if err := r.Store.AddEventTask(ctx, tx, event.ID, taskID); err != nil {
 			return err
 		}
@@ -142,6 +138,17 @@ func (r *Router) attach(ctx context.Context, taskID int64, event *model.Event) e
 		}); err != nil {
 			return err
 		}
+		notification.Resources = []model.NotificationResource{
+			{Action: "updated", Type: "task", ID: task.ID},
+			{Action: "updated", Type: "event", ID: event.ID},
+			{Action: "appended", Type: "task_logs", ID: task.ID},
+		}
+		notification.Runner = task.PendingRunner()
 		return tx.Commit()
 	})
+	if err != nil {
+		return err
+	}
+	r.publish(ctx, notification)
+	return nil
 }

--- a/internal/model/notification.go
+++ b/internal/model/notification.go
@@ -7,10 +7,12 @@ import "time"
 type Notification struct {
 	Type      string                 `json:"type"`
 	Resources []NotificationResource `json:"resources,omitempty"`
+	Time      time.Time              `json:"timestamp"`
 	OrgID     int64                  `json:"org_id"`
 	UserID    string                 `json:"user_id,omitempty"`
 	ClientID  string                 `json:"client_id,omitempty"`
-	Time      time.Time              `json:"timestamp"`
+	// Runner is only set if there's pending work to do
+	Runner string `json:"for_runner,omitempty"`
 }
 
 // NotificationResource describes an affected resource within a "change" Notification.

--- a/internal/model/task.go
+++ b/internal/model/task.go
@@ -405,3 +405,13 @@ func (t *Task) Start() bool {
 	t.Version++
 	return true
 }
+
+// PendingRunner returns the runner that has pending work for this task, or ""
+// if no runner action is needed. A runner has work when the task has a command
+// and is not archived — the same condition as ListTasksForRunner.
+func (t *Task) PendingRunner() string {
+	if t.Command == TaskCommandNone || t.Archived {
+		return ""
+	}
+	return t.Runner
+}

--- a/internal/server/apiserver/publish_test.go
+++ b/internal/server/apiserver/publish_test.go
@@ -37,6 +37,7 @@ func TestCreateTask_Publishes(t *testing.T) {
 			{Action: "appended", Type: "task_logs", ID: resp.Task.Id},
 		},
 		OrgID:  org.OrgID,
+		Runner: "r",
 		UserID: org.UserID,
 	}, cmpopts.IgnoreFields(model.Notification{}, "Time"))
 }

--- a/internal/server/apiserver/publish_test.go
+++ b/internal/server/apiserver/publish_test.go
@@ -73,6 +73,7 @@ func TestUpdateTask_Publishes(t *testing.T) {
 			{Action: "appended", Type: "task_logs", ID: resp.Task.Id},
 		},
 		OrgID:  org.OrgID,
+		Runner: "r",
 		UserID: org.UserID,
 	}, cmpopts.IgnoreFields(model.Notification{}, "Time"))
 }

--- a/internal/server/apiserver/runner.go
+++ b/internal/server/apiserver/runner.go
@@ -60,6 +60,7 @@ func (s *Server) SubmitRunnerEvents(ctx context.Context, req *xagentv1.SubmitRun
 					{Action: "appended", Type: "task_logs", ID: event.TaskID},
 				},
 				OrgID:    caller.OrgID,
+				Runner:   task.PendingRunner(),
 				UserID:   caller.ID,
 				ClientID: caller.ClientID,
 				Time:     time.Now(),

--- a/internal/server/apiserver/task.go
+++ b/internal/server/apiserver/task.go
@@ -124,6 +124,7 @@ func (s *Server) CreateTask(ctx context.Context, req *xagentv1.CreateTaskRequest
 			{Action: "appended", Type: "task_logs", ID: task.ID},
 		},
 		OrgID:    caller.OrgID,
+		Runner:   task.PendingRunner(),
 		UserID:   caller.ID,
 		ClientID: caller.ClientID,
 		Time:     time.Now(),
@@ -173,6 +174,13 @@ func (s *Server) GetTaskDetails(ctx context.Context, req *xagentv1.GetTaskDetail
 
 func (s *Server) UpdateTask(ctx context.Context, req *xagentv1.UpdateTaskRequest) (*xagentv1.UpdateTaskResponse, error) {
 	caller := apiauth.MustCaller(ctx)
+	notification := model.Notification{
+		Type:     "change",
+		OrgID:    caller.OrgID,
+		UserID:   caller.ID,
+		ClientID: caller.ClientID,
+		Time:     time.Now(),
+	}
 	err := s.store.WithTx(ctx, nil, func(tx *sql.Tx) error {
 		task, err := s.store.GetTaskForUpdate(ctx, tx, req.Id, caller.OrgID)
 		if err != nil {
@@ -205,6 +213,11 @@ func (s *Server) UpdateTask(ctx context.Context, req *xagentv1.UpdateTaskRequest
 		}); err != nil {
 			return err
 		}
+		notification.Runner = task.PendingRunner()
+		notification.Resources = []model.NotificationResource{
+			{Action: "updated", Type: "task", ID: task.ID},
+			{Action: "appended", Type: "task_logs", ID: task.ID},
+		}
 		return tx.Commit()
 	})
 	if err != nil {
@@ -214,22 +227,19 @@ func (s *Server) UpdateTask(ctx context.Context, req *xagentv1.UpdateTaskRequest
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	s.log.Info("task updated", "id", req.Id, "name", req.Name, "start", req.Start, "instructions_added", len(req.AddInstructions))
-	s.publish(model.Notification{
-		Type: "change",
-		Resources: []model.NotificationResource{
-			{Action: "updated", Type: "task", ID: req.Id},
-			{Action: "appended", Type: "task_logs", ID: req.Id},
-		},
-		OrgID:    caller.OrgID,
-		UserID:   caller.ID,
-		ClientID: caller.ClientID,
-		Time:     time.Now(),
-	})
+	s.publish(notification)
 	return &xagentv1.UpdateTaskResponse{}, nil
 }
 
 func (s *Server) ArchiveTask(ctx context.Context, req *xagentv1.ArchiveTaskRequest) (*xagentv1.ArchiveTaskResponse, error) {
 	caller := apiauth.MustCaller(ctx)
+	notification := model.Notification{
+		Type:     "change",
+		OrgID:    caller.OrgID,
+		UserID:   caller.ID,
+		ClientID: caller.ClientID,
+		Time:     time.Now(),
+	}
 	err := s.store.WithTx(ctx, nil, func(tx *sql.Tx) error {
 		task, err := s.store.GetTaskForUpdate(ctx, tx, req.Id, caller.OrgID)
 		if err != nil {
@@ -248,6 +258,11 @@ func (s *Server) ArchiveTask(ctx context.Context, req *xagentv1.ArchiveTaskReque
 		}); err != nil {
 			return err
 		}
+		notification.Runner = task.PendingRunner()
+		notification.Resources = []model.NotificationResource{
+			{Action: "archived", Type: "task", ID: task.ID},
+			{Action: "appended", Type: "task_logs", ID: task.ID},
+		}
 		return tx.Commit()
 	})
 	if err != nil {
@@ -257,22 +272,19 @@ func (s *Server) ArchiveTask(ctx context.Context, req *xagentv1.ArchiveTaskReque
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	s.log.Info("task archived", "id", req.Id)
-	s.publish(model.Notification{
-		Type: "change",
-		Resources: []model.NotificationResource{
-			{Action: "archived", Type: "task", ID: req.Id},
-			{Action: "appended", Type: "task_logs", ID: req.Id},
-		},
-		OrgID:    caller.OrgID,
-		UserID:   caller.ID,
-		ClientID: caller.ClientID,
-		Time:     time.Now(),
-	})
+	s.publish(notification)
 	return &xagentv1.ArchiveTaskResponse{}, nil
 }
 
 func (s *Server) UnarchiveTask(ctx context.Context, req *xagentv1.UnarchiveTaskRequest) (*xagentv1.UnarchiveTaskResponse, error) {
 	caller := apiauth.MustCaller(ctx)
+	notification := model.Notification{
+		Type:     "change",
+		OrgID:    caller.OrgID,
+		UserID:   caller.ID,
+		ClientID: caller.ClientID,
+		Time:     time.Now(),
+	}
 	err := s.store.WithTx(ctx, nil, func(tx *sql.Tx) error {
 		task, err := s.store.GetTaskForUpdate(ctx, tx, req.Id, caller.OrgID)
 		if err != nil {
@@ -291,6 +303,11 @@ func (s *Server) UnarchiveTask(ctx context.Context, req *xagentv1.UnarchiveTaskR
 		}); err != nil {
 			return err
 		}
+		notification.Runner = task.PendingRunner()
+		notification.Resources = []model.NotificationResource{
+			{Action: "unarchived", Type: "task", ID: task.ID},
+			{Action: "appended", Type: "task_logs", ID: task.ID},
+		}
 		return tx.Commit()
 	})
 	if err != nil {
@@ -300,22 +317,19 @@ func (s *Server) UnarchiveTask(ctx context.Context, req *xagentv1.UnarchiveTaskR
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	s.log.Info("task unarchived", "id", req.Id)
-	s.publish(model.Notification{
-		Type: "change",
-		Resources: []model.NotificationResource{
-			{Action: "unarchived", Type: "task", ID: req.Id},
-			{Action: "appended", Type: "task_logs", ID: req.Id},
-		},
-		OrgID:    caller.OrgID,
-		UserID:   caller.ID,
-		ClientID: caller.ClientID,
-		Time:     time.Now(),
-	})
+	s.publish(notification)
 	return &xagentv1.UnarchiveTaskResponse{}, nil
 }
 
 func (s *Server) CancelTask(ctx context.Context, req *xagentv1.CancelTaskRequest) (*xagentv1.CancelTaskResponse, error) {
 	caller := apiauth.MustCaller(ctx)
+	notification := model.Notification{
+		Type:     "change",
+		OrgID:    caller.OrgID,
+		UserID:   caller.ID,
+		ClientID: caller.ClientID,
+		Time:     time.Now(),
+	}
 	err := s.store.WithTx(ctx, nil, func(tx *sql.Tx) error {
 		task, err := s.store.GetTaskForUpdate(ctx, tx, req.Id, caller.OrgID)
 		if err != nil {
@@ -334,6 +348,11 @@ func (s *Server) CancelTask(ctx context.Context, req *xagentv1.CancelTaskRequest
 		}); err != nil {
 			return err
 		}
+		notification.Runner = task.PendingRunner()
+		notification.Resources = []model.NotificationResource{
+			{Action: "cancelled", Type: "task", ID: task.ID},
+			{Action: "appended", Type: "task_logs", ID: task.ID},
+		}
 		return tx.Commit()
 	})
 	if err != nil {
@@ -343,22 +362,19 @@ func (s *Server) CancelTask(ctx context.Context, req *xagentv1.CancelTaskRequest
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	s.log.Info("task cancelled", "id", req.Id)
-	s.publish(model.Notification{
-		Type: "change",
-		Resources: []model.NotificationResource{
-			{Action: "cancelled", Type: "task", ID: req.Id},
-			{Action: "appended", Type: "task_logs", ID: req.Id},
-		},
-		OrgID:    caller.OrgID,
-		UserID:   caller.ID,
-		ClientID: caller.ClientID,
-		Time:     time.Now(),
-	})
+	s.publish(notification)
 	return &xagentv1.CancelTaskResponse{}, nil
 }
 
 func (s *Server) RestartTask(ctx context.Context, req *xagentv1.RestartTaskRequest) (*xagentv1.RestartTaskResponse, error) {
 	caller := apiauth.MustCaller(ctx)
+	notification := model.Notification{
+		Type:     "change",
+		OrgID:    caller.OrgID,
+		UserID:   caller.ID,
+		ClientID: caller.ClientID,
+		Time:     time.Now(),
+	}
 	err := s.store.WithTx(ctx, nil, func(tx *sql.Tx) error {
 		task, err := s.store.GetTaskForUpdate(ctx, tx, req.Id, caller.OrgID)
 		if err != nil {
@@ -377,6 +393,11 @@ func (s *Server) RestartTask(ctx context.Context, req *xagentv1.RestartTaskReque
 		}); err != nil {
 			return err
 		}
+		notification.Runner = task.PendingRunner()
+		notification.Resources = []model.NotificationResource{
+			{Action: "restarted", Type: "task", ID: task.ID},
+			{Action: "appended", Type: "task_logs", ID: task.ID},
+		}
 		return tx.Commit()
 	})
 	if err != nil {
@@ -386,16 +407,6 @@ func (s *Server) RestartTask(ctx context.Context, req *xagentv1.RestartTaskReque
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	s.log.Info("task restarted", "id", req.Id)
-	s.publish(model.Notification{
-		Type: "change",
-		Resources: []model.NotificationResource{
-			{Action: "restarted", Type: "task", ID: req.Id},
-			{Action: "appended", Type: "task_logs", ID: req.Id},
-		},
-		OrgID:    caller.OrgID,
-		UserID:   caller.ID,
-		ClientID: caller.ClientID,
-		Time:     time.Now(),
-	})
+	s.publish(notification)
 	return &xagentv1.RestartTaskResponse{}, nil
 }

--- a/internal/server/notifyserver/sse.go
+++ b/internal/server/notifyserver/sse.go
@@ -26,6 +26,10 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+
+	// When set, only forward notifications carrying pending work for this
+	// runner. Used by runners to wake on actionable task changes.
+	runner := r.URL.Query().Get("runner")
 	orgID, err := s.orgResolver.ResolveOrg(r.Context(), caller.ID, orgID)
 	if err != nil {
 		http.Error(w, "forbidden", http.StatusForbidden)
@@ -70,6 +74,9 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case n := <-ch:
+			if runner != "" && n.Runner != runner {
+				continue
+			}
 			seq++
 			data, err := json.Marshal(n)
 			if err != nil {

--- a/internal/server/notifyserver/sse_test.go
+++ b/internal/server/notifyserver/sse_test.go
@@ -161,6 +161,77 @@ func TestSSE_SelfNotificationDelivered(t *testing.T) {
 	assert.DeepEqual(t, got, want)
 }
 
+func TestSSE_RunnerFilter(t *testing.T) {
+	t.Parallel()
+
+	ps := pubsub.NewLocalPubSub()
+	const orgID int64 = 1
+	srv := New(Options{
+		Subscriber:  ps,
+		OrgResolver: allowOrgResolver("u", orgID),
+	})
+
+	ts := httptest.NewServer(apiauth.WithTestUser(srv.Handler(), &apiauth.UserInfo{ID: "u", OrgID: orgID}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/events?org_id=%d&runner=r1", ts.URL, orgID), nil)
+	assert.NilError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	assert.NilError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+
+	r := sse.NewReader(resp.Body)
+
+	// Read the ready event.
+	ev, err := r.Read()
+	assert.NilError(t, err)
+	assert.Equal(t, ev.Event, "ready")
+
+	// Notification with no runner (no pending work) should be skipped.
+	err = ps.Publish(ctx, model.Notification{
+		Type:      "change",
+		Resources: []model.NotificationResource{{Action: "updated", Type: "task", ID: 1}},
+		OrgID:     orgID,
+	})
+	assert.NilError(t, err)
+
+	// Notification for a different runner should be skipped.
+	err = ps.Publish(ctx, model.Notification{
+		Type:      "change",
+		Resources: []model.NotificationResource{{Action: "updated", Type: "task", ID: 2}},
+		OrgID:     orgID,
+		Runner:    "r2",
+	})
+	assert.NilError(t, err)
+
+	// Notification for this runner should be delivered.
+	want := model.Notification{
+		Type:      "change",
+		Resources: []model.NotificationResource{{Action: "restarted", Type: "task", ID: 3}},
+		OrgID:     orgID,
+		Runner:    "r1",
+		Time:      time.Now().Truncate(time.Second),
+	}
+	err = ps.Publish(ctx, want)
+	assert.NilError(t, err)
+
+	// Should only receive the r1 notification.
+	ev, err = r.Read()
+	assert.NilError(t, err)
+	assert.Equal(t, ev.Event, "change")
+
+	var got model.Notification
+	err = json.Unmarshal(ev.Data, &got)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, got, want)
+}
+
 func TestSSE_OrgIsolation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Server-side groundwork for replacing the runner's fixed-interval polling with an SSE wake-up signal (#527).

- Add a `Runner` field to `model.Notification`, set **only** when a change leaves pending work for a runner — i.e. the task has a command and is not archived, mirroring the `ListTasksForRunner` predicate (`command != 0 AND archived = FALSE`).
- Introduce `(*Task).PendingRunner()` to encapsulate that invariant, so every task publish site (`CreateTask`, `UpdateTask`, `ArchiveTask`, `UnarchiveTask`, `CancelTask`, `RestartTask`, the applied branch of `SubmitRunnerEvents`, and the event router's `attach`) stays consistent.
- The SSE handler accepts an optional `?runner=` query param and forwards only notifications whose `Runner` matches. The `ready` event always passes; with no param the web UI behaves exactly as before.

Because only command-bearing changes set `Runner`, the `?runner=` stream naturally excludes the log firehose (`AppendLogs` carries only `task_logs`) and non-task notifications, and the self-triggered cascade (`stopped` while a Start is pending → back to `Pending` with `Command=Start`) still correctly wakes the runner — so no client-id self-filtering is needed.

This is the server half; the runner-side SSE client and loop change are a follow-up.

## Test plan

- [x] `go test ./internal/model/ ./internal/eventrouter/ ./internal/server/apiserver/ ./internal/server/notifyserver/`
- [x] `TestSSE_RunnerFilter` — verifies a no-runner notification and a different-runner notification are skipped while the matching one is delivered
- [x] Existing publish tests updated: `CreateTask` carries `Runner`; cancelling a *pending* task and the `started` lifecycle event correctly yield an empty `Runner`
- [ ] Follow-up: runner-side SSE subscriber consuming `/events?runner=<id>`