### PR TITLE
fix(store): write timestamps in UTC

### DIFF
--- a/internal/store/event.go
+++ b/internal/store/event.go
@@ -15,7 +15,7 @@ func (s *Store) CreateEvent(ctx context.Context, tx *sql.Tx, event *model.Event)
 		Data:        event.Data,
 		Url:         event.URL,
 		OrgID:       event.OrgID,
-		CreatedAt:   time.Now(),
+		CreatedAt:   time.Now().UTC(),
 	})
 	if err != nil {
 		return err

--- a/internal/store/key.go
+++ b/internal/store/key.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *Store) CreateKey(ctx context.Context, tx *sql.Tx, key *model.Key) error {
-	now := time.Now()
+	now := time.Now().UTC()
 	var expiresAt sql.NullTime
 	if key.ExpiresAt != nil {
 		expiresAt = sql.NullTime{Time: *key.ExpiresAt, Valid: true}

--- a/internal/store/log.go
+++ b/internal/store/log.go
@@ -14,7 +14,7 @@ func (s *Store) CreateLog(ctx context.Context, tx *sql.Tx, log *model.Log) error
 		TaskID:    log.TaskID,
 		Type:      log.Type,
 		Content:   log.Content,
-		CreatedAt: time.Now(),
+		CreatedAt: time.Now().UTC(),
 	})
 	if err != nil {
 		return err

--- a/internal/store/org.go
+++ b/internal/store/org.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *Store) CreateOrg(ctx context.Context, tx *sql.Tx, org *model.Org) error {
-	now := time.Now()
+	now := time.Now().UTC()
 	id, err := s.q(tx).CreateOrg(ctx, sqlc.CreateOrgParams{
 		Name:      org.Name,
 		Owner:     org.Owner,
@@ -66,7 +66,7 @@ func (s *Store) ListOrgsByMember(ctx context.Context, tx *sql.Tx, userID string)
 }
 
 func (s *Store) UpdateOrg(ctx context.Context, tx *sql.Tx, org *model.Org) error {
-	org.UpdatedAt = time.Now()
+	org.UpdatedAt = time.Now().UTC()
 	return s.q(tx).UpdateOrg(ctx, sqlc.UpdateOrgParams{
 		ID:        org.ID,
 		Name:      org.Name,
@@ -83,7 +83,7 @@ func (s *Store) DestroyOrg(ctx context.Context, tx *sql.Tx, id int64) error {
 }
 
 func (s *Store) AddOrgMember(ctx context.Context, tx *sql.Tx, member *model.OrgMember) error {
-	now := time.Now()
+	now := time.Now().UTC()
 	err := s.q(tx).AddOrgMember(ctx, sqlc.AddOrgMemberParams{
 		OrgID:     member.OrgID,
 		UserID:    member.UserID,

--- a/internal/store/pending_integration.go
+++ b/internal/store/pending_integration.go
@@ -16,7 +16,7 @@ func (s *Store) UpsertPendingIntegration(ctx context.Context, tx *sql.Tx, p *mod
 	if err != nil {
 		return fmt.Errorf("marshal options: %w", err)
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	if err := s.q(tx).UpsertPendingIntegration(ctx, sqlc.UpsertPendingIntegrationParams{
 		Type:       string(p.Type),
 		ExternalID: p.ExternalID,

--- a/internal/store/task.go
+++ b/internal/store/task.go
@@ -15,7 +15,7 @@ func (s *Store) CreateTask(ctx context.Context, tx *sql.Tx, task *model.Task) er
 	if err != nil {
 		return err
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	id, err := s.q(tx).CreateTask(ctx, sqlc.CreateTaskParams{
 		Name:         task.Name,
 		Parent:       task.Parent,
@@ -112,7 +112,7 @@ func (s *Store) UpdateTask(ctx context.Context, tx *sql.Tx, task *model.Task) er
 	if err != nil {
 		return err
 	}
-	task.UpdatedAt = time.Now()
+	task.UpdatedAt = time.Now().UTC()
 	return s.q(tx).UpdateTask(ctx, sqlc.UpdateTaskParams{
 		Name:         task.Name,
 		Parent:       task.Parent,


### PR DESCRIPTION
## Summary

Store methods generated timestamps with `time.Now()`, which carries the host's local zone. pgx encodes a `timestamp without time zone` column from the value's **wall-clock components without normalizing to UTC**, so on a non-UTC host the stored wall clock differs from the UTC `NOW()` / `CURRENT_TIMESTAMP` defaults by the local offset.

This was invisible while timestamps only round-tripped back into Go (the error was uniform across all reads). The archiver is the first code to compare `updated_at` against SQL `NOW()`, so on a non-UTC host the dropped offset skewed the `archive_after` deadline and terminal tasks were auto-archived early. `TestArchiver_Tick_SkipsFutureDeadline` fails locally (e.g. EDT) but passes in CI (UTC) for this reason.

Normalize every generated timestamp in the store to UTC:

- `task.go` — `CreateTask`, `UpdateTask`
- `org.go` — `CreateOrg`, `UpdateOrg`, `AddOrgMember`
- `log.go` — `CreateLog`
- `key.go` — `CreateKey`
- `event.go` — `CreateEvent`
- `pending_integration.go` — `UpsertPendingIntegration`

(`key.ExpiresAt` is caller-supplied, not generated here, so it's unchanged.)

## Test plan

- [x] `mise run test` passes (previously `TestArchiver_Tick_SkipsFutureDeadline` failed on a non-UTC host)
- [x] Archiver suite green: `go test ./internal/server/archiver/`