### PR TITLE
feat(webui): chat-style task page layout

### DIFF
--- a/webui/src/components/task-timeline.tsx
+++ b/webui/src/components/task-timeline.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import Markdown from 'react-markdown'
 import {
   Bot,
@@ -23,82 +23,21 @@ import { GithubIcon } from '@/components/github-icon'
 import { AtlassianIcon } from '@/components/atlassian-icon'
 import type { TimelineItem, LifecycleCategory, ExternalSource } from '@/lib/timeline'
 
-// ----- filtering -------------------------------------------------------------
-
-type FilterKey = 'instruction' | 'agent' | 'external' | 'system'
-
-const FILTERS: { key: FilterKey; label: string }[] = [
-  { key: 'agent', label: 'Agent output' },
-  { key: 'instruction', label: 'Instructions' },
-  { key: 'external', label: 'Events' },
-  { key: 'system', label: 'System' },
-]
-
-// `system` collapses the lower-signal about-task entries (lifecycle + link).
-function filterOf(item: TimelineItem): FilterKey {
-  switch (item.kind) {
-    case 'instruction':
-      return 'instruction'
-    case 'report':
-      return 'agent'
-    case 'external':
-      return 'external'
-    default:
-      return 'system'
-  }
-}
-
 // ----- top-level component ---------------------------------------------------
 
 export function TaskTimeline({ items }: { items: TimelineItem[] }) {
-  const [hidden, setHidden] = useState<Set<FilterKey>>(new Set())
-
-  const visible = useMemo(() => items.filter((i) => !hidden.has(filterOf(i))), [items, hidden])
-
-  const toggle = (key: FilterKey) =>
-    setHidden((prev) => {
-      const next = new Set(prev)
-      if (next.has(key)) next.delete(key)
-      else next.add(key)
-      return next
-    })
-
   if (items.length === 0) {
     return <div className="text-muted-foreground">No activity yet.</div>
   }
 
   return (
-    <div>
-      <div className="mb-4 flex flex-wrap items-center gap-2">
-        <span className="text-xs text-muted-foreground mr-1">Show</span>
-        {FILTERS.map((f) => {
-          const active = !hidden.has(f.key)
-          return (
-            <button
-              key={f.key}
-              type="button"
-              onClick={() => toggle(f.key)}
-              className={cn(
-                'rounded-full border px-3 py-1 text-xs transition-colors',
-                active
-                  ? 'bg-foreground text-background border-foreground'
-                  : 'bg-transparent text-muted-foreground hover:bg-muted',
-              )}
-            >
-              {f.label}
-            </button>
-          )
-        })}
-      </div>
-
-      <ol className="relative space-y-3">
-        {/* the rail */}
-        <div className="absolute left-[17px] top-2 bottom-2 w-px bg-border" aria-hidden />
-        {visible.map((item) => (
-          <TimelineRow key={item.id} item={item} />
-        ))}
-      </ol>
-    </div>
+    <ol className="relative space-y-3">
+      {/* the rail */}
+      <div className="absolute left-[17px] top-2 bottom-2 w-px bg-border" aria-hidden />
+      {items.map((item) => (
+        <TimelineRow key={item.id} item={item} />
+      ))}
+    </ol>
   )
 }
 

--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -10,7 +10,7 @@ import {
   restartTask,
 } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
 import { timestampDate } from '@bufbuild/protobuf/wkt'
-import { useState } from 'react'
+import { useState, useRef, useLayoutEffect } from 'react'
 import {
   canArchiveTask,
   canUnarchiveTask,
@@ -27,7 +27,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { RelativeTime } from '@/components/relative-time'
 import { CommandBadge } from '@/components/command-badge'
 import { TaskTimeline } from '@/components/task-timeline'
-import { Plus, Loader2 } from 'lucide-react'
+import { Send, Loader2 } from 'lucide-react'
 
 export const Route = createFileRoute('/tasks/$id')({
   staticData: { orgSwitchRedirect: '/tasks' },
@@ -38,6 +38,18 @@ function TaskDetail() {
   const { id } = Route.useParams()
   const taskId = BigInt(id)
   const [instruction, setInstruction] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Auto-grow the composer to fit its content. Done in JS rather than relying on
+  // CSS field-sizing, which isn't supported across all browsers (e.g. Firefox).
+  // The min/max heights are enforced by the textarea's CSS classes.
+  useLayoutEffect(() => {
+    const el = textareaRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    const borderY = el.offsetHeight - el.clientHeight
+    el.style.height = `${el.scrollHeight + borderY}px`
+  }, [instruction])
 
   const { data, isLoading, error, refetch } = useQuery(
     getTaskDetails,
@@ -80,15 +92,27 @@ function TaskDetail() {
     await restartMutation.mutateAsync({ id: taskId })
   }
 
-  const handleAddInstruction = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!instruction.trim()) return
+  const submitInstruction = async () => {
+    if (!instruction.trim() || updateMutation.isPending) return
     await updateMutation.mutateAsync({
       id: taskId,
       start: true,
       addInstructions: [{ text: instruction, url: '' }],
     })
     setInstruction('')
+  }
+
+  const handleAddInstruction = (e: React.FormEvent) => {
+    e.preventDefault()
+    submitInstruction()
+  }
+
+  // Enter sends, Shift+Enter inserts a newline (chat-style).
+  const handleInstructionKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      submitInstruction()
+    }
   }
 
   if (isLoading) {
@@ -125,99 +149,96 @@ function TaskDetail() {
     restartMutation.isPending
 
   return (
-    <div className="container mx-auto py-8 px-4 space-y-6">
-      <div className="flex flex-wrap justify-between items-start gap-4 mb-6">
-        <h1 className="text-2xl font-bold">{task.name || `Unnamed - ${id}`}</h1>
-        <div className="flex flex-wrap gap-2">
-          {canCancelTask(task) && (
-            <Button variant="destructive" size="sm" onClick={handleCancel} disabled={isMutating}>
-              {cancelMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              Cancel
-            </Button>
-          )}
-          {canRestartTask(task) && (
-            <Button variant="outline" size="sm" onClick={handleRestart} disabled={isMutating}>
-              {restartMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              Restart
-            </Button>
-          )}
-          {canArchiveTask(task) && (
-            <ArchiveButton
-              task={task}
-              onArchive={handleArchive}
-              pending={archiveMutation.isPending}
-              disabled={isMutating}
-            />
-          )}
-          {canUnarchiveTask(task) && (
-            <Button variant="outline" size="sm" onClick={handleUnarchive} disabled={isMutating}>
-              {unarchiveMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              Unarchive
-            </Button>
-          )}
-        </div>
-      </div>
-
-      {/* Task Details */}
-      <div className="rounded-lg border p-4">
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
-          <div className="flex items-center gap-2">
-            <span className="text-muted-foreground">Runner:</span>
-            <span>{task.runner}</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="text-muted-foreground">Workspace:</span>
-            <span>{task.workspace}</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="text-muted-foreground">Status:</span>
-            <StatusBadge task={task} />
-            <CommandBadge task={task} />
-            <ArchivedBadge task={task} />
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="text-muted-foreground">Created:</span>
-            <span>
-              {task.createdAt ? <RelativeTime date={timestampDate(task.createdAt)} /> : '-'}
-            </span>
-          </div>
-          {task.updatedAt && (
-            <div className="flex items-center gap-2">
-              <span className="text-muted-foreground">Updated:</span>
-              <span>
-                <RelativeTime date={timestampDate(task.updatedAt)} />
+    <div className="container mx-auto flex flex-col px-4">
+      {/* Sticky compact header: title, status/meta, and actions stay visible
+          while the timeline scrolls underneath. */}
+      <header className="sticky top-0 z-20 -mx-4 border-b bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
+          <div className="min-w-0 flex-1">
+            <h1 className="truncate text-xl font-bold">{task.name || `Unnamed - ${id}`}</h1>
+            <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+              <span className="flex items-center gap-1.5">
+                <StatusBadge task={task} />
+                <CommandBadge task={task} />
+                <ArchivedBadge task={task} />
               </span>
+              <span>
+                <span className="text-foreground/60">Runner</span> {task.runner}
+              </span>
+              <span>
+                <span className="text-foreground/60">Workspace</span> {task.workspace}
+              </span>
+              {task.createdAt && (
+                <span>
+                  <span className="text-foreground/60">Created</span>{' '}
+                  <RelativeTime date={timestampDate(task.createdAt)} />
+                </span>
+              )}
+              {task.updatedAt && (
+                <span>
+                  <span className="text-foreground/60">Updated</span>{' '}
+                  <RelativeTime date={timestampDate(task.updatedAt)} />
+                </span>
+              )}
             </div>
-          )}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {canCancelTask(task) && (
+              <Button variant="destructive" size="sm" onClick={handleCancel} disabled={isMutating}>
+                {cancelMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Cancel
+              </Button>
+            )}
+            {canRestartTask(task) && (
+              <Button variant="outline" size="sm" onClick={handleRestart} disabled={isMutating}>
+                {restartMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Restart
+              </Button>
+            )}
+            {canArchiveTask(task) && (
+              <ArchiveButton
+                task={task}
+                onArchive={handleArchive}
+                pending={archiveMutation.isPending}
+                disabled={isMutating}
+              />
+            )}
+            {canUnarchiveTask(task) && (
+              <Button variant="outline" size="sm" onClick={handleUnarchive} disabled={isMutating}>
+                {unarchiveMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Unarchive
+              </Button>
+            )}
+          </div>
         </div>
-      </div>
+      </header>
 
-      {/* Activity timeline */}
-      <div className="rounded-lg border p-6">
-        <h2 className="text-lg font-semibold mb-4">Activity</h2>
+      {/* Activity timeline — the scrolling thread between header and input. */}
+      <div className="py-6">
         <TaskTimeline items={timeline} />
       </div>
 
-      {/* Add instruction */}
+      {/* Sticky composer pinned to the viewport bottom (chat-style). */}
       {!isArchivedTask(task) && (
-        <div className="rounded-lg border p-6">
-          <form onSubmit={handleAddInstruction} className="space-y-4">
+        <div className="sticky bottom-0 z-20 -mx-4 border-t bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+          <form onSubmit={handleAddInstruction} className="flex items-end gap-2">
             <Textarea
-              placeholder="Enter a new instruction..."
+              ref={textareaRef}
+              placeholder="Send an instruction…  (Enter to send, Shift+Enter for newline)"
               value={instruction}
               onChange={(e) => setInstruction(e.target.value)}
+              onKeyDown={handleInstructionKeyDown}
+              rows={1}
+              className="max-h-60 min-h-[40px] flex-1 resize-none overflow-y-auto"
               required
             />
-            <div className="flex justify-start">
-              <Button type="submit" disabled={updateMutation.isPending}>
-                {updateMutation.isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Plus className="h-4 w-4" />
-                )}
-                Instruction
-              </Button>
-            </div>
+            <Button type="submit" size="icon" disabled={updateMutation.isPending} title="Send instruction">
+              {updateMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+            </Button>
           </form>
         </div>
       )}


### PR DESCRIPTION
## Summary

Restructures the task detail page (`webui/src/routes/tasks.$id.tsx`) into a chat-style layout.

- **Sticky compact header** — title, status/command/archived badges, and the runner/workspace/created/updated meta inline, with action buttons (Cancel/Restart/Archive). Stays visible while the timeline scrolls underneath.
- **Scrolling thread** — dropped the bordered "Activity" card chrome so the timeline flows full-width in the normal `container` width (matching the rest of the app).
- **Sticky composer** pinned to the viewport bottom — Enter sends, Shift+Enter inserts a newline, and the textarea auto-grows to fit its content (JS-based resize so it works in browsers without CSS `field-sizing`, e.g. Firefox).
- **Removed the activity-log filter toggles** (Agent output / Instructions / Events / System); the timeline now renders every item directly.

## Notes

Draft — exploring layout direction; may be superseded by a different approach.