### PR TITLE
feat: fork driver into debug shell on shell_session

### DIFF
--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/icholy/xagent/internal/model"
 	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
+	"github.com/icholy/xagent/internal/shell"
 	"github.com/icholy/xagent/internal/xagentclient"
 )
 
@@ -22,6 +23,12 @@ type Driver struct {
 	TaskID int64
 	Client xagentclient.Client
 	Log    *slog.Logger
+
+	// ServerURL and Token are the driver's own server credentials, reused to dial
+	// the shell relay WebSocket when the task is a debug-shell run. They mirror
+	// the values passed to xagentclient.New for Client above.
+	ServerURL string
+	Token     string
 }
 
 // Run executes the task and reports its outcome to the server. The driver
@@ -86,8 +93,26 @@ func (d *Driver) submit(ctx context.Context, event model.RunnerEventType) error 
 	return nil
 }
 
-// run executes the setup commands and the agent prompt.
+// run reads the task and forks into one of two mutually exclusive modes: a
+// debug-shell run when the task carries a shell_session, or the normal agent
+// path otherwise. A sandbox run is one mode, chosen once at startup (see the
+// design in proposals/draft/driver-reverse-shell.md). The fork lives inside run
+// so a shell run emits the same started/stopped/failed lifecycle events as an
+// agent run.
 func (d *Driver) run(ctx context.Context) error {
+	resp, err := d.Client.GetTask(ctx, &xagentv1.GetTaskRequest{Id: d.TaskID})
+	if err != nil {
+		return fmt.Errorf("failed to get task: %w", err)
+	}
+	if session := resp.GetTask().GetShellSession(); session != "" {
+		return shell.Serve(ctx, d.ServerURL, d.Token, session, d.Log)
+	}
+	return d.runAgent(ctx)
+}
+
+// runAgent executes the setup commands and the agent prompt. This is the normal
+// (non-shell) sandbox run.
+func (d *Driver) runAgent(ctx context.Context) error {
 	// Load config
 	cfg, err := LoadConfig(d.TaskID)
 	if err != nil {

--- a/internal/agent/driver_shell_test.go
+++ b/internal/agent/driver_shell_test.go
@@ -1,0 +1,78 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/icholy/xagent/internal/auth/apiauth"
+	xagentv1 "github.com/icholy/xagent/internal/proto/xagent/v1"
+	"github.com/icholy/xagent/internal/server/shellrelay"
+	"github.com/icholy/xagent/internal/shellwire"
+	"github.com/icholy/xagent/internal/xagentclient"
+	"gotest.tools/v3/assert"
+)
+
+// TestRun_ForksIntoShell verifies that when the task carries a shell_session,
+// run() dials the relay and serves a debug shell instead of the agent path —
+// wiring the driver's credentials through to shell.Serve.
+func TestRun_ForksIntoShell(t *testing.T) {
+	t.Parallel()
+	// Real relay with both legs; the attach leg is authorized as a caller in org 1.
+	reg := shellrelay.NewRegistry(nil, time.Minute)
+	caller := &apiauth.UserInfo{ID: "op", OrgID: 1}
+	mux := http.NewServeMux()
+	mux.Handle("GET /shell/{session}/driver", reg.DriverHandler())
+	mux.Handle("GET /shell/{session}/attach", apiauth.WithTestUser(reg.AttachHandler(), caller))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	t.Cleanup(reg.Close)
+	assert.NilError(t, reg.Seed("s1", 1))
+
+	// A driver whose task carries the shell_session, pointed at the relay.
+	mock := &xagentclient.ClientMock{
+		GetTaskFunc: func(_ context.Context, req *xagentv1.GetTaskRequest) (*xagentv1.GetTaskResponse, error) {
+			return &xagentv1.GetTaskResponse{Task: &xagentv1.Task{Id: req.Id, ShellSession: "s1"}}, nil
+		},
+	}
+	d := &Driver{TaskID: 1, Client: mock, Log: slog.Default(), ServerURL: srv.URL, Token: "t"}
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- d.run(t.Context()) }()
+
+	// Connect the operator leg and exercise the shell the fork spawned.
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	attach, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(srv.URL, "http")+"/shell/s1/attach", &websocket.DialOptions{
+		Subprotocols: []string{shellwire.Subprotocol},
+	})
+	assert.NilError(t, err)
+	t.Cleanup(func() { attach.Close(websocket.StatusNormalClosure, "done") })
+
+	// A command echoes back through the PTY as data frames.
+	assert.NilError(t, attach.Write(ctx, websocket.MessageBinary, shellwire.Data([]byte("echo forked\n"))))
+	var buf strings.Builder
+	for !strings.Contains(buf.String(), "forked") {
+		_, msg, err := attach.Read(ctx)
+		assert.NilError(t, err)
+		frame, err := shellwire.Parse(msg)
+		assert.NilError(t, err)
+		if frame.Type == shellwire.TypeData {
+			buf.Write(frame.Payload)
+		}
+	}
+
+	// Ending the shell makes run() return.
+	assert.NilError(t, attach.Write(ctx, websocket.MessageBinary, shellwire.Data([]byte("exit\n"))))
+	select {
+	case err := <-runErr:
+		assert.NilError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("run did not return after shell exit")
+	}
+}

--- a/internal/agent/driver_test.go
+++ b/internal/agent/driver_test.go
@@ -26,6 +26,10 @@ func setupDriver(t *testing.T, cfg *Config) (*Driver, *xagentclient.ClientMock) 
 		SubmitRunnerEventsFunc: func(_ context.Context, req *xagentv1.SubmitRunnerEventsRequest) (*xagentv1.SubmitRunnerEventsResponse, error) {
 			return &xagentv1.SubmitRunnerEventsResponse{}, nil
 		},
+		// run() forks on shell_session; an empty one takes the normal agent path.
+		GetTaskFunc: func(_ context.Context, req *xagentv1.GetTaskRequest) (*xagentv1.GetTaskResponse, error) {
+			return &xagentv1.GetTaskResponse{Task: &xagentv1.Task{Id: req.Id}}, nil
+		},
 	}
 	return &Driver{TaskID: 1, Client: mock, Log: slog.Default()}, mock
 }

--- a/internal/command/driver.go
+++ b/internal/command/driver.go
@@ -37,7 +37,9 @@ var DriverCommand = &cli.Command{
 				BaseURL: cmd.String("server"),
 				Token:   cmd.String("token"),
 			}),
-			Log: slog.Default(),
+			Log:       slog.Default(),
+			ServerURL: cmd.String("server"),
+			Token:     cmd.String("token"),
 		}
 		return driver.Run(ctx)
 	},

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -66,6 +66,11 @@ func TestRunnerStart(t *testing.T) {
 		GetTaskDetailsFunc: func(_ context.Context, req *xagentv1.GetTaskDetailsRequest) (*xagentv1.GetTaskDetailsResponse, error) {
 			return &xagentv1.GetTaskDetailsResponse{Task: task.Proto("")}, nil
 		},
+		// The driver reads its task at startup to fork on shell_session; this
+		// task has none, so it takes the normal agent path.
+		GetTaskFunc: func(_ context.Context, req *xagentv1.GetTaskRequest) (*xagentv1.GetTaskResponse, error) {
+			return &xagentv1.GetTaskResponse{Task: task.Proto("")}, nil
+		},
 	}
 
 	// Create httptest server with the mock


### PR DESCRIPTION
Step 4a of #1113 (design: `proposals/draft/driver-reverse-shell.md`). Wires the driver to the shell library merged in step 3, closing the loop with `OpenShell` (4b, merged): the driver now serves a debug shell when the task carries a `shell_session`.

## What it does
- **Fork at startup.** `driver.run()` fetches its task via `GetTask` and branches: `shell_session` set → `shell.Serve` (PTY + relay dial); empty → the normal agent path (the old body, renamed `runAgent`). The fork lives inside `run()` so a shell run emits the same started/stopped/failed lifecycle events as an agent run.
- **Credentials.** Added `ServerURL`/`Token` to the `Driver`, wired from `xagent driver`'s `--server`/`--token`, so `shell.Serve` can dial the relay with the task token as Bearer.
- **Authorization: no change needed.** The driver's task token already grants `OpTaskRead` scoped to its own task (`agentauth/scope.go`), which is exactly what `GetTask` requires — confirmed against `taskscope`.

## Tests
- `TestRun_ForksIntoShell`: with `GetTask` returning a `shell_session`, `run()` dials the real relay and serves a shell (echo round-trip, then exit) — proving the dispatch and credential wiring.
- Fixed the driver-launching mocks that now see the startup `GetTask` call: `agent.setupDriver` and the runner's `TestRunnerStart` (returns an empty `shell_session` → agent path). This is the same `GetTaskFunc`-missing failure that broke CI on the earlier attempt.

Verified: `go build ./...`, `vet`, `gofmt` clean; `go test -race ./internal/agent/` passes (incl. the fork test against the real relay + a real `/bin/sh`).

## Still deferred (follow-ups on #1113)
- **Clearing `shell_session` on session teardown.** Now that the driver reads the field, this matters: after a shell session ends the field stays set, so a subsequent restart would replay as a shell run. Should land before this flow is exercised in anger.
- **Binding the driver-leg token to the session's task** (the `shellrelay` TODO).
- **Step 5:** reimplement `xagent shell` against `OpenShell` + attach WS (the field is now fully served end-to-end; only the operator-side CLI remains).