### PR TITLE
feat(webui): view and edit auto_archive on the task page

### DIFF
--- a/webui/src/components/auto-archive-control.tsx
+++ b/webui/src/components/auto-archive-control.tsx
@@ -1,0 +1,85 @@
+import { Loader2 } from 'lucide-react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { RelativeTime } from '@/components/relative-time'
+import { autoArchiveDeadline } from '@/lib/task'
+import {
+  AUTO_ARCHIVE_IMMEDIATE,
+  AUTO_ARCHIVE_NEVER,
+  autoArchiveSelectValue,
+  durationFromAutoArchiveSelect,
+  durationToMillis,
+  formatCountdown,
+} from '@/lib/duration'
+import type { Duration } from '@bufbuild/protobuf/wkt'
+import type { Task } from '@/gen/xagent/v1/xagent_pb'
+
+type AutoArchiveTask = Pick<Task, 'status' | 'actions' | 'archived' | 'autoArchive' | 'updatedAt'>
+
+// The presets offered in the dropdown. Positive values are keyed by their
+// whole-second count to match autoArchiveSelectValue's lossless encoding.
+const PRESETS: { value: string; label: string }[] = [
+  { value: AUTO_ARCHIVE_NEVER, label: 'Never' },
+  { value: AUTO_ARCHIVE_IMMEDIATE, label: 'Immediately' },
+  { value: String(60 * 60), label: '1 hour' },
+  { value: String(24 * 60 * 60), label: '24 hours' },
+  { value: String(7 * 24 * 60 * 60), label: '7 days' },
+]
+
+// AutoArchiveControl shows and edits a task's auto_archive window. It renders the
+// current value as a Select and, for terminal-but-not-archived tasks with a
+// positive delay, the resulting archive deadline. Changing the Select calls
+// onChange with the Duration to persist via UpdateTask.
+export function AutoArchiveControl({
+  task,
+  onChange,
+  pending,
+  disabled,
+}: {
+  task: AutoArchiveTask
+  onChange: (autoArchive: Duration) => void
+  pending?: boolean
+  disabled?: boolean
+}) {
+  const deadline = autoArchiveDeadline(task)
+  const current = autoArchiveSelectValue(task.autoArchive)
+  // A task's auto_archive can be any duration the API set, not just a preset
+  // (e.g. 30m). When it's off-preset, inject an option showing the real value so
+  // the trigger renders it faithfully instead of colliding with a preset.
+  const isPreset = PRESETS.some((p) => p.value === current)
+  const customLabel =
+    !isPreset && task.autoArchive ? formatCountdown(durationToMillis(task.autoArchive)) : null
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <span className="text-muted-foreground">Auto-archive:</span>
+      <Select
+        value={current}
+        onValueChange={(v) => onChange(durationFromAutoArchiveSelect(v))}
+        disabled={disabled || pending}
+      >
+        <SelectTrigger id="auto-archive" className="h-8 w-auto gap-1 px-3 text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {PRESETS.map((p) => (
+            <SelectItem key={p.value} value={p.value}>
+              {p.label}
+            </SelectItem>
+          ))}
+          {customLabel && <SelectItem value={current}>{customLabel}</SelectItem>}
+        </SelectContent>
+      </Select>
+      {pending && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
+      {deadline && (
+        <span className="text-muted-foreground text-xs">
+          archives <RelativeTime date={deadline} />
+        </span>
+      )}
+    </div>
+  )
+}

--- a/webui/src/lib/duration.test.ts
+++ b/webui/src/lib/duration.test.ts
@@ -1,9 +1,61 @@
 import { describe, it, expect } from 'vitest'
-import { formatCountdown } from './duration'
+import type { Duration } from '@bufbuild/protobuf/wkt'
+import { autoArchiveSelectValue, durationFromAutoArchiveSelect, formatCountdown } from './duration'
+
+function duration(seconds: number, nanos = 0): Duration {
+  return { seconds: BigInt(seconds), nanos, $typeName: 'google.protobuf.Duration' }
+}
 
 describe('formatCountdown', () => {
   it('renders the two largest units for a multi-day remaining time', () => {
     const ms = (2 * 24 * 60 * 60 + 3 * 60 * 60 + 30 * 60) * 1000
     expect(formatCountdown(ms)).toBe('2d 3h')
+  })
+})
+
+describe('autoArchiveSelectValue', () => {
+  it('maps unset and zero durations to "never"', () => {
+    expect(autoArchiveSelectValue(undefined)).toBe('never')
+    expect(autoArchiveSelectValue(duration(0))).toBe('never')
+  })
+
+  it('maps negative durations to "immediate"', () => {
+    expect(autoArchiveSelectValue(duration(-1))).toBe('immediate')
+    expect(autoArchiveSelectValue(duration(0, -1))).toBe('immediate')
+  })
+
+  it('maps positive durations to their whole-second count', () => {
+    expect(autoArchiveSelectValue(duration(24 * 3600))).toBe('86400')
+    expect(autoArchiveSelectValue(duration(168 * 3600))).toBe('604800')
+  })
+
+  it('preserves off-preset durations losslessly instead of rounding to a preset', () => {
+    // 30 minutes must not collapse onto the "1 hour" preset value.
+    expect(autoArchiveSelectValue(duration(30 * 60))).toBe('1800')
+    expect(autoArchiveSelectValue(duration(3 * 3600))).toBe('10800')
+  })
+})
+
+describe('durationFromAutoArchiveSelect', () => {
+  it('returns an explicit zero duration for "never" so UpdateTask persists it', () => {
+    // UpdateTask treats an omitted auto_archive as "leave alone", so "never" must
+    // round-trip as a concrete zero duration rather than undefined.
+    expect(durationFromAutoArchiveSelect('never')).toEqual(duration(0))
+  })
+
+  it('returns a negative duration for "immediate"', () => {
+    const d = durationFromAutoArchiveSelect('immediate')
+    expect(d.seconds).toBeLessThan(0n)
+  })
+
+  it('parses a seconds-encoded selection back into a duration', () => {
+    expect(durationFromAutoArchiveSelect('86400')).toEqual(duration(24 * 3600))
+    expect(durationFromAutoArchiveSelect('1800')).toEqual(duration(30 * 60))
+  })
+
+  it('round-trips through autoArchiveSelectValue', () => {
+    for (const value of ['never', 'immediate', '3600', '86400', '604800', '1800']) {
+      expect(autoArchiveSelectValue(durationFromAutoArchiveSelect(value))).toBe(value)
+    }
   })
 })

--- a/webui/src/lib/duration.ts
+++ b/webui/src/lib/duration.ts
@@ -26,6 +26,41 @@ export function durationToMillis(d: Duration): number {
   return Number(d.seconds) * 1000 + d.nanos / 1_000_000
 }
 
+// AUTO_ARCHIVE_IMMEDIATE is the auto-archive Select value for the "archive
+// immediately once terminal" semantics (a negative Duration).
+export const AUTO_ARCHIVE_IMMEDIATE = 'immediate'
+
+// AUTO_ARCHIVE_NEVER is the auto-archive Select value for "never auto-archive"
+// (a zero/unset Duration).
+export const AUTO_ARCHIVE_NEVER = 'never'
+
+// autoArchiveSelectValue maps a stored auto_archive Duration to the string value
+// the auto-archive Select uses, honoring Task.auto_archive semantics: zero/unset
+// is "never", negative is "immediate", positive is the whole-second delay. Using
+// seconds (rather than rounded hours) keeps the value lossless so an arbitrary
+// API-set duration like 30m round-trips instead of colliding with the "1 hour"
+// preset or rendering blank.
+export function autoArchiveSelectValue(d: Duration | undefined): string {
+  if (!d) return AUTO_ARCHIVE_NEVER
+  if (d.seconds < 0n || d.nanos < 0) return AUTO_ARCHIVE_IMMEDIATE
+  if (d.seconds === 0n && d.nanos === 0) return AUTO_ARCHIVE_NEVER
+  return String(d.seconds)
+}
+
+// durationFromAutoArchiveSelect is the inverse of autoArchiveSelectValue for the
+// update path. It always returns a concrete Duration (never undefined): UpdateTask
+// treats an unset auto_archive as "leave alone", so selecting "never" must persist
+// an explicit zero Duration rather than omit it.
+export function durationFromAutoArchiveSelect(value: string): Duration {
+  if (value === AUTO_ARCHIVE_IMMEDIATE) {
+    return { seconds: -1n, nanos: 0, $typeName: 'google.protobuf.Duration' }
+  }
+  if (value === AUTO_ARCHIVE_NEVER) {
+    return { seconds: 0n, nanos: 0, $typeName: 'google.protobuf.Duration' }
+  }
+  return { seconds: BigInt(value), nanos: 0, $typeName: 'google.protobuf.Duration' }
+}
+
 // formatCountdown renders a coarse, human-readable remaining time using the one
 // or two largest units, e.g. "45s", "5m", "2h 10m", "3d 4h". Negative inputs
 // clamp to "0s".

--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -21,6 +21,7 @@ import {
 import { eventsToTimeline } from '@/lib/timeline'
 import { ArchivedBadge } from '@/components/archived-badge'
 import { ArchiveButton } from '@/components/archive-button'
+import { AutoArchiveControl } from '@/components/auto-archive-control'
 import { StatusBadge } from '@/components/status-badge'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
@@ -71,6 +72,7 @@ function TaskDetail() {
   }
 
   const updateMutation = useMutation(updateTask, { onSuccess: refetchAll })
+  const autoArchiveMutation = useMutation(updateTask, { onSuccess: refetchAll })
   const archiveMutation = useMutation(archiveTask, { onSuccess: refetchAll })
   const unarchiveMutation = useMutation(unarchiveTask, { onSuccess: refetchAll })
   const cancelMutation = useMutation(cancelTask, { onSuccess: refetchAll })
@@ -152,7 +154,13 @@ function TaskDetail() {
     <div className="container mx-auto py-8 px-4 space-y-6">
       <div className="flex flex-wrap justify-between items-start gap-4 mb-6">
         <h1 className="text-2xl font-bold">{task.name || `Unnamed - ${id}`}</h1>
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <AutoArchiveControl
+            task={task}
+            onChange={(autoArchive) => autoArchiveMutation.mutateAsync({ id: taskId, autoArchive })}
+            pending={autoArchiveMutation.isPending}
+            disabled={isArchivedTask(task)}
+          />
           {canCancelTask(task) && (
             <Button variant="destructive" size="sm" onClick={handleCancel} disabled={isMutating}>
               {cancelMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}


### PR DESCRIPTION
Closes #1095.

## Summary

Adds an **Auto-archive** control to the task detail page's action row (next to Restart / Archive) so a task's `auto_archive` window can be seen and changed after creation. Previously the value was only set at creation and was invisible/uneditable from the task page. Backend already supported this (`UpdateTask` accepts `auto_archive`, `GetTask` returns it), so this is frontend-only.

## Changes

- **`webui/src/components/auto-archive-control.tsx`** (new) — `Auto-archive: [dropdown]` control. Options: **Never**, **Immediately**, **1 hour**, **24 hours**, **7 days**. For terminal-but-not-archived tasks with a positive delay it also shows the resulting archive deadline (`archives <relative time>`), and a spinner while a change is in flight. Editing is disabled for archived tasks (consistent with the hidden instruction composer).
- **`webui/src/routes/tasks.$id.tsx`** — renders the control in the action row with its own `updateTask` mutation (isolated pending state).
- **`webui/src/lib/duration.ts`** — `autoArchiveSelectValue` / `durationFromAutoArchiveSelect` map between the stored `Duration` and the Select value, honoring the semantics: `0`/unset = never, negative = immediate, positive = delay.
- **`webui/src/lib/duration.test.ts`** — unit tests for the mapping and round-trip.

## Value semantics & lossless encoding

- Selecting **Never** persists an explicit **zero** `Duration` (not `undefined`) — `UpdateTask` treats an omitted `auto_archive` as "leave alone", so omitting it would silently fail to clear a previously-set window.
- Positive values are encoded as their exact **whole-second** count rather than rounded hours. This avoids an off-preset value (e.g. an API-set 30m) collapsing onto the "1 hour" preset or rendering a blank trigger. Off-preset durations get a dynamically injected option showing the real value (via `formatCountdown`, e.g. `30m`), mirroring the `legacyOption` pattern in `routing-rule-form.tsx`.

## Testing

- `pnpm lint` — clean
- `tsc -b` — clean
- `pnpm test` — 11 passing