### PR TITLE
feat: move ownership of task lifecycle events into the driver

### DIFF
--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"text/template"
 
 	"github.com/icholy/xagent/internal/auth/agentauth"
+	"github.com/icholy/xagent/internal/model"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
 	"github.com/icholy/xagent/internal/xagentclient"
 )
@@ -23,7 +25,16 @@ type Driver struct {
 	Log    *slog.Logger
 }
 
+// Run executes the task and reports its outcome to the server. The driver
+// owns the started / stopped / failed runner events (see the
+// driver-owned-events proposal); it returns an error only when it could not
+// report the outcome itself, so the runner's monitor reads the exit code as
+// a single bit meaning "did the driver report?".
 func (d *Driver) Run(ctx context.Context) error {
+	// Events are submitted on the parent context, which survives the SIGTERM
+	// cancellation below — the terminal events go out after the run context
+	// is torn down, bounded by the client's HTTP timeout.
+	eventCtx := ctx
 
 	// Set up SIGTERM handler to cancel with ErrStop
 	ctx, cancel := context.WithCancelCause(ctx)
@@ -36,11 +47,48 @@ func (d *Driver) Run(ctx context.Context) error {
 	}()
 	defer signal.Stop(sigCh)
 
-	// Make sure the server is reachable
-	if _, err := d.Client.Ping(ctx, &xagentv1.PingRequest{}); err != nil {
-		return fmt.Errorf("failed to ping server: %w", err)
+	// Report started: replaces the startup ping — an acked submit proves the
+	// connection, token, server, and DB are all healthy.
+	if err := d.submit(eventCtx, model.RunnerEventStarted); err != nil {
+		return err
 	}
 
+	err := d.run(ctx)
+	if err != nil && context.Cause(ctx) == ErrStop {
+		d.Log.Info("agent stopped gracefully")
+		err = nil
+	}
+	event := model.RunnerEventStopped
+	if err != nil {
+		d.Log.Error("task failed", "error", err)
+		event = model.RunnerEventFailed
+	}
+	// The terminal ack decides the exit code: acked means the outcome is
+	// durably recorded and the driver exits 0 even on agent failure; a lost
+	// report exits non-zero so the monitor's "failed" fires.
+	if serr := d.submit(eventCtx, event); serr != nil {
+		return errors.Join(err, serr)
+	}
+	return nil
+}
+
+// submit reports a runner event for the driver's task and waits for the ack.
+// The SubmitRunnerEvents handler commits the transaction before returning,
+// so a nil error means the state transition is durable.
+func (d *Driver) submit(ctx context.Context, event model.RunnerEventType) error {
+	// Version 0 bypasses the version check (spontaneous events).
+	re := model.RunnerEvent{TaskID: d.TaskID, Event: event}
+	_, err := d.Client.SubmitRunnerEvents(ctx, &xagentv1.SubmitRunnerEventsRequest{
+		Events: []*xagentv1.RunnerEvent{re.Proto()},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to submit %s event: %w", event, err)
+	}
+	return nil
+}
+
+// run executes the setup commands and the agent prompt.
+func (d *Driver) run(ctx context.Context) error {
 	// Load config
 	cfg, err := LoadConfig(d.TaskID)
 	if err != nil {
@@ -84,10 +132,6 @@ func (d *Driver) Run(ctx context.Context) error {
 	}
 
 	if err := a.Prompt(ctx, prompt, cfg.Started); err != nil {
-		if context.Cause(ctx) == ErrStop {
-			d.Log.Info("agent stopped gracefully")
-			return nil
-		}
 		return err
 	}
 

--- a/internal/agent/driver_test.go
+++ b/internal/agent/driver_test.go
@@ -1,12 +1,168 @@
 package agent
 
 import (
+	"context"
+	"errors"
+	"log/slog"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/icholy/xagent/internal/auth/agentauth"
+	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
+	"github.com/icholy/xagent/internal/xagentclient"
 	"gotest.tools/v3/assert"
 )
+
+// setupDriver writes cfg for task 1 in a temporary config dir and returns a
+// driver backed by a mock client whose SubmitRunnerEvents always acks.
+// The tests mutate the global ConfigDir, so they must not run in parallel.
+func setupDriver(t *testing.T, cfg *Config) (*Driver, *xagentclient.ClientMock) {
+	t.Helper()
+	dir := ConfigDir
+	ConfigDir = t.TempDir()
+	t.Cleanup(func() { ConfigDir = dir })
+	assert.NilError(t, SaveConfig(1, cfg))
+	mock := &xagentclient.ClientMock{
+		SubmitRunnerEventsFunc: func(_ context.Context, req *xagentv1.SubmitRunnerEventsRequest) (*xagentv1.SubmitRunnerEventsResponse, error) {
+			return &xagentv1.SubmitRunnerEventsResponse{}, nil
+		},
+	}
+	return &Driver{TaskID: 1, Client: mock, Log: slog.Default()}, mock
+}
+
+// submittedEvents returns the runner events submitted to the mock, in order.
+func submittedEvents(mock *xagentclient.ClientMock) []string {
+	var events []string
+	for _, call := range mock.SubmitRunnerEventsCalls() {
+		for _, e := range call.SubmitRunnerEventsRequest.Events {
+			events = append(events, e.Event)
+		}
+	}
+	return events
+}
+
+func TestDriverRun(t *testing.T) {
+	// Arrange
+	driver, mock := setupDriver(t, &Config{Type: TypeDummy})
+
+	// Act
+	err := driver.Run(t.Context())
+
+	// Assert
+	assert.NilError(t, err)
+	assert.DeepEqual(t, submittedEvents(mock), []string{"started", "stopped"})
+}
+
+func TestDriverRun_AgentError(t *testing.T) {
+	// Arrange
+	driver, mock := setupDriver(t, &Config{
+		Type:  TypeDummy,
+		Dummy: &DummyOptions{Commands: []string{"false"}},
+	})
+
+	// Act
+	err := driver.Run(t.Context())
+
+	// Assert - the failure was reported and acked, so the driver exits 0
+	assert.NilError(t, err)
+	assert.DeepEqual(t, submittedEvents(mock), []string{"started", "failed"})
+}
+
+func TestDriverRun_SetupCommandError(t *testing.T) {
+	// Arrange
+	driver, mock := setupDriver(t, &Config{
+		Type:     TypeDummy,
+		Commands: []string{"false"},
+	})
+
+	// Act
+	err := driver.Run(t.Context())
+
+	// Assert
+	assert.NilError(t, err)
+	assert.DeepEqual(t, submittedEvents(mock), []string{"started", "failed"})
+}
+
+func TestDriverRun_Sigterm(t *testing.T) {
+	// Arrange - the dummy agent sleeps until the run context is cancelled
+	driver, mock := setupDriver(t, &Config{
+		Type:  TypeDummy,
+		Dummy: &DummyOptions{Sleep: -1},
+	})
+	started := make(chan struct{})
+	mock.SubmitRunnerEventsFunc = func(_ context.Context, req *xagentv1.SubmitRunnerEventsRequest) (*xagentv1.SubmitRunnerEventsResponse, error) {
+		if req.Events[0].Event == "started" {
+			close(started)
+		}
+		return &xagentv1.SubmitRunnerEventsResponse{}, nil
+	}
+	go func() {
+		// Run's SIGTERM handler is registered before the started event is
+		// submitted, so the signal cannot kill the test process.
+		<-started
+		_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+	}()
+
+	// Act
+	err := driver.Run(t.Context())
+
+	// Assert - a graceful stop is reported as stopped
+	assert.NilError(t, err)
+	assert.DeepEqual(t, submittedEvents(mock), []string{"started", "stopped"})
+}
+
+func TestDriverRun_StartedSubmitError(t *testing.T) {
+	// Arrange
+	driver, mock := setupDriver(t, &Config{Type: TypeDummy})
+	mock.SubmitRunnerEventsFunc = func(_ context.Context, req *xagentv1.SubmitRunnerEventsRequest) (*xagentv1.SubmitRunnerEventsResponse, error) {
+		return nil, errors.New("server unreachable")
+	}
+
+	// Act
+	err := driver.Run(t.Context())
+
+	// Assert
+	assert.ErrorContains(t, err, "failed to submit started event")
+}
+
+func TestDriverRun_StoppedSubmitError(t *testing.T) {
+	// Arrange
+	driver, mock := setupDriver(t, &Config{Type: TypeDummy})
+	mock.SubmitRunnerEventsFunc = func(_ context.Context, req *xagentv1.SubmitRunnerEventsRequest) (*xagentv1.SubmitRunnerEventsResponse, error) {
+		if req.Events[0].Event == "stopped" {
+			return nil, errors.New("server unreachable")
+		}
+		return &xagentv1.SubmitRunnerEventsResponse{}, nil
+	}
+
+	// Act
+	err := driver.Run(t.Context())
+
+	// Assert - an unacked terminal submit exits non-zero
+	assert.ErrorContains(t, err, "failed to submit stopped event")
+}
+
+func TestDriverRun_FailedSubmitError(t *testing.T) {
+	// Arrange
+	driver, mock := setupDriver(t, &Config{
+		Type:  TypeDummy,
+		Dummy: &DummyOptions{Commands: []string{"false"}},
+	})
+	mock.SubmitRunnerEventsFunc = func(_ context.Context, req *xagentv1.SubmitRunnerEventsRequest) (*xagentv1.SubmitRunnerEventsResponse, error) {
+		if req.Events[0].Event == "failed" {
+			return nil, errors.New("server unreachable")
+		}
+		return &xagentv1.SubmitRunnerEventsResponse{}, nil
+	}
+
+	// Act
+	err := driver.Run(t.Context())
+
+	// Assert - both the agent error and the lost report surface
+	assert.ErrorContains(t, err, "dummy command failed")
+	assert.ErrorContains(t, err, "failed to submit failed event")
+}
 
 func TestConfigPrompt_WithoutChildTasksCapability(t *testing.T) {
 	cfg := &Config{}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -148,9 +148,22 @@ func (r *Runner) Poll(ctx context.Context) error {
 		switch task.Command {
 		case model.TaskCommandStop:
 			g.Go(func() error {
-				if err := r.Kill(ctx, task); err != nil {
+				signalled, err := r.Kill(ctx, task)
+				if err != nil {
+					// The stop command survives, so the kill is retried on
+					// the next poll.
 					r.log.Error("failed to stop task", "task", task.ID, "error", err)
+					return nil
 				}
+				if signalled {
+					// The driver owns the terminal report. If it hangs until
+					// SIGKILL, the non-zero exit triggers the monitor's
+					// "failed" instead.
+					return nil
+				}
+				// No running container to signal: there is no driver to
+				// complete the cancel, so emit "stopped" to land the task in
+				// cancelled instead of sticking in cancelling.
 				r.queue.Enqueue(model.RunnerEvent{
 					TaskID:  task.ID,
 					Event:   model.RunnerEventStopped,
@@ -160,8 +173,11 @@ func (r *Runner) Poll(ctx context.Context) error {
 			})
 		case model.TaskCommandRestart:
 			g.Go(func() error {
-				// Kill existing container if running
-				if err := r.Kill(ctx, task); err != nil {
+				// Kill existing container if running. The old run's "stopped"
+				// is rejected by the status guard while the restart command is
+				// pending, so the command survives until the new run's
+				// "started" consumes it.
+				if _, err := r.Kill(ctx, task); err != nil {
 					r.log.Error("failed to kill task for restart", "task", task.ID, "error", err)
 				}
 				// Atomically acquire a semaphore slot before starting
@@ -179,7 +195,7 @@ func (r *Runner) Poll(ctx context.Context) error {
 					})
 					return nil
 				}
-				// The "started" event is sent by Monitor when the container starts
+				// The "started" event is submitted by the driver on startup
 				return nil
 			})
 		case model.TaskCommandStart:
@@ -217,7 +233,7 @@ func (r *Runner) Poll(ctx context.Context) error {
 					})
 					return nil
 				}
-				// The "started" event is sent by Monitor when the container starts
+				// The "started" event is submitted by the driver on startup
 				return nil
 			})
 		}
@@ -277,28 +293,15 @@ func (r *Runner) Reconcile(ctx context.Context) error {
 			continue
 		}
 
-		// Inspect container to get exit code
-		info, err := r.docker.ContainerInspect(ctx, c.ID)
-		if err != nil {
-			r.log.Error("failed to inspect container", "task", taskID, "error", err)
-			continue
-		}
-
+		// An exited container whose task is still running means the driver's
+		// report was lost — "failed" is the honest outcome regardless of exit
+		// code (see the driver-owned-events proposal).
+		r.log.Error("reconcile: container exited without reporting", "task", taskID)
 		// Use version 0 to bypass version check (spontaneous events)
-		exitCode := info.State.ExitCode
-		if exitCode == 0 {
-			r.log.Info("reconcile: container exited successfully", "task", taskID)
-			r.queue.Enqueue(model.RunnerEvent{
-				TaskID: taskID,
-				Event:  model.RunnerEventStopped,
-			})
-		} else {
-			r.log.Error("reconcile: container exited with error", "task", taskID, "exitCode", exitCode)
-			r.queue.Enqueue(model.RunnerEvent{
-				TaskID: taskID,
-				Event:  model.RunnerEventFailed,
-			})
-		}
+		r.queue.Enqueue(model.RunnerEvent{
+			TaskID: taskID,
+			Event:  model.RunnerEventFailed,
+		})
 	}
 
 	return nil
@@ -332,16 +335,16 @@ func (r *Runner) isRunning(ctx context.Context, task *model.Task) (bool, error) 
 	return c.State == "running", nil
 }
 
-func (r *Runner) Kill(ctx context.Context, task *model.Task) error {
+// Kill stops the task's container if it is running. It reports whether a
+// running container was signalled — in that case the driver owns the
+// terminal event report (see the driver-owned-events proposal).
+func (r *Runner) Kill(ctx context.Context, task *model.Task) (bool, error) {
 	c, ok, err := r.find(ctx, task.ID)
 	if err != nil {
-		return err
+		return false, err
 	}
-	if !ok {
-		return nil
-	}
-	if c.State != "running" {
-		return nil
+	if !ok || c.State != "running" {
+		return false, nil
 	}
 	r.log.Info("killing container", "task", task.ID)
 
@@ -349,23 +352,25 @@ func (r *Runner) Kill(ctx context.Context, task *model.Task) error {
 	killCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	err = dockerx.ContainerKill(killCtx, r.docker, c.ID, "SIGTERM")
-	if err == nil || errors.Is(err, dockerx.ErrNotRunning) {
-		return nil
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, dockerx.ErrNotRunning) {
+		// The container exited between the running check and the kill, so
+		// nothing was signalled.
+		return false, nil
 	}
 
 	// If SIGTERM timed out, send SIGKILL
 	if errors.Is(err, context.DeadlineExceeded) {
 		r.log.Warn("SIGTERM timed out, sending SIGKILL", "task", task.ID)
-		if err := dockerx.ContainerKill(ctx, r.docker, c.ID, "SIGKILL"); err != nil {
-			if errors.Is(err, dockerx.ErrNotRunning) {
-				return nil
-			}
-			return err
+		if err := dockerx.ContainerKill(ctx, r.docker, c.ID, "SIGKILL"); err != nil && !errors.Is(err, dockerx.ErrNotRunning) {
+			return true, err
 		}
-		return nil
+		return true, nil
 	}
 
-	return err
+	return true, err
 }
 
 func (r *Runner) create(ctx context.Context, task *model.Task) (string, error) {
@@ -499,12 +504,15 @@ func (r *Runner) Start(ctx context.Context, task *model.Task) error {
 	return nil
 }
 
-// Monitor watches for container starts and exits and sends runner events accordingly.
+// Monitor watches for container exits and reports the ones the driver
+// couldn't: a non-zero exit means the driver died without reporting its
+// outcome, so the runner emits "failed" on its behalf. Exit 0 means the
+// driver already reported (see the driver-owned-events proposal), so no
+// event is emitted.
 func (r *Runner) Monitor(ctx context.Context) error {
 	eventCh, errCh := r.docker.Events(ctx, events.ListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("type", "container"),
-			filters.Arg("event", "start"),
 			filters.Arg("event", "die"),
 			filters.Arg("label", "xagent=true"),
 			filters.Arg("label", "xagent.runner="+r.runnerID),
@@ -521,33 +529,19 @@ func (r *Runner) Monitor(ctx context.Context) error {
 				continue
 			}
 
-			switch event.Action {
-			case events.ActionStart:
-				r.log.Info("container started", "task", taskID)
-				// Use version 0 to bypass version check (spontaneous events)
-				r.queue.Enqueue(model.RunnerEvent{
-					TaskID: taskID,
-					Event:  model.RunnerEventStarted,
-				})
-			case events.ActionDie:
-				r.sem.Release(1)
-				r.wake.Wake()
-				// Use version 0 to bypass version check (spontaneous events)
-				exitCode := event.Actor.Attributes["exitCode"]
-				if exitCode == "0" {
-					r.log.Info("container exited successfully", "task", taskID)
-					r.queue.Enqueue(model.RunnerEvent{
-						TaskID: taskID,
-						Event:  model.RunnerEventStopped,
-					})
-				} else {
-					r.log.Error("container exited with error", "task", taskID, "exitCode", exitCode)
-					r.queue.Enqueue(model.RunnerEvent{
-						TaskID: taskID,
-						Event:  model.RunnerEventFailed,
-					})
-				}
+			r.sem.Release(1)
+			r.wake.Wake()
+			exitCode := event.Actor.Attributes["exitCode"]
+			if exitCode == "0" {
+				r.log.Info("container exited, driver already reported", "task", taskID)
+				continue
 			}
+			r.log.Error("container exited without reporting", "task", taskID, "exitCode", exitCode)
+			// Use version 0 to bypass version check (spontaneous events)
+			r.queue.Enqueue(model.RunnerEvent{
+				TaskID: taskID,
+				Event:  model.RunnerEventFailed,
+			})
 
 		case err := <-errCh:
 			return fmt.Errorf("docker events error: %w", err)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -39,11 +39,9 @@ func TestRunnerStart(t *testing.T) {
 
 	// Create mock client. The driver and the injected MCP server now connect to
 	// this server directly (over the host network), so it must answer the
-	// driver's startup Ping and the agent's get_my_task (GetTaskDetails).
+	// driver's started/stopped events and the agent's get_my_task
+	// (GetTaskDetails).
 	mock := &xagentclient.ClientMock{
-		PingFunc: func(_ context.Context, req *xagentv1.PingRequest) (*xagentv1.PingResponse, error) {
-			return &xagentv1.PingResponse{}, nil
-		},
 		CreateTaskTokenFunc: func(_ context.Context, req *xagentv1.CreateTaskTokenRequest) (*xagentv1.CreateTaskTokenResponse, error) {
 			return &xagentv1.CreateTaskTokenResponse{Token: "test-token"}, nil
 		},
@@ -114,4 +112,13 @@ func TestRunnerStart(t *testing.T) {
 
 	// Verify get_my_task was called
 	assert.Equal(t, len(mock.GetTaskDetailsCalls()), 1)
+
+	// Verify the driver reported its own lifecycle: started, then stopped.
+	var events []string
+	for _, call := range mock.SubmitRunnerEventsCalls() {
+		for _, e := range call.SubmitRunnerEventsRequest.Events {
+			events = append(events, e.Event)
+		}
+	}
+	assert.DeepEqual(t, events, []string{"started", "stopped"})
 }


### PR DESCRIPTION
Implements [proposals/accepted/driver-owned-events.md](https://github.com/icholy/xagent/blob/master/proposals/accepted/driver-owned-events.md) (#581, simplified by #933): the driver is the source of truth for `started` / `stopped` / `failed` runner events, and the runner speaks only when no driver exists or the driver died without reporting.

## Invariant

The driver exits non-zero **only when it could not report its outcome itself**. The exit code is a single bit meaning "did the driver report?", and the monitor reads it as exactly that: exit 0 emits nothing, exit non-zero emits `failed`.

## Driver (`internal/agent/driver.go`)

- The startup `Ping` is replaced by submitting `started` and waiting for the ack — an acked submit proves the connection, token, server, and DB are all healthy in one round trip.
- The run body is extracted into a `run` helper; `Run` maps its outcome to a terminal event: `stopped` on clean completion and on the `ErrStop` SIGTERM path (stop and restart alike — the status-guarded state machine routes it), `failed` on any other error.
- The terminal ack decides the exit code: acked means exit 0 even when the agent failed; an unacked terminal submit (including `stopped`) returns an error so the monitor's `failed` fires. This makes the exit-before-ack race structurally impossible — there is no exit-0 fallback left to mislabel a lost failure as completed.
- All events are submitted on the parent context that survives the SIGTERM cancellation, bounded by the client's HTTP timeout. Submitting `started` on it too means a SIGTERM racing the startup submit still ends in a `stopped` report (`cancelled`) rather than a torn submit (`failed`).

## Runner (`internal/runner/runner.go`)

- `Monitor` subscribes only to `die` events: non-zero exit emits `failed`, exit 0 emits nothing. The `start` subscription and the `started` / exit-0 `stopped` emits are removed; the semaphore-release / wake-up bookkeeping is kept.
- `Kill` now reports whether it signalled a running container (the SIGKILL fallback counts; a container that exited between the running check and the kill does not).
- `Poll`'s stop branch emits `stopped` only when no running container was signalled — without it a stop for an already-dead container would stick in `cancelling`. When a container was signalled the driver owns the report, so a cancel that hangs until SIGKILL now lands deterministically in `failed` instead of racing the runner's `stopped` against the monitor's `failed`. On a kill error it emits nothing and retries on the next poll. Dispatch-failure `failed` emits are unchanged.
- `Reconcile` emits `failed` for any exited container whose task is still `running`, regardless of exit code: a lost report is a failure even when the container exited 0.

No protocol/schema changes, no state-machine changes, no new signals. Driver-emitted events use `Version: 0` like today's monitor.

## Tests

- Seven new `Driver.Run` tests covering the happy path, agent/setup failures, the SIGTERM-to-`stopped` path (real signal to the test process), and unacked `started`/`stopped`/`failed` submits.
- `TestRunnerStart` no longer mocks `Ping` and now asserts the driver reported `started` then `stopped` from inside the container.

The proposal stays in `proposals/accepted/` for now; I'll move it to `implemented/` in a follow-up docs commit once this merges, per convention.