### PR TITLE
feat(webui): prototype unified task activity timeline

### DIFF
--- a/webui/src/components/task-timeline.tsx
+++ b/webui/src/components/task-timeline.tsx
@@ -1,0 +1,520 @@
+import { useMemo, useState } from 'react'
+import Markdown from 'react-markdown'
+import {
+  Bot,
+  MessageSquarePlus,
+  Play,
+  RotateCcw,
+  CheckCircle2,
+  XCircle,
+  Ban,
+  Clock,
+  Link2,
+  Terminal,
+  Info,
+  Wrench,
+  AlertTriangle,
+  ChevronRight,
+  ChevronDown,
+  Zap,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { RelativeTime } from '@/components/relative-time'
+import { GithubIcon } from '@/components/github-icon'
+import { AtlassianIcon } from '@/components/atlassian-icon'
+import type {
+  TimelineItem,
+  LifecycleKind,
+  ReportLevel,
+  ExternalSource,
+} from '@/lib/mock-timeline'
+
+// ----- filtering -------------------------------------------------------------
+
+type FilterKey = 'instruction' | 'agent' | 'external' | 'system'
+
+const FILTERS: { key: FilterKey; label: string }[] = [
+  { key: 'agent', label: 'Agent output' },
+  { key: 'instruction', label: 'Instructions' },
+  { key: 'external', label: 'Events' },
+  { key: 'system', label: 'System' },
+]
+
+// `system` collapses the lower-signal about-task / operational entries.
+function filterOf(item: TimelineItem): FilterKey {
+  switch (item.kind) {
+    case 'instruction':
+      return 'instruction'
+    case 'agent':
+      return 'agent'
+    case 'external':
+      return 'external'
+    default:
+      return 'system'
+  }
+}
+
+// ----- row grouping ----------------------------------------------------------
+
+// Consecutive `report` entries collapse into a single expandable group so the
+// operational chatter doesn't drown out the story.
+type Row =
+  | { type: 'item'; item: TimelineItem }
+  | { type: 'reports'; items: Extract<TimelineItem, { kind: 'report' }>[] }
+
+function buildRows(items: TimelineItem[]): Row[] {
+  const rows: Row[] = []
+  for (const item of items) {
+    if (item.kind === 'report') {
+      const last = rows[rows.length - 1]
+      if (last && last.type === 'reports') {
+        last.items.push(item)
+      } else {
+        rows.push({ type: 'reports', items: [item] })
+      }
+    } else {
+      rows.push({ type: 'item', item })
+    }
+  }
+  return rows
+}
+
+// ----- top-level component ---------------------------------------------------
+
+export function TaskTimeline({ items }: { items: TimelineItem[] }) {
+  const [hidden, setHidden] = useState<Set<FilterKey>>(new Set())
+
+  const rows = useMemo(() => {
+    const visible = items.filter((i) => !hidden.has(filterOf(i)))
+    return buildRows(visible)
+  }, [items, hidden])
+
+  const toggle = (key: FilterKey) =>
+    setHidden((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <span className="text-xs text-muted-foreground mr-1">Show</span>
+        {FILTERS.map((f) => {
+          const active = !hidden.has(f.key)
+          return (
+            <button
+              key={f.key}
+              type="button"
+              onClick={() => toggle(f.key)}
+              className={cn(
+                'rounded-full border px-3 py-1 text-xs transition-colors',
+                active
+                  ? 'bg-foreground text-background border-foreground'
+                  : 'bg-transparent text-muted-foreground hover:bg-muted',
+              )}
+            >
+              {f.label}
+            </button>
+          )
+        })}
+      </div>
+
+      <ol className="relative space-y-3">
+        {/* the rail */}
+        <div className="absolute left-[17px] top-2 bottom-2 w-px bg-border" aria-hidden />
+        {rows.map((row, i) =>
+          row.type === 'reports' ? (
+            <ReportGroup key={`r-${i}`} items={row.items} />
+          ) : (
+            <TimelineRow key={row.item.id} item={row.item} />
+          ),
+        )}
+      </ol>
+    </div>
+  )
+}
+
+// ----- marker + row scaffolding ----------------------------------------------
+
+function Marker({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        'relative z-10 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+function Row({
+  marker,
+  children,
+}: {
+  marker: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <li className="relative flex gap-3">
+      {marker}
+      <div className="min-w-0 flex-1 pt-0.5">{children}</div>
+    </li>
+  )
+}
+
+function TimelineRow({ item }: { item: TimelineItem }) {
+  switch (item.kind) {
+    case 'instruction':
+      return <InstructionRow item={item} />
+    case 'agent':
+      return <AgentRow item={item} />
+    case 'external':
+      return <ExternalRow item={item} />
+    case 'lifecycle':
+      return <LifecycleRow item={item} />
+    case 'link':
+      return <LinkRow item={item} />
+    case 'report':
+      // reports are normally grouped; render standalone as a fallback.
+      return <ReportGroup items={[item]} />
+  }
+}
+
+// ----- per-kind rows ---------------------------------------------------------
+
+function InstructionRow({ item }: { item: Extract<TimelineItem, { kind: 'instruction' }> }) {
+  return (
+    <Row
+      marker={
+        <Marker className="border-primary/30 bg-primary/10 text-primary">
+          <MessageSquarePlus className="h-4 w-4" />
+        </Marker>
+      }
+    >
+      <div className="rounded-lg border border-primary/30 bg-primary/5">
+        <div className="flex items-center gap-2 px-4 py-2 text-xs">
+          <span className="font-medium text-foreground">Instruction</span>
+          {item.wakes && <WakeBadge />}
+          <span className="ml-auto text-muted-foreground">
+            <RelativeTime date={item.at} />
+          </span>
+        </div>
+        <div className="border-t border-primary/20 px-4 py-3">
+          <Prose text={item.text} />
+          {item.url && <SourceLink url={item.url} />}
+        </div>
+      </div>
+    </Row>
+  )
+}
+
+function AgentRow({ item }: { item: Extract<TimelineItem, { kind: 'agent' }> }) {
+  return (
+    <Row
+      marker={
+        <Marker className="border-violet-300 bg-violet-100 text-violet-700">
+          <Bot className="h-4 w-4" />
+        </Marker>
+      }
+    >
+      <div className="rounded-lg border bg-card shadow-sm">
+        <div className="flex items-center gap-2 px-4 py-2 text-xs">
+          <span className="font-medium text-foreground">Agent</span>
+          <span className="ml-auto text-muted-foreground">
+            <RelativeTime date={item.at} />
+          </span>
+        </div>
+        <div className="border-t px-4 py-3">
+          <CollapsibleProse text={item.text} />
+        </div>
+      </div>
+    </Row>
+  )
+}
+
+const externalSource: Record<
+  ExternalSource,
+  { icon: React.ReactNode; label: string; marker: string }
+> = {
+  github: {
+    icon: <GithubIcon className="h-4 w-4" />,
+    label: 'GitHub',
+    marker: 'border-slate-300 bg-slate-100 text-slate-800',
+  },
+  jira: {
+    icon: <AtlassianIcon className="h-4 w-4" />,
+    label: 'Jira',
+    marker: 'border-blue-300 bg-blue-100 text-blue-700',
+  },
+}
+
+function ExternalRow({ item }: { item: Extract<TimelineItem, { kind: 'external' }> }) {
+  const src = externalSource[item.source]
+  return (
+    <Row marker={<Marker className={src.marker}>{src.icon}</Marker>}>
+      <div className="rounded-lg border border-amber-300/60 bg-amber-50/60 dark:bg-amber-950/20">
+        <div className="flex items-center gap-2 px-4 py-2 text-xs">
+          <span className="font-medium text-foreground">Event</span>
+          <span className="text-muted-foreground">· {src.label}</span>
+          {item.wakes && <WakeBadge />}
+          <span className="ml-auto text-muted-foreground">
+            <RelativeTime date={item.at} />
+          </span>
+        </div>
+        <div className="border-t border-amber-300/40 px-4 py-3">
+          <p className="text-sm font-medium text-foreground">{item.description}</p>
+          {item.data && (
+            <p className="mt-1 text-sm text-muted-foreground whitespace-pre-wrap">{item.data}</p>
+          )}
+          {item.url && <SourceLink url={item.url} />}
+        </div>
+      </div>
+    </Row>
+  )
+}
+
+const lifecycleConfig: Record<
+  LifecycleKind,
+  { icon: React.ReactNode; label: string; tone: string }
+> = {
+  pending: { icon: <Clock className="h-3.5 w-3.5" />, label: 'Created', tone: 'text-amber-600' },
+  started: { icon: <Play className="h-3.5 w-3.5" />, label: 'Started', tone: 'text-blue-600' },
+  restarted: {
+    icon: <RotateCcw className="h-3.5 w-3.5" />,
+    label: 'Restarted',
+    tone: 'text-pink-600',
+  },
+  completed: {
+    icon: <CheckCircle2 className="h-3.5 w-3.5" />,
+    label: 'Completed',
+    tone: 'text-green-600',
+  },
+  failed: { icon: <XCircle className="h-3.5 w-3.5" />, label: 'Failed', tone: 'text-red-600' },
+  cancelled: { icon: <Ban className="h-3.5 w-3.5" />, label: 'Cancelled', tone: 'text-amber-600' },
+}
+
+// Lifecycle entries are deliberately understated: a slim inline marker on the
+// rail rather than a full card.
+function LifecycleRow({ item }: { item: Extract<TimelineItem, { kind: 'lifecycle' }> }) {
+  const cfg = lifecycleConfig[item.event]
+  return (
+    <li className="relative flex items-center gap-3">
+      <div
+        className={cn(
+          'relative z-10 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border bg-muted',
+          cfg.tone,
+        )}
+      >
+        {cfg.icon}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2 text-xs">
+        <span className={cn('font-medium', cfg.tone)}>{cfg.label}</span>
+        {item.detail && <span className="text-muted-foreground truncate">{item.detail}</span>}
+        <span className="ml-auto text-muted-foreground">
+          <RelativeTime date={item.at} />
+        </span>
+      </div>
+    </li>
+  )
+}
+
+function LinkRow({ item }: { item: Extract<TimelineItem, { kind: 'link' }> }) {
+  const icon =
+    item.source === 'github' ? (
+      <GithubIcon className="h-4 w-4" />
+    ) : item.source === 'jira' ? (
+      <AtlassianIcon className="h-4 w-4" />
+    ) : (
+      <Link2 className="h-4 w-4" />
+    )
+  return (
+    <Row marker={<Marker className="border-border bg-muted text-foreground">{icon}</Marker>}>
+      <div className="rounded-lg border bg-card px-4 py-3">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">Link created</span>
+          {item.subscribed && (
+            <Badge
+              variant="outline"
+              className="border-blue-200 bg-blue-100 text-blue-800 text-[10px]"
+            >
+              subscribed
+            </Badge>
+          )}
+          <span className="ml-auto">
+            <RelativeTime date={item.at} />
+          </span>
+        </div>
+        <a
+          href={item.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-1 block text-sm font-medium text-primary hover:underline break-words"
+        >
+          {item.title}
+        </a>
+        {item.relevance && (
+          <p className="mt-0.5 text-xs text-muted-foreground">{item.relevance}</p>
+        )}
+      </div>
+    </Row>
+  )
+}
+
+// ----- report group (collapsible) --------------------------------------------
+
+const reportConfig: Record<ReportLevel, { icon: React.ReactNode; tone: string; label: string }> = {
+  info: { icon: <Info className="h-3.5 w-3.5" />, tone: 'text-blue-600', label: 'info' },
+  mcp: { icon: <Wrench className="h-3.5 w-3.5" />, tone: 'text-teal-600', label: 'mcp' },
+  audit: { icon: <Terminal className="h-3.5 w-3.5" />, tone: 'text-amber-600', label: 'audit' },
+  error: { icon: <AlertTriangle className="h-3.5 w-3.5" />, tone: 'text-red-600', label: 'error' },
+}
+
+function ReportGroup({
+  items,
+}: {
+  items: Extract<TimelineItem, { kind: 'report' }>[]
+}) {
+  // Collapse multi-entry groups by default; single entries (and groups
+  // containing an error) start expanded so problems aren't hidden.
+  const hasError = items.some((i) => i.level === 'error')
+  const [open, setOpen] = useState(items.length === 1 || hasError)
+  const last = items[items.length - 1]
+
+  return (
+    <Row
+      marker={
+        <Marker className="border-border bg-muted text-muted-foreground">
+          <Terminal className="h-4 w-4" />
+        </Marker>
+      }
+    >
+      <div className="rounded-lg border bg-muted/30">
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground"
+        >
+          {open ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" />
+          )}
+          <span className="font-medium text-foreground">
+            {items.length === 1 ? 'System event' : `${items.length} system events`}
+          </span>
+          {hasError && (
+            <Badge
+              variant="outline"
+              className="border-red-200 bg-red-100 text-red-700 text-[10px]"
+            >
+              error
+            </Badge>
+          )}
+          {!open && (
+            <span className="truncate font-mono text-[11px] text-muted-foreground/80">
+              {last.content.split('\n')[0]}
+            </span>
+          )}
+          <span className="ml-auto shrink-0">
+            <RelativeTime date={last.at} />
+          </span>
+        </button>
+        {open && (
+          <div className="space-y-2 border-t px-3 py-2">
+            {items.map((r) => {
+              const cfg = reportConfig[r.level]
+              return (
+                <div key={r.id} className="flex gap-2 text-xs">
+                  <span className={cn('mt-0.5 shrink-0', cfg.tone)}>{cfg.icon}</span>
+                  <span
+                    className={cn(
+                      'mt-px shrink-0 font-mono uppercase tracking-wide text-[10px]',
+                      cfg.tone,
+                    )}
+                  >
+                    {cfg.label}
+                  </span>
+                  <pre className="min-w-0 flex-1 whitespace-pre-wrap break-words font-mono text-[11px] text-foreground/90">
+                    {r.content}
+                  </pre>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </Row>
+  )
+}
+
+// ----- small shared bits -----------------------------------------------------
+
+function WakeBadge() {
+  return (
+    <Badge
+      variant="outline"
+      className="gap-1 border-orange-200 bg-orange-100 text-orange-800 text-[10px]"
+    >
+      <Zap className="h-3 w-3" />
+      woke task
+    </Badge>
+  )
+}
+
+function SourceLink({ url }: { url: string }) {
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="mt-2 inline-block break-all text-xs text-muted-foreground hover:text-primary"
+    >
+      {url}
+    </a>
+  )
+}
+
+function Prose({ text }: { text: string }) {
+  return (
+    <div className="prose prose-sm dark:prose-invert max-w-none break-words text-foreground">
+      <Markdown>{text}</Markdown>
+    </div>
+  )
+}
+
+// Agent output can be verbose — collapse anything tall behind a "Show more".
+function CollapsibleProse({ text }: { text: string }) {
+  const long = text.length > 320 || text.split('\n').length > 4
+  const [open, setOpen] = useState(false)
+  if (!long) return <Prose text={text} />
+  return (
+    <div>
+      <div className={cn(!open && 'relative max-h-24 overflow-hidden')}>
+        <Prose text={text} />
+        {!open && (
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-card to-transparent" />
+        )}
+      </div>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="mt-1 h-6 px-2 text-xs text-muted-foreground"
+        onClick={() => setOpen((o) => !o)}
+      >
+        {open ? 'Show less' : 'Show more'}
+      </Button>
+    </div>
+  )
+}

--- a/webui/src/lib/mock-timeline.ts
+++ b/webui/src/lib/mock-timeline.ts
@@ -1,0 +1,252 @@
+// Mock data for experimenting with the unified task timeline (issues #918 /
+// #947). This is throwaway UI-only data — no backend involvement.
+//
+// The stream below is reconstructed from a real task (#827, "Fix nvim
+// LspTypescriptGoToSourceDefinition command") and intentionally contains ONLY
+// real data: its instruction, the audit/info/mcp/llm log entries, the links,
+// and the two issue #8 comments that woke it. Nothing is invented — there are
+// no get_my_task calls, test output, or fabricated event bodies. The event
+// bodies are the verbatim comments icholy posted on the issue; the two restarts
+// have no agent output because the task itself logged none (the agent replied
+// on GitHub, which the task record doesn't capture).
+
+export type TimelineDirection = 'to-agent' | 'from-agent' | 'about-task'
+
+export type ReportLevel = 'info' | 'mcp' | 'audit' | 'error'
+
+export type LifecycleKind =
+  | 'pending'
+  | 'started'
+  | 'restarted'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+
+export type ExternalSource = 'github' | 'jira'
+
+// A single entry in the unified task stream. The discriminated `kind` decides
+// the visual treatment; `direction` is informational (to-agent / from-agent /
+// about-task) and could drive alignment or grouping later.
+export type TimelineItem =
+  | {
+      kind: 'instruction'
+      id: string
+      at: Date
+      direction: 'to-agent'
+      text: string
+      url?: string
+      wakes?: boolean
+    }
+  | {
+      kind: 'agent'
+      id: string
+      at: Date
+      direction: 'from-agent'
+      text: string
+    }
+  | {
+      kind: 'external'
+      id: string
+      at: Date
+      direction: 'to-agent'
+      source: ExternalSource
+      description: string
+      data?: string
+      url?: string
+      wakes?: boolean
+    }
+  | {
+      kind: 'lifecycle'
+      id: string
+      at: Date
+      direction: 'about-task'
+      event: LifecycleKind
+      detail?: string
+    }
+  | {
+      kind: 'link'
+      id: string
+      at: Date
+      direction: 'from-agent'
+      title: string
+      url: string
+      source?: ExternalSource
+      relevance?: string
+      subscribed?: boolean
+    }
+  | {
+      kind: 'report'
+      id: string
+      at: Date
+      direction: 'from-agent'
+      level: ReportLevel
+      content: string
+    }
+
+// Build timestamps relative to "now" so the relative-time labels stay fresh.
+// `m` is minutes ago. The values only encode ordering — the task's real logs
+// and links carry no timestamps.
+const now = Date.now()
+const ago = (m: number) => new Date(now - m * 60_000)
+
+const ISSUE_8 = 'https://github.com/icholy/dotfiles/issues/8'
+const PR_9 = 'https://github.com/icholy/dotfiles/pull/9'
+const PR_10 = 'https://github.com/icholy/dotfiles/pull/10'
+const PR_11 = 'https://github.com/icholy/dotfiles/pull/11'
+
+export const MOCK_TIMELINE: TimelineItem[] = [
+  // ----- run 1: created by a routing rule on issue_assigned -----------------
+  {
+    kind: 'lifecycle',
+    id: 'lc-created',
+    at: ago(2880),
+    direction: 'about-task',
+    event: 'pending',
+    detail: 'webhook created task',
+  },
+  {
+    kind: 'link',
+    id: 'link-issue-8',
+    at: ago(2880),
+    direction: 'from-agent',
+    source: 'github',
+    title: 'icholy assigned issue #8 to @icholy-bot',
+    url: ISSUE_8,
+    relevance: 'trigger',
+    subscribed: true,
+  },
+  {
+    kind: 'instruction',
+    id: 'inst-1',
+    at: ago(2879),
+    direction: 'to-agent',
+    text: 'You were created by a routing rule in response to a github issue_assigned event.',
+  },
+  {
+    kind: 'lifecycle',
+    id: 'lc-start-1',
+    at: ago(2878),
+    direction: 'about-task',
+    event: 'started',
+    detail: 'container started',
+  },
+  {
+    kind: 'report',
+    id: 'rep-name',
+    at: ago(2876),
+    direction: 'from-agent',
+    level: 'audit',
+    content: 'updated task: name',
+  },
+  {
+    kind: 'link',
+    id: 'link-pr-9',
+    at: ago(2875),
+    direction: 'from-agent',
+    source: 'github',
+    title: 'PR #9: restore gs go-to-source-definition mapping',
+    url: PR_9,
+    relevance: 'PR fixing issue #8 (broken gs / LspTypescriptGoToSourceDefinition mapping)',
+    subscribed: true,
+  },
+  {
+    kind: 'agent',
+    id: 'agent-diagnosis',
+    at: ago(2874),
+    direction: 'from-agent',
+    text: 'Diagnosed issue #8: the `gs` keymap in nvim init.lua called `:LspTypescriptGoToSourceDefinition`, a command provided by a TS LSP plugin (typescript-tools.nvim) no longer used. Commit f6c8e78 replaced a working inline Lua implementation with that nonexistent command. Restored the Lua implementation (invokes `_typescript.goToSourceDefinition` workspace command). Opened PR #9.',
+  },
+  {
+    kind: 'lifecycle',
+    id: 'lc-done-1',
+    at: ago(2873),
+    direction: 'about-task',
+    event: 'completed',
+    detail: 'container exited successfully',
+  },
+
+  // ----- icholy's comment wakes the task (run 2 trigger) -------------------
+  {
+    kind: 'external',
+    id: 'ext-deprecation',
+    at: ago(1442),
+    direction: 'to-agent',
+    source: 'github',
+    wakes: true,
+    description: 'icholy commented on issue #8',
+    data: '@icholy-bot I merged that PR and it\'s working, but I\'m getting this logged\n\n> client.request is deprecated. Run ":checkhealth vim.deprecated" for more information',
+    url: `${ISSUE_8}#issuecomment-4670840200`,
+  },
+
+  // ----- run 2: woken by webhook; produced PR #10 --------------------------
+  {
+    kind: 'lifecycle',
+    id: 'lc-restart-2',
+    at: ago(1440),
+    direction: 'about-task',
+    event: 'restarted',
+    detail: 'container restarted',
+  },
+  {
+    kind: 'link',
+    id: 'link-pr-10',
+    at: ago(1437),
+    direction: 'from-agent',
+    source: 'github',
+    title: 'PR #10: silence gs deprecation warnings',
+    url: PR_10,
+    relevance: 'Follow-up PR fixing the client.request deprecation warning reported on issue #8',
+    subscribed: true,
+  },
+  {
+    kind: 'lifecycle',
+    id: 'lc-done-2',
+    at: ago(1436),
+    direction: 'about-task',
+    event: 'completed',
+    detail: 'container exited successfully',
+  },
+
+  // ----- icholy's follow-up comment wakes the task (run 3 trigger) ----------
+  {
+    kind: 'external',
+    id: 'ext-rootcause',
+    at: ago(182),
+    direction: 'to-agent',
+    source: 'github',
+    wakes: true,
+    description: 'icholy commented on issue #8',
+    data: '@icholy-bot this is working, but I just check lsp-config and the function is still there https://github.com/neovim/nvim-lspconfig/blob/master/lsp/ts_ls.lua#L179-L198',
+    url: `${ISSUE_8}#issuecomment-4670917365`,
+  },
+
+  // ----- run 3: woken by webhook; produced PR #11 --------------------------
+  {
+    kind: 'lifecycle',
+    id: 'lc-restart-3',
+    at: ago(180),
+    direction: 'about-task',
+    event: 'restarted',
+    detail: 'container restarted',
+  },
+  {
+    kind: 'link',
+    id: 'link-pr-11',
+    at: ago(177),
+    direction: 'from-agent',
+    source: 'github',
+    title: 'PR #11: use built-in LspTypescriptGoToSourceDefinition',
+    url: PR_11,
+    relevance:
+      "PR switching gs to lspconfig's built-in command; addresses root cause (on_attach clobbering) raised on issue #8",
+    subscribed: true,
+  },
+  {
+    kind: 'lifecycle',
+    id: 'lc-done-3',
+    at: ago(176),
+    direction: 'about-task',
+    event: 'completed',
+    detail: 'container exited successfully',
+  },
+]

--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -37,7 +37,10 @@ import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { RelativeTime } from '@/components/relative-time'
 import { CommandBadge } from '@/components/command-badge'
+import { TaskTimeline } from '@/components/task-timeline'
+import { MOCK_TIMELINE } from '@/lib/mock-timeline'
 import { Plus, Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
 import { useOrgId } from '@/hooks/use-org-id'
 
 export const Route = createFileRoute('/tasks/$id')({
@@ -56,7 +59,7 @@ function TaskDetail() {
   const orgId = useOrgId()
   const { id } = Route.useParams()
   const taskId = BigInt(id)
-  const [instruction, setInstruction] = useState('')
+  const [view, setView] = useState<'timeline' | 'classic'>('timeline')
 
   const { data, isLoading, error, refetch } = useQuery(
     getTaskDetails,
@@ -66,7 +69,6 @@ function TaskDetail() {
 
   const { data: logsData } = useQuery(listLogs, { taskId }, { refetchInterval: 60000 })
 
-  const updateMutation = useMutation(updateTask, { onSuccess: () => refetch() })
   const removeEventMutation = useMutation(removeEventTask, { onSuccess: () => refetch() })
   const archiveMutation = useMutation(archiveTask, { onSuccess: () => refetch() })
   const unarchiveMutation = useMutation(unarchiveTask, { onSuccess: () => refetch() })
@@ -87,17 +89,6 @@ function TaskDetail() {
 
   const handleRestart = async () => {
     await restartMutation.mutateAsync({ id: taskId })
-  }
-
-  const handleAddInstruction = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!instruction.trim()) return
-    await updateMutation.mutateAsync({
-      id: taskId,
-      start: true,
-      addInstructions: [{ text: instruction, url: '' }],
-    })
-    setInstruction('')
   }
 
   const handleUnlinkEvent = async (eventId: bigint) => {
@@ -144,7 +135,24 @@ function TaskDetail() {
     <div className="container mx-auto py-8 px-4 space-y-6">
       <div className="flex flex-wrap justify-between items-start gap-4 mb-6">
         <h1 className="text-2xl font-bold">{task.name || `Unnamed - ${id}`}</h1>
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex rounded-md border p-0.5">
+            {(['timeline', 'classic'] as const).map((v) => (
+              <button
+                key={v}
+                type="button"
+                onClick={() => setView(v)}
+                className={cn(
+                  'rounded px-3 py-1 text-xs capitalize transition-colors',
+                  view === v
+                    ? 'bg-foreground text-background'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                {v}
+              </button>
+            ))}
+          </div>
           {canCancelTask(task) && (
             <Button variant="destructive" size="sm" onClick={handleCancel} disabled={isMutating}>
               {cancelMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
@@ -221,7 +229,7 @@ function TaskDetail() {
         </div>
       </div>
 
-      {/* Links */}
+      {/* Links (pinned in both views) */}
       {links.length > 0 && (
         <div className="rounded-lg border p-6">
           <h2 className="text-lg font-semibold mb-4">Links</h2>
@@ -229,66 +237,112 @@ function TaskDetail() {
         </div>
       )}
 
-      {/* Instructions */}
-      <div className="rounded-lg border p-6">
-        <h2 className="text-lg font-semibold mb-4">Instructions</h2>
-        {task.instructions.length === 0 ? (
-          <p className="text-muted-foreground">No instructions</p>
-        ) : (
-          <div className="space-y-3">
-            {task.instructions.map((inst, index) => (
-              <InstructionCard key={index} text={inst.text} url={inst.url} />
-            ))}
+      {view === 'timeline' ? (
+        <>
+          {/* Experimental unified activity timeline (mock data) */}
+          <div className="rounded-lg border p-6">
+            <h2 className="text-lg font-semibold mb-4">Activity</h2>
+            <TaskTimeline items={MOCK_TIMELINE} />
+            {!isArchivedTask(task) && (
+              <div className="mt-6 border-t pt-4">
+                <AddInstruction taskId={taskId} onAdded={refetch} />
+              </div>
+            )}
           </div>
-        )}
-        {!isArchivedTask(task) && (
-          <form onSubmit={handleAddInstruction} className="space-y-4 pt-4 mt-4 border-t">
-            <Textarea
-              placeholder="Enter a new instruction..."
-              value={instruction}
-              onChange={(e) => setInstruction(e.target.value)}
-              required
-            />
-            <div className="flex justify-start">
-              <Button type="submit" disabled={updateMutation.isPending}>
-                {updateMutation.isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Plus className="h-4 w-4" />
-                )}
-                Instruction
-              </Button>
+
+          {children.length > 0 && (
+            <div className="rounded-lg border p-6">
+              <h2 className="text-lg font-semibold mb-4">Child Tasks</h2>
+              <ChildTasksTable tasks={children} onUpdate={refetch} />
             </div>
-          </form>
-        )}
-      </div>
+          )}
+        </>
+      ) : (
+        <>
+          {/* Instructions */}
+          <div className="rounded-lg border p-6">
+            <h2 className="text-lg font-semibold mb-4">Instructions</h2>
+            {task.instructions.length === 0 ? (
+              <p className="text-muted-foreground">No instructions</p>
+            ) : (
+              <div className="space-y-3">
+                {task.instructions.map((inst, index) => (
+                  <InstructionCard key={index} text={inst.text} url={inst.url} />
+                ))}
+              </div>
+            )}
+            {!isArchivedTask(task) && (
+              <div className="pt-4 mt-4 border-t">
+                <AddInstruction taskId={taskId} onAdded={refetch} />
+              </div>
+            )}
+          </div>
 
-      {/* Child Tasks */}
-      {children.length > 0 && (
-        <div className="rounded-lg border p-6">
-          <h2 className="text-lg font-semibold mb-4">Child Tasks</h2>
-          <ChildTasksTable tasks={children} onUpdate={refetch} />
-        </div>
+          {/* Child Tasks */}
+          {children.length > 0 && (
+            <div className="rounded-lg border p-6">
+              <h2 className="text-lg font-semibold mb-4">Child Tasks</h2>
+              <ChildTasksTable tasks={children} onUpdate={refetch} />
+            </div>
+          )}
+
+          {/* Events */}
+          {events.length > 0 && (
+            <div className="rounded-lg border p-6">
+              <h2 className="text-lg font-semibold mb-4">Events</h2>
+              <EventsTable
+                events={events}
+                onUnlink={handleUnlinkEvent}
+                isUnlinking={removeEventMutation.isPending}
+              />
+            </div>
+          )}
+
+          {/* Logs */}
+          <div className="rounded-lg border p-6">
+            <h2 className="text-lg font-semibold mb-4">Logs</h2>
+            <LogsTable logs={logs} />
+          </div>
+        </>
       )}
-
-      {/* Events */}
-      {events.length > 0 && (
-        <div className="rounded-lg border p-6">
-          <h2 className="text-lg font-semibold mb-4">Events</h2>
-          <EventsTable
-            events={events}
-            onUnlink={handleUnlinkEvent}
-            isUnlinking={removeEventMutation.isPending}
-          />
-        </div>
-      )}
-
-      {/* Logs */}
-      <div className="rounded-lg border p-6">
-        <h2 className="text-lg font-semibold mb-4">Logs</h2>
-        <LogsTable logs={logs} />
-      </div>
     </div>
+  )
+}
+
+function AddInstruction({ taskId, onAdded }: { taskId: bigint; onAdded: () => void }) {
+  const [instruction, setInstruction] = useState('')
+  const updateMutation = useMutation(updateTask, { onSuccess: () => onAdded() })
+
+  const handleAddInstruction = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!instruction.trim()) return
+    await updateMutation.mutateAsync({
+      id: taskId,
+      start: true,
+      addInstructions: [{ text: instruction, url: '' }],
+    })
+    setInstruction('')
+  }
+
+  return (
+    <form onSubmit={handleAddInstruction} className="space-y-4">
+      <Textarea
+        placeholder="Enter a new instruction..."
+        value={instruction}
+        onChange={(e) => setInstruction(e.target.value)}
+        required
+      />
+      <div className="flex justify-start">
+        <Button type="submit" disabled={updateMutation.isPending}>
+          {updateMutation.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Plus className="h-4 w-4" />
+          )}
+          Instruction
+        </Button>
+      </div>
+    </form>
   )
 }
 


### PR DESCRIPTION
Draft / experiment — saving WIP so we don't lose it.

Prototype for #918 (UI) consuming the unified stream idea from #947: render a task's history as a single chronological feed instead of the separate **Instructions / Events / Logs** sections.

## What's here
- **Timeline ⇄ Classic toggle** on the task page (defaults to Timeline). Classic is the existing layout, untouched.
- **`TaskTimeline` component** — vertical rail with per-type markers:
  - `instruction` (to-agent), `agent` output (first-class, not a log `type`), `external` event, `lifecycle`, `link`, `report`.
  - Collapsible grouping of consecutive system `report` entries.
  - "Show more" on long agent output.
  - Filter chips (Agent output / Instructions / Events / System).
- **Mock data** (`webui/src/lib/mock-timeline.ts`) reconstructed from real task **#827** — its instruction, audit/info/mcp/llm logs, links, and the two issue #8 comments that woke it. Nothing fabricated.

## Scope / caveats
- **UI-only.** No backend, proto, or API changes. The timeline is driven entirely by hard-coded mock data so layouts can be iterated without a running server.
- Each restart is collapsed into a single `Restarted` lifecycle entry (the "webhook started task" + "container started" pair is one moment).
- Not wired to live data yet — this is for layout exploration before the design proposal called for in #918.

Related: #918, #947, #946 (delivery cursor), #945 (C2-hosted agent MCP).