### PR TITLE
fix: mount postgres volume at /var/lib/postgresql for pg18

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_DB: xagent
       PGPORT: "5433"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U xagent -p 5433"]
       interval: 5s

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,7 +8,7 @@ services:
       PGPORT: "5433"
     network_mode: host
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U xagent -p 5433"]
       interval: 5s


### PR DESCRIPTION
The renovate bump #783 moved the dev/test postgres image from \`17-alpine\` to \`18-alpine\`, but postgres:18 changed where it stores data:

| image | default \`PGDATA\` |
|---|---|
| \`postgres:17-alpine\` | \`/var/lib/postgresql/data\` |
| \`postgres:18-alpine\` | \`/var/lib/postgresql/18/docker\` |

The compose files mount the named volume at \`/var/lib/postgresql/data\`. Under pg18 that path is no longer \`PGDATA\`, so:

- the database isn't persisted on the volume anymore, and
- leftover pg17 data sitting at \`/var/lib/postgresql/data\` makes the pg18 entrypoint refuse to start (exit 1).

Mounting the volume at \`/var/lib/postgresql\` puts the version-specific subdir (\`/var/lib/postgresql/18/docker\`) back inside the volume, which is the layout the pg18 image documents.

Applied to both \`docker-compose.dev.yml\` and \`docker-compose.test.yml\`.

> Note: existing local \`*_postgres_data\` volumes hold data in the old layout and must be recreated (\`docker compose ... down -v\`).