### PR TITLE
feat(webui): show auto-archive countdown on archive button

### DIFF
--- a/webui/src/components/archive-button.tsx
+++ b/webui/src/components/archive-button.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { autoArchiveDeadline } from '@/lib/task'
+import { formatCountdown } from '@/lib/duration'
+import type { Task } from '@/gen/xagent/v1/xagent_pb'
+
+type ArchiveTask = Pick<Task, 'status' | 'actions' | 'archived' | 'archiveAfter' | 'updatedAt'>
+
+// useAutoArchiveCountdown returns a live-ticking, human-readable string of the
+// time until the task is auto-archived (e.g. "5m"), or null when the task isn't
+// scheduled for auto-archiving.
+function useAutoArchiveCountdown(task: ArchiveTask): string | null {
+  const deadlineTime = autoArchiveDeadline(task)?.getTime() ?? null
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (deadlineTime === null) return
+    const interval = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(interval)
+  }, [deadlineTime])
+  if (deadlineTime === null) return null
+  return formatCountdown(deadlineTime - now)
+}
+
+// ArchiveButton renders the manual archive control. When the task is scheduled
+// to be auto-archived, it shows a live countdown in the label ("Archive (5m)")
+// so the automatic behavior is co-located with the manual action.
+export function ArchiveButton({
+  task,
+  onArchive,
+  pending,
+  disabled,
+}: {
+  task: ArchiveTask
+  onArchive: () => void
+  pending: boolean
+  disabled?: boolean
+}) {
+  const countdown = useAutoArchiveCountdown(task)
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={onArchive}
+      disabled={disabled ?? pending}
+      title={countdown ? `Auto-archives in ${countdown}` : undefined}
+    >
+      {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+      {countdown ? `Archive (${countdown})` : 'Archive'}
+    </Button>
+  )
+}

--- a/webui/src/lib/duration.ts
+++ b/webui/src/lib/duration.ts
@@ -20,3 +20,26 @@ export function hoursFromDuration(d: Duration | undefined): string {
   if (!Number.isFinite(hours) || hours <= 0) return ''
   return String(Math.round(hours))
 }
+
+// durationToMillis converts a protobuf Duration to milliseconds.
+export function durationToMillis(d: Duration): number {
+  return Number(d.seconds) * 1000 + d.nanos / 1_000_000
+}
+
+// formatCountdown renders a coarse, human-readable remaining time using the one
+// or two largest units, e.g. "45s", "5m", "2h 10m", "3d 4h". Negative inputs
+// clamp to "0s".
+export function formatCountdown(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000))
+  if (totalSeconds < 60) return `${totalSeconds}s`
+  const totalMinutes = Math.floor(totalSeconds / 60)
+  if (totalMinutes < 60) return `${totalMinutes}m`
+  const totalHours = Math.floor(totalMinutes / 60)
+  if (totalHours < 24) {
+    const minutes = totalMinutes % 60
+    return minutes ? `${totalHours}h ${minutes}m` : `${totalHours}h`
+  }
+  const totalDays = Math.floor(totalHours / 24)
+  const hours = totalHours % 24
+  return hours ? `${totalDays}d ${hours}h` : `${totalDays}d`
+}

--- a/webui/src/lib/task.ts
+++ b/webui/src/lib/task.ts
@@ -1,7 +1,10 @@
+import { timestampDate } from '@bufbuild/protobuf/wkt'
 import type { Task } from '@/gen/xagent/v1/xagent_pb'
+import { durationToMillis } from '@/lib/duration'
 
 type TaskLike = Pick<Task, 'status' | 'actions' | 'archived'>
 type TaskWithParent = Pick<Task, 'parent'>
+type AutoArchiveTask = TaskLike & Pick<Task, 'archiveAfter' | 'updatedAt'>
 
 export function isChildTask(task: TaskWithParent): boolean {
   return task.parent !== 0n
@@ -25,4 +28,20 @@ export function canRestartTask(task: TaskLike): boolean {
 
 export function isArchivedTask(task: TaskLike): boolean {
   return task.archived
+}
+
+// autoArchiveDeadline returns the time at which the task is scheduled to be
+// auto-archived, or null when it isn't. The timer only runs once a task is in a
+// terminal state, so this requires the task to be archivable (terminal and not
+// yet archived), archive_after to be positive, and updated_at (the terminal
+// timestamp) to be set.
+export function autoArchiveDeadline(task: AutoArchiveTask): Date | null {
+  if (!canArchiveTask(task) || !task.archiveAfter || !task.updatedAt) {
+    return null
+  }
+  const afterMs = durationToMillis(task.archiveAfter)
+  if (afterMs <= 0) {
+    return null
+  }
+  return new Date(timestampDate(task.updatedAt).getTime() + afterMs)
 }

--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -22,6 +22,7 @@ import {
   isArchivedTask,
 } from '@/lib/task'
 import { ArchivedBadge } from '@/components/archived-badge'
+import { ArchiveButton } from '@/components/archive-button'
 import {
   Table,
   TableBody,
@@ -157,10 +158,12 @@ function TaskDetail() {
             </Button>
           )}
           {canArchiveTask(task) && (
-            <Button variant="outline" size="sm" onClick={handleArchive} disabled={isMutating}>
-              {archiveMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              Archive
-            </Button>
+            <ArchiveButton
+              task={task}
+              onArchive={handleArchive}
+              pending={archiveMutation.isPending}
+              disabled={isMutating}
+            />
           )}
           {canUnarchiveTask(task) && (
             <Button variant="outline" size="sm" onClick={handleUnarchive} disabled={isMutating}>
@@ -396,15 +399,11 @@ function ChildTaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) 
       </TableCell>
       <TableCell>
         {canArchiveTask(task) && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleArchive}
-            disabled={archiveMutation.isPending}
-          >
-            {archiveMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            Archive
-          </Button>
+          <ArchiveButton
+            task={task}
+            onArchive={handleArchive}
+            pending={archiveMutation.isPending}
+          />
         )}
       </TableCell>
     </TableRow>

--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -15,6 +15,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { StatusBadge } from '@/components/status-badge'
+import { ArchiveButton } from '@/components/archive-button'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { Input } from '@/components/ui/input'
@@ -22,7 +23,7 @@ import { RelativeTime } from '@/components/relative-time'
 import { CommandBadge } from '@/components/command-badge'
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
-import { Plus, Search, Loader2, X } from 'lucide-react'
+import { Plus, Search, X } from 'lucide-react'
 import { useOrgId } from '@/hooks/use-org-id'
 
 export const Route = createFileRoute('/tasks/')({
@@ -174,15 +175,11 @@ function TaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) {
       </TableCell>
       <TableCell className="hidden md:table-cell">
         {canArchiveTask(task) && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleArchive}
-            disabled={archiveMutation.isPending}
-          >
-            {archiveMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            Archive
-          </Button>
+          <ArchiveButton
+            task={task}
+            onArchive={handleArchive}
+            pending={archiveMutation.isPending}
+          />
         )}
       </TableCell>
     </TableRow>


### PR DESCRIPTION
Closes #865

Tasks can have an \`archive_after\` timeout that auto-archives them once they've been terminal for some time, but the web UI never surfaced it — there was no way to tell a task was scheduled to be auto-archived, or when.

## Change

Renders a live countdown in the **Archive button** label, co-locating the automatic behavior with the manual control. Reads as "this will auto-archive in 5m, or click to archive now."

- \`Archive (5m)\` button label with a tooltip \`Auto-archives in 5m\`, ticking down once per second.
- Applied to all three places the button renders: task detail header, task list, and the child-tasks table (via a shared \`ArchiveButton\` component).

## Gating / computation

Shown only when \`archive_after > 0\`, the task is terminal (\`COMPLETED\`/\`FAILED\`/\`CANCELLED\`), and not yet archived — the same conditions the server archiver uses (\`canArchiveTask\` mirrors the backend's \`CanArchive()\`). Remaining time = \`updated_at\` (the terminal timestamp) + \`archive_after\` − now.

New helpers: \`durationToMillis\` / \`formatCountdown\` in \`lib/duration.ts\`, \`autoArchiveDeadline\` in \`lib/task.ts\`.

\`pnpm lint\` and \`tsc --noEmit\` pass.