### PR TITLE
fix(webui): hide routing rules Filters and Action columns on small screens

### DIFF
--- a/webui/src/routes/events.index.tsx
+++ b/webui/src/routes/events.index.tsx
@@ -232,8 +232,8 @@ function RoutingRulesCard() {
             <TableHeader>
               <TableRow>
                 <TableHead>Event Type</TableHead>
-                <TableHead>Filters</TableHead>
-                <TableHead>Action</TableHead>
+                <TableHead className="hidden md:table-cell">Filters</TableHead>
+                <TableHead className="hidden md:table-cell">Action</TableHead>
                 <TableHead></TableHead>
               </TableRow>
             </TableHeader>
@@ -243,7 +243,7 @@ function RoutingRulesCard() {
                   <TableCell className="font-medium whitespace-nowrap">
                     {eventTypeLabel(rule.source, rule.type)}
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="hidden md:table-cell">
                     <div className="flex flex-wrap gap-1">
                       {ruleMatchBadges(rule).map((label) => (
                         <Badge
@@ -256,7 +256,7 @@ function RoutingRulesCard() {
                       ))}
                     </div>
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="hidden md:table-cell">
                     <div className="flex flex-wrap gap-1">
                       {rule.wakeup && <Badge variant="secondary">wake</Badge>}
                       {rule.create && <Badge variant="secondary">create</Badge>}


### PR DESCRIPTION
The Routing Rules table overflowed on narrow viewports. This hides the **Filters** and **Action** columns below the \`md\` breakpoint via \`hidden md:table-cell\` on their header and body cells — matching the pattern already used in the Recent Events table on the same page.

On small screens only **Event Type** and the row controls (move / edit / delete) remain; all columns reappear at \`md\` and up.