### PR TITLE
fix(runner): keep supervise on the runner's root context

### DIFF
--- a/internal/runner/backend/docker/docker.go
+++ b/internal/runner/backend/docker/docker.go
@@ -305,8 +305,14 @@ func (b *Backend) Wait(ctx context.Context, h backend.Handle) (backend.ExitCode,
 	select {
 	case <-ctx.Done():
 		return 0, ctx.Err()
-	case <-errCh:
+	case err := <-errCh:
+		// A canceled ctx aborts the SDK's request, surfacing here as an error
+		// when the select races ctx.Done(). That is cancellation, not an exit.
+		if ctx.Err() != nil {
+			return 0, ctx.Err()
+		}
 		// Removed (NotFound) or a wait error: no code to recover → report lost.
+		b.log.Error("container wait failed", "container", h.ID, "error", err)
 		return backend.ExitLost, nil
 	case res := <-okCh:
 		return backend.ExitCode(res.StatusCode), nil

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -140,7 +140,10 @@ func (r *Runner) Poll(ctx context.Context) error {
 		return err
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
+	// Plain group (limit + join only): WithContext's derived ctx is canceled
+	// when Wait returns, which would kill the supervise goroutines Start spawns
+	// on this ctx. supervise must outlive the poll cycle.
+	var g errgroup.Group
 	g.SetLimit(int(r.concurrency))
 
 	for _, pbTask := range resp.Tasks {


### PR DESCRIPTION
## Problem

A task whose agent ran fine was still marked **failed**. The runner logged, ~3s after creating the container:

```
INFO  creating container task=998
ERROR sandbox exited without reporting task=998 exitCode=-1
INFO  event delivered task=998 event=failed
```

`exitCode=-1` is `backend.ExitLost` — the docker `Wait` hit its `errCh` branch, i.e. `ContainerWait` errored while the container was actually still running.

## Root cause

`Poll` shadowed its context with `errgroup.WithContext`:

```go
g, ctx := errgroup.WithContext(ctx)
```

`errgroup.WithContext` cancels the derived context the moment `g.Wait()` returns. `Start` launches the sandbox and returns immediately (it doesn't block on the sandbox — it spawns `go r.supervise(ctx, ...)`), so every poll cycle's `g.Wait()` fired within seconds and canceled the context the long-lived `supervise`/`ContainerWait` was blocked on.

When that cancellation raced the `select` in docker `Wait`, both `ctx.Done()` and the SDK's aborted-request `errCh` were ready. When `errCh` won, `Wait` returned `ExitLost` and `supervise` reported a spurious `failed`.

## Fix

- **`runner.go`**: use a plain `errgroup.Group` (only `SetLimit` + `Wait` were ever used — every closure returns nil, so cancel-on-first-error never fired). `supervise` now keeps the caller's long-lived context.
- **`docker.go`**: guard the `errCh` branch with `ctx.Err()` so a cancellation is reported as `context.Canceled`, not `ExitLost`, even when the select races `ctx.Done()`. Also log the underlying wait error, which was previously swallowed.

## Testing

`go build` + `go vet` clean. The docker `Wait` integration tests require a live daemon and were not run in this environment.