### PR TITLE
feat(driver): emit runner events from the driver with in-place restart

### DIFF
--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -3,19 +3,34 @@ package agent
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"text/template"
+	"time"
 
 	"github.com/icholy/xagent/internal/auth/agentauth"
+	"github.com/icholy/xagent/internal/model"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/xagentclient"
 )
+
+// StopTimeout is how long a cancelled agent run is given to unwind before
+// escalating: the runner SIGKILLs a container this long after SIGTERM, and
+// the driver exits non-zero if the agent doesn't return this long after a
+// cancellation.
+const StopTimeout = 30 * time.Second
+
+// errUnwindTimeout means a cancelled agent run did not return within
+// StopTimeout. The driver exits non-zero without reporting an event so the
+// monitor's failed fallback takes over when the container dies.
+var errUnwindTimeout = errors.New("agent did not exit after cancellation")
 
 type Driver struct {
 	TaskID int64
@@ -23,28 +38,74 @@ type Driver struct {
 	Log    *slog.Logger
 }
 
+// Run executes the task's agent and reports the outcome to the server as
+// runner events. The driver is the source of truth for started / stopped /
+// failed; the runner's docker monitor only covers processes that die before
+// they can report. The invariant: Run returns non-zero only when it could not
+// report its outcome itself — an acked stopped or failed event means exit 0.
 func (d *Driver) Run(ctx context.Context) error {
+	// emitCtx survives signal-driven cancellation so terminal events can still
+	// be submitted and acked after the run context is torn down. Each submit
+	// is bounded by the client's HTTP timeout.
+	emitCtx := context.WithoutCancel(ctx)
 
-	// Set up SIGTERM handler to cancel with ErrStop
-	ctx, cancel := context.WithCancelCause(ctx)
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGTERM)
-	go func() {
-		<-sigCh
-		d.Log.Info("received SIGTERM, stopping agent")
-		cancel(ErrStop)
-	}()
+	// stopCtx is cancelled only by SIGTERM (ErrStop). It is the parent of
+	// every run context, so a stop always cancels the current run, and a stop
+	// that races with an in-progress reload wins.
+	stopCtx, stopCancel := context.WithCancelCause(ctx)
+	defer stopCancel(nil)
+
+	// Each agent run gets its own context layered on stopCtx so SIGHUP can
+	// cancel just the current run with ErrReload.
+	var mu sync.Mutex
+	var runCancel context.CancelCauseFunc
+	newRun := func() context.Context {
+		mu.Lock()
+		defer mu.Unlock()
+		runCtx, cancel := context.WithCancelCause(stopCtx)
+		runCancel = cancel
+		return runCtx
+	}
+	runCtx := newRun()
+
+	// The driver is PID 1 in the container: the kernel ignores default-action
+	// signals delivered to PID 1, so both signals must be explicitly handled.
+	sigCh := make(chan os.Signal, 2)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGHUP)
 	defer signal.Stop(sigCh)
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		for {
+			select {
+			case sig := <-sigCh:
+				switch sig {
+				case syscall.SIGTERM:
+					d.Log.Info("received SIGTERM, stopping agent")
+					stopCancel(ErrStop)
+				case syscall.SIGHUP:
+					d.Log.Info("received SIGHUP, reloading agent")
+					mu.Lock()
+					runCancel(ErrReload)
+					mu.Unlock()
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
 
-	// Make sure the server is reachable
-	if _, err := d.Client.Ping(ctx, &xagentv1.PingRequest{}); err != nil {
-		return fmt.Errorf("failed to ping server: %w", err)
+	// Report started and wait for the ack: a successful submit proves the
+	// server, auth, and DB are all healthy (this replaces the old Ping) and
+	// transitions the task's pending command to running.
+	if err := d.emit(emitCtx, model.RunnerEventStarted); err != nil {
+		return err
 	}
 
 	// Load config
 	cfg, err := LoadConfig(d.TaskID)
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return d.fail(emitCtx, fmt.Errorf("failed to load config: %w", err))
 	}
 
 	d.Log.Info("loaded config",
@@ -55,8 +116,14 @@ func (d *Driver) Run(ctx context.Context) error {
 		"started", cfg.Started,
 	)
 
-	if err := d.setup(ctx, cfg); err != nil {
-		return err
+	// Setup runs under stopCtx: a reload doesn't interrupt setup commands,
+	// only a stop does.
+	if err := d.setup(stopCtx, cfg); err != nil {
+		if context.Cause(stopCtx) == ErrStop {
+			d.Log.Info("agent stopped during setup")
+			return d.stop(emitCtx)
+		}
+		return d.fail(emitCtx, err)
 	}
 
 	// Start agent
@@ -73,31 +140,126 @@ func (d *Driver) Run(ctx context.Context) error {
 		Dummy:      cfg.Dummy,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create agent: %w", err)
+		return d.fail(emitCtx, fmt.Errorf("failed to create agent: %w", err))
 	}
 	defer a.Close()
 
 	// Bootstrap prompt
 	prompt, err := cfg.prompt()
 	if err != nil {
-		return fmt.Errorf("failed to build prompt: %w", err)
+		return d.fail(emitCtx, fmt.Errorf("failed to build prompt: %w", err))
 	}
+	resume := cfg.Started
 
-	if err := a.Prompt(ctx, prompt, cfg.Started); err != nil {
-		if context.Cause(ctx) == ErrStop {
-			d.Log.Info("agent stopped gracefully")
-			return nil
+	// A SIGHUP that arrived before the agent ever ran is just a start: swap in
+	// a fresh run context and ack the restart command, keeping the original
+	// bootstrap prompt since there is no session to reload.
+	if context.Cause(runCtx) == ErrReload {
+		runCtx = newRun()
+		if err := d.emit(emitCtx, model.RunnerEventStarted); err != nil {
+			return err
 		}
+	}
+
+	for {
+		err := d.runPrompt(runCtx, a, prompt, resume)
+		if errors.Is(err, errUnwindTimeout) {
+			return err
+		}
+		if err == nil {
+			// Natural completion wins over any cancel that raced in: a late
+			// signal does not discard a genuinely finished run.
+			cfg.Started = true
+			if err := SaveConfig(d.TaskID, cfg); err != nil {
+				return d.fail(emitCtx, fmt.Errorf("failed to save config: %w", err))
+			}
+			d.Log.Info("task completed successfully")
+			return d.stop(emitCtx)
+		}
+		switch context.Cause(runCtx) {
+		case ErrStop:
+			d.Log.Info("agent stopped gracefully")
+			return d.stop(emitCtx)
+		case ErrReload:
+			// A stop that arrived during the reload wins.
+			if context.Cause(stopCtx) == ErrStop {
+				d.Log.Info("agent stopped during reload")
+				return d.stop(emitCtx)
+			}
+			// Re-arm before reporting so a SIGHUP racing in cancels the new
+			// run instead of being lost; the extra pass through this branch
+			// is a no-op at the server.
+			runCtx = newRun()
+			if err := d.emit(emitCtx, model.RunnerEventStarted); err != nil {
+				return err
+			}
+			cfg.Started = true
+			if prompt, err = cfg.prompt(); err != nil {
+				return d.fail(emitCtx, fmt.Errorf("failed to build prompt: %w", err))
+			}
+			resume = true
+			d.Log.Info("agent reloaded")
+		default:
+			return d.fail(emitCtx, err)
+		}
+	}
+}
+
+// runPrompt invokes a.Prompt and bounds how long the agent may take to unwind
+// after ctx is cancelled. If the agent doesn't return within StopTimeout of
+// the cancellation, the in-flight Prompt is abandoned and errUnwindTimeout is
+// returned.
+func (d *Driver) runPrompt(ctx context.Context, a Agent, prompt string, resume bool) error {
+	result := make(chan error, 1)
+	go func() { result <- a.Prompt(ctx, prompt, resume) }()
+	select {
+	case err := <-result:
 		return err
+	case <-ctx.Done():
 	}
-
-	// Save config
-	cfg.Started = true
-	if err := SaveConfig(d.TaskID, cfg); err != nil {
-		return fmt.Errorf("failed to save config: %w", err)
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(StopTimeout):
+		return errUnwindTimeout
 	}
+}
 
-	d.Log.Info("Task completed successfully.")
+// emit submits a runner event for the driver's task and waits for the ack.
+// The SubmitRunnerEvents handler commits the transaction before returning, so
+// a nil error means the state transition is durable. Driver events are
+// spontaneous and carry version 0 to bypass the server's version check.
+func (d *Driver) emit(ctx context.Context, event model.RunnerEventType) error {
+	_, err := d.Client.SubmitRunnerEvents(ctx, &xagentv1.SubmitRunnerEventsRequest{
+		Events: []*xagentv1.RunnerEvent{{TaskId: d.TaskID, Event: string(event)}},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to submit %s event: %w", event, err)
+	}
+	return nil
+}
+
+// stop reports a graceful stop. The exit code doesn't depend on the ack: if
+// the event is lost the driver still exits 0, and the monitor's exit-0
+// fallback lands on the same stopped event.
+func (d *Driver) stop(ctx context.Context) error {
+	if err := d.emit(ctx, model.RunnerEventStopped); err != nil {
+		d.Log.Error("failed to report stop", "error", err)
+	}
+	return nil
+}
+
+// fail reports cause as a failed event. An acked submit fulfils the driver's
+// reporting duty, so it returns nil and the process exits 0. If the submit
+// fails, cause is returned and the non-zero exit lets the monitor's failed
+// fallback report instead — exiting 0 there would make the monitor emit
+// stopped and silently swallow the failure.
+func (d *Driver) fail(ctx context.Context, cause error) error {
+	d.Log.Error("task failed", "error", cause)
+	if err := d.emit(ctx, model.RunnerEventFailed); err != nil {
+		d.Log.Error("failed to report failure", "error", err)
+		return cause
+	}
 	return nil
 }
 

--- a/internal/agent/driver_test.go
+++ b/internal/agent/driver_test.go
@@ -1,12 +1,155 @@
 package agent
 
 import (
+	"context"
+	"errors"
+	"log/slog"
+	"slices"
 	"strings"
+	"sync"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/icholy/xagent/internal/auth/agentauth"
+	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
+	"github.com/icholy/xagent/internal/xagentclient"
 	"gotest.tools/v3/assert"
 )
+
+// eventRecorder records the runner events a driver under test submits.
+// When failOn is set, submits of that event type return an error.
+type eventRecorder struct {
+	mu     sync.Mutex
+	events []string
+	failOn string
+}
+
+func (r *eventRecorder) client() *xagentclient.ClientMock {
+	return &xagentclient.ClientMock{
+		SubmitRunnerEventsFunc: func(_ context.Context, req *xagentv1.SubmitRunnerEventsRequest) (*xagentv1.SubmitRunnerEventsResponse, error) {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			for _, ev := range req.Events {
+				if ev.Event == r.failOn {
+					return nil, errors.New("submit failed")
+				}
+				r.events = append(r.events, ev.Event)
+			}
+			return &xagentv1.SubmitRunnerEventsResponse{}, nil
+		},
+	}
+}
+
+func (r *eventRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.events)
+}
+
+// waitLen blocks until at least n events have been recorded.
+func (r *eventRecorder) waitLen(t *testing.T, n int) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		r.mu.Lock()
+		l := len(r.events)
+		r.mu.Unlock()
+		if l >= n {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d events, have %d", n, l)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func setupDriver(t *testing.T, cfg *Config) (*Driver, *eventRecorder) {
+	t.Helper()
+	ConfigDir = t.TempDir()
+	cfg.Type = TypeDummy
+	assert.NilError(t, SaveConfig(1, cfg))
+	rec := &eventRecorder{}
+	return &Driver{TaskID: 1, Client: rec.client(), Log: slog.Default()}, rec
+}
+
+func TestDriverRun(t *testing.T) {
+	d, rec := setupDriver(t, &Config{})
+
+	err := d.Run(t.Context())
+
+	assert.NilError(t, err)
+	assert.DeepEqual(t, rec.snapshot(), []string{"started", "stopped"})
+	cfg, err := LoadConfig(1)
+	assert.NilError(t, err)
+	assert.Assert(t, cfg.Started, "config should be saved with Started=true")
+}
+
+func TestDriverRun_AgentError(t *testing.T) {
+	d, rec := setupDriver(t, &Config{
+		Dummy: &DummyOptions{Commands: []string{"exit 1"}},
+	})
+
+	err := d.Run(t.Context())
+
+	// An acked failed event fulfils the reporting duty: exit 0.
+	assert.NilError(t, err)
+	assert.DeepEqual(t, rec.snapshot(), []string{"started", "failed"})
+}
+
+func TestDriverRun_SetupError(t *testing.T) {
+	d, rec := setupDriver(t, &Config{Commands: []string{"exit 1"}})
+
+	err := d.Run(t.Context())
+
+	assert.NilError(t, err)
+	assert.DeepEqual(t, rec.snapshot(), []string{"started", "failed"})
+}
+
+func TestDriverRun_FailedEventNotAcked(t *testing.T) {
+	d, rec := setupDriver(t, &Config{
+		Dummy: &DummyOptions{Commands: []string{"exit 1"}},
+	})
+	rec.failOn = "failed"
+
+	err := d.Run(t.Context())
+
+	// The failure could not be reported: exit non-zero so the monitor's
+	// failed fallback fires.
+	assert.ErrorContains(t, err, "dummy command failed")
+	assert.DeepEqual(t, rec.snapshot(), []string{"started"})
+}
+
+func TestDriverRun_Stop(t *testing.T) {
+	d, rec := setupDriver(t, &Config{
+		Dummy: &DummyOptions{Sleep: -1},
+	})
+
+	result := make(chan error, 1)
+	go func() { result <- d.Run(t.Context()) }()
+	rec.waitLen(t, 1) // started: the signal handler is installed
+	assert.NilError(t, syscall.Kill(syscall.Getpid(), syscall.SIGTERM))
+
+	assert.NilError(t, <-result)
+	assert.DeepEqual(t, rec.snapshot(), []string{"started", "stopped"})
+}
+
+func TestDriverRun_Reload(t *testing.T) {
+	d, rec := setupDriver(t, &Config{
+		Dummy: &DummyOptions{Sleep: -1},
+	})
+
+	result := make(chan error, 1)
+	go func() { result <- d.Run(t.Context()) }()
+	rec.waitLen(t, 1) // started: the signal handler is installed
+	assert.NilError(t, syscall.Kill(syscall.Getpid(), syscall.SIGHUP))
+	rec.waitLen(t, 2) // started again: the reload completed
+	assert.NilError(t, syscall.Kill(syscall.Getpid(), syscall.SIGTERM))
+
+	assert.NilError(t, <-result)
+	assert.DeepEqual(t, rec.snapshot(), []string{"started", "started", "stopped"})
+}
 
 func TestConfigPrompt_WithoutChildTasksCapability(t *testing.T) {
 	cfg := &Config{}

--- a/internal/agent/interface.go
+++ b/internal/agent/interface.go
@@ -18,6 +18,11 @@ import (
 // to distinguish a graceful stop from other errors.
 var ErrStop = errors.New("stop")
 
+// ErrReload is a sentinel cancellation cause, like ErrStop, used to signal an
+// in-place reload: the current agent run is cancelled, and the driver starts a
+// new run for the updated task in the same process.
+var ErrReload = errors.New("reload")
+
 // Agent type constants.
 const (
 	TypeClaude  = "claude"

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -11,7 +11,6 @@ import (
 	"path"
 	"regexp"
 	"strconv"
-	"time"
 
 	"connectrpc.com/connect"
 	"github.com/docker/docker/api/types/container"
@@ -160,11 +159,20 @@ func (r *Runner) Poll(ctx context.Context) error {
 			})
 		case model.TaskCommandRestart:
 			g.Go(func() error {
-				// Kill existing container if running
-				if err := r.Kill(ctx, task); err != nil {
-					r.log.Error("failed to kill task for restart", "task", task.ID, "error", err)
+				// In-place reload: SIGHUP the running driver. It cancels the
+				// current agent run, emits "started" (clearing the restart
+				// command), and starts a new run without the container ever
+				// stopping.
+				reloaded, err := r.Reload(ctx, task)
+				if err != nil {
+					r.log.Error("failed to reload task", "task", task.ID, "error", err)
+					return nil // retried on the next poll
 				}
-				// Atomically acquire a semaphore slot before starting
+				if reloaded {
+					return nil
+				}
+				// Container not running: fall back to recreate-and-start.
+				// Atomically acquire a semaphore slot before starting.
 				if !r.sem.TryAcquire(1) {
 					r.log.Debug("concurrency limit reached, skipping task", "task", task.ID, "limit", r.concurrency)
 					return nil
@@ -179,7 +187,8 @@ func (r *Runner) Poll(ctx context.Context) error {
 					})
 					return nil
 				}
-				// The "started" event is sent by Monitor when the container starts
+				// The "started" event is sent by the driver once it's up
+				// (the Monitor's start event is the backup).
 				return nil
 			})
 		case model.TaskCommandStart:
@@ -332,6 +341,28 @@ func (r *Runner) isRunning(ctx context.Context, task *model.Task) (bool, error) 
 	return c.State == "running", nil
 }
 
+// Reload sends SIGHUP to the container's PID 1 (the driver), telling it to
+// cancel the current agent run and start a new one in place. It reports
+// whether a running container was signalled; if not, the caller falls back
+// to recreate-and-start.
+func (r *Runner) Reload(ctx context.Context, task *model.Task) (bool, error) {
+	c, ok, err := r.find(ctx, task.ID)
+	if err != nil {
+		return false, err
+	}
+	if !ok || c.State != "running" {
+		return false, nil
+	}
+	r.log.Info("reloading container", "task", task.ID)
+	if err := dockerx.ContainerSignal(ctx, r.docker, c.ID, "SIGHUP"); err != nil {
+		if errors.Is(err, dockerx.ErrNotRunning) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 func (r *Runner) Kill(ctx context.Context, task *model.Task) error {
 	c, ok, err := r.find(ctx, task.ID)
 	if err != nil {
@@ -345,8 +376,10 @@ func (r *Runner) Kill(ctx context.Context, task *model.Task) error {
 	}
 	r.log.Info("killing container", "task", task.ID)
 
-	// Try SIGTERM first with a timeout
-	killCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	// Try SIGTERM first with a timeout. The driver applies the same timeout
+	// to the agent's unwind (agent.StopTimeout), so a hung agent exits
+	// non-zero on its own at roughly the moment we'd SIGKILL it.
+	killCtx, cancel := context.WithTimeout(ctx, agent.StopTimeout)
 	defer cancel()
 	err = dockerx.ContainerKill(killCtx, r.docker, c.ID, "SIGTERM")
 	if err == nil || errors.Is(err, dockerx.ErrNotRunning) {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -5,7 +5,10 @@ import (
 	"log/slog"
 	"net/http/httptest"
 	"path/filepath"
+	"slices"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types/container"
 	dockerclient "github.com/docker/docker/client"
@@ -38,12 +41,9 @@ func TestRunnerStart(t *testing.T) {
 	}
 
 	// Create mock client. The driver and the injected MCP server now connect to
-	// this server directly (over the host network), so it must answer the
-	// driver's startup Ping and the agent's get_my_task (GetTaskDetails).
+	// this server directly (over the host network), so it must ack the driver's
+	// runner events and answer the agent's get_my_task (GetTaskDetails).
 	mock := &xagentclient.ClientMock{
-		PingFunc: func(_ context.Context, req *xagentv1.PingRequest) (*xagentv1.PingResponse, error) {
-			return &xagentv1.PingResponse{}, nil
-		},
 		CreateTaskTokenFunc: func(_ context.Context, req *xagentv1.CreateTaskTokenRequest) (*xagentv1.CreateTaskTokenResponse, error) {
 			return &xagentv1.CreateTaskTokenResponse{Token: "test-token"}, nil
 		},
@@ -114,4 +114,113 @@ func TestRunnerStart(t *testing.T) {
 
 	// Verify get_my_task was called
 	assert.Equal(t, len(mock.GetTaskDetailsCalls()), 1)
+}
+
+func TestRunnerReload(t *testing.T) {
+	abs, err := filepath.Abs("../../prebuilt")
+	assert.NilError(t, err)
+	t.Setenv("XAGENT_PREBUILT_DIR", abs)
+
+	task := &model.Task{
+		ID:        2,
+		Name:      "test-reload-task",
+		Runner:    "test-runner",
+		Workspace: "test",
+		Status:    model.TaskStatusPending,
+		Command:   model.TaskCommandStart,
+		Version:   1,
+	}
+
+	// Record the runner events the driver submits.
+	var mu sync.Mutex
+	var events []string
+	waitEvents := func(t *testing.T, want []string) {
+		t.Helper()
+		deadline := time.Now().Add(60 * time.Second)
+		for {
+			mu.Lock()
+			got := slices.Clone(events)
+			mu.Unlock()
+			if slices.Equal(got, want) {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("timed out waiting for events %v, have %v", want, got)
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	mock := &xagentclient.ClientMock{
+		CreateTaskTokenFunc: func(_ context.Context, req *xagentv1.CreateTaskTokenRequest) (*xagentv1.CreateTaskTokenResponse, error) {
+			return &xagentv1.CreateTaskTokenResponse{Token: "test-token"}, nil
+		},
+		SubmitRunnerEventsFunc: func(_ context.Context, req *xagentv1.SubmitRunnerEventsRequest) (*xagentv1.SubmitRunnerEventsResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			for _, ev := range req.Events {
+				events = append(events, ev.Event)
+			}
+			return &xagentv1.SubmitRunnerEventsResponse{}, nil
+		},
+	}
+
+	_, handler := xagentv1connect.NewXAgentServiceHandler(mock)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	client := xagentclient.New(xagentclient.Options{BaseURL: ts.URL})
+	r, err := New(Options{
+		Client:    client,
+		ServerURL: ts.URL,
+		Queue:     NewEventQueue(EventQueueOptions{Client: client, Log: slog.Default()}),
+		Workspaces: &workspace.Config{
+			Workspaces: map[string]workspace.Workspace{
+				"test": {
+					Container: workspace.Container{
+						Image:       "alpine:latest",
+						NetworkMode: "host",
+					},
+					Agent: workspace.Agent{
+						Type:  "dummy",
+						Dummy: &workspace.DummyConfig{Sleep: -1},
+					},
+				},
+			},
+		},
+		Concurrency: 1,
+		RunnerID:    "test-runner",
+	})
+	assert.NilError(t, err)
+	t.Cleanup(func() { r.Close() })
+
+	docker, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
+	assert.NilError(t, err)
+	defer docker.Close()
+
+	// Remove any leftover container from a previous aborted run.
+	_ = docker.ContainerRemove(t.Context(), "xagent-2", container.RemoveOptions{Force: true})
+
+	// Start the task and wait for the driver to report started.
+	err = r.Start(t.Context(), task)
+	assert.NilError(t, err)
+	waitEvents(t, []string{"started"})
+
+	// Reload in place: the driver reports started again without the
+	// container ever stopping.
+	reloaded, err := r.Reload(t.Context(), task)
+	assert.NilError(t, err)
+	assert.Assert(t, reloaded, "expected a running container to be signalled")
+	waitEvents(t, []string{"started", "started"})
+
+	// Stop: the driver reports stopped and exits 0.
+	err = r.Kill(t.Context(), task)
+	assert.NilError(t, err)
+	waitEvents(t, []string{"started", "started", "stopped"})
+
+	info, err := docker.ContainerInspect(t.Context(), "xagent-2")
+	assert.NilError(t, err)
+	assert.Equal(t, info.State.ExitCode, 0)
+
+	err = docker.ContainerRemove(t.Context(), "xagent-2", container.RemoveOptions{})
+	assert.NilError(t, err)
 }

--- a/internal/x/dockerx/container.go
+++ b/internal/x/dockerx/container.go
@@ -40,13 +40,22 @@ func ContainerWait(ctx context.Context, client ContainerWaiter, containerID stri
 	}
 }
 
-// ContainerKill kills a container with the specified signal and waits for it to stop.
-// It returns ErrNotRunning if the container was not running.
-func ContainerKill(ctx context.Context, client ContainerKiller, containerID string, signal string) error {
+// ContainerSignal sends a signal to a running container without waiting for
+// it to stop. It returns ErrNotRunning if the container was not running.
+func ContainerSignal(ctx context.Context, client ContainerKiller, containerID string, signal string) error {
 	if err := client.ContainerKill(ctx, containerID, signal); err != nil {
 		if cerrdefs.IsConflict(err) && strings.Contains(err.Error(), "is not running") {
 			return ErrNotRunning
 		}
+		return err
+	}
+	return nil
+}
+
+// ContainerKill kills a container with the specified signal and waits for it to stop.
+// It returns ErrNotRunning if the container was not running.
+func ContainerKill(ctx context.Context, client ContainerKiller, containerID string, signal string) error {
+	if err := ContainerSignal(ctx, client, containerID, signal); err != nil {
 		return err
 	}
 	return ContainerWait(ctx, client, containerID, container.WaitConditionNotRunning)

--- a/proposals/implemented/driver-owned-events.md
+++ b/proposals/implemented/driver-owned-events.md
@@ -450,6 +450,38 @@ sequenceDiagram
 
 ---
 
+## Implementation notes
+
+The implementation deviates from the design above in a few places:
+
+- **No `AgentFilter` changes.** The socket proxy and its filter were removed
+  (see proposals/implemented/eliminate-runner-socket-proxy.md) before this
+  proposal was implemented. The driver talks to the C2 directly with a
+  task-scoped JWT whose `task.write` scope already constrains
+  `SubmitRunnerEvents` to the driver's own task — no new authorization
+  surface was needed.
+- **`Kill` + `Reload` instead of a parameterized `Signal`.** Stop and reload
+  have different wait semantics (SIGTERM waits for exit and escalates to
+  SIGKILL; SIGHUP must not wait — the container stays up), so the runner
+  keeps `Kill` unchanged and adds `Reload`, which reports whether a running
+  container was signalled so `Poll` can fall back to recreate-and-start.
+- **The unwind timeout covers stop too.** The driver bounds how long a
+  cancelled run may take to return (`agent.StopTimeout`, shared with
+  `runner.Kill`) regardless of whether the cancel cause was `ErrStop` or
+  `ErrReload`, and exits non-zero without reporting if it fires.
+- **SIGHUP before the first run is a plain start.** A reload that arrives
+  while setup commands are still running (setup is only interruptible by
+  stop) is honored by re-arming the run context and emitting `started`,
+  keeping the original bootstrap prompt — there is no agent session to
+  reload yet, so `resume=true` would be wrong.
+- **No `reloading` flag.** Layered contexts make it unnecessary: SIGTERM
+  cancels a stop context that parents every run context (so a stop always
+  wins over an in-progress reload), and the run context is re-armed before
+  `started` is emitted so a racing SIGHUP cancels the new run instead of
+  being lost. Duplicate SIGHUPs against an already-cancelled run context are
+  no-ops, and the extra pass through the reload branch is rejected by the
+  server's status guard.
+
 ## Migration notes
 
 - `internal/command/driver.go`:


### PR DESCRIPTION
Implements [proposals/implemented/driver-owned-events.md](https://github.com/icholy/xagent/blob/driver-owned-events/proposals/implemented/driver-owned-events.md): the driver becomes the source of truth for `started` / `stopped` / `failed` runner events, with the runner's docker monitor retained as a fallback for processes that die before they can report (OOM, SIGKILL, image-pull failure).

## Driver (`internal/agent/driver.go`)

- Emits `started` on entry and waits for the ack — an acked submit proves server, auth, and DB are healthy, so the old `Ping` is dropped.
- Emits `failed` on setup/agent errors and `stopped` on clean completion or SIGTERM.
- Invariant: the driver exits non-zero only when it could not report its outcome itself. An acked `failed` event means exit 0; an unacked one returns the original error so the monitor's exit-code fallback reports instead.
- SIGHUP triggers an in-place reload: the current run is cancelled with the new `agent.ErrReload` cause, the driver re-emits `started` (clearing `running+restart`), and re-prompts with the task-updated prompt and `resume=true` — the container never stops. SIGTERM wins over an in-progress reload via layered cancel contexts (a stop context parents every run context).
- A cancelled run gets `agent.StopTimeout` (30s, shared with `runner.Kill`) to unwind; on timeout the driver exits non-zero without reporting so the monitor's `failed` fallback fires.
- A SIGHUP that arrives before the agent ever ran (during setup) is treated as a plain start with the original bootstrap prompt.

## Runner (`internal/runner/runner.go`)

- `Poll`'s restart branch now SIGHUPs a running container via the new `Runner.Reload` (built on the new `dockerx.ContainerSignal`, which signals without waiting) and only falls back to recreate-and-start when the container is not running. This eliminates the container recreate cost on restart.
- `Monitor`, `Reconcile`, and the stop branch keep their emits as backups; duplicates are harmless because the task state machine is status-guarded.

No server, proto, or state-machine changes: the task token's `task.write` scope already constrains `SubmitRunnerEvents` to the driver's own task.

## Tests

- Six new driver tests covering clean completion, agent error, setup error, the unacked-failure exit path, SIGTERM stop, and SIGHUP reload (using real signals against the test process).
- A docker integration test (`TestRunnerReload`) verifying started, in-place reload, and stopped with the container exiting 0 and never being recreated.