### PR TITLE
docs: correct internal/proto note (checked in, not gitignored)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ xagent github     # GitHub integration
 
 ### Protobuf
 
-Service definitions in `proto/xagent/v1/xagent.proto`, generated code goes to `internal/proto/` (gitignored).
+Service definitions in `proto/xagent/v1/xagent.proto`; generated code is written to `internal/proto/` (checked in) by `mise run generate`.
 
 ## Conventional Commits & Releases
 


### PR DESCRIPTION
`internal/proto/` is tracked (both `xagent.pb.go` and `xagent.connect.go` are checked in; `git check-ignore` finds nothing), but CLAUDE.md described it as gitignored. That stale note misleads tasks and anyone running `mise run generate` into expecting the regen not to appear in diffs.

Corrects the line to say the generated code is checked in and produced by `mise run generate`.

Found while reviewing #1114 (step 1 of #1113).