### PR TITLE
feat: clear shell_session when the shell rendezvous ends

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"context"
 	"crypto/ed25519"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"connectrpc.com/connect"
 	"connectrpc.com/otelconnect"
@@ -55,7 +57,17 @@ func New(opts Options) *Server {
 	if log == nil {
 		log = slog.Default()
 	}
-	shell := shellrelay.NewRegistry(log, shellrelay.DefaultEstablishTimeout)
+	// When a shell rendezvous tears down, clear the task's shell_session so a
+	// later restart is a normal agent run. The relay observes teardown; the
+	// server owns the field.
+	shell := shellrelay.NewRegistry(log, shellrelay.DefaultEstablishTimeout,
+		shellrelay.WithOnClose(func(session string, orgID int64) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := opts.Store.ClearShellSession(ctx, nil, session, orgID); err != nil {
+				log.Warn("failed to clear shell_session on teardown", "session", session, "error", err)
+			}
+		}))
 	apiOpts := apiserver.Options{
 		Log:       log,
 		Store:     opts.Store,

--- a/internal/server/shellrelay/shellrelay.go
+++ b/internal/server/shellrelay/shellrelay.go
@@ -44,9 +44,22 @@ var (
 type Registry struct {
 	log              *slog.Logger
 	establishTimeout time.Duration
+	onClose          func(session string, orgID int64)
 
 	mu       sync.Mutex
 	sessions map[string]*session
+}
+
+// Option configures a Registry.
+type Option func(*Registry)
+
+// WithOnClose registers a hook invoked once when a session tears down (for any
+// reason: normal exit, a dropped leg, the establishment timeout, or registry
+// shutdown). The server uses it to clear the task's shell_session so a later
+// restart is a normal agent run — neither the driver nor the runner writes that
+// field, so the server owns clearing it here, tied to the shell's own lifecycle.
+func WithOnClose(fn func(session string, orgID int64)) Option {
+	return func(r *Registry) { r.onClose = fn }
 }
 
 // session holds the two legs of a rendezvous plus its lifecycle state. All
@@ -70,18 +83,22 @@ type session struct {
 // NewRegistry creates a session registry. establishTimeout <= 0 falls back to
 // DefaultEstablishTimeout. Tests inject a small timeout to exercise the
 // establishment-timeout path without sleeping the real default.
-func NewRegistry(log *slog.Logger, establishTimeout time.Duration) *Registry {
+func NewRegistry(log *slog.Logger, establishTimeout time.Duration, opts ...Option) *Registry {
 	if log == nil {
 		log = slog.Default()
 	}
 	if establishTimeout <= 0 {
 		establishTimeout = DefaultEstablishTimeout
 	}
-	return &Registry{
+	r := &Registry{
 		log:              log,
 		establishTimeout: establishTimeout,
 		sessions:         make(map[string]*session),
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 // Seed registers a new rendezvous session owned by orgID and starts the
@@ -168,6 +185,9 @@ func (r *Registry) teardown(s *session, reason string) {
 		}
 		if attach != nil {
 			attach.Close(websocket.StatusNormalClosure, reason)
+		}
+		if r.onClose != nil {
+			r.onClose(s.id, s.orgID)
 		}
 		r.log.Debug("shell session torn down", "session", s.id, "reason", reason)
 	})

--- a/internal/server/shellrelay/shellrelay_test.go
+++ b/internal/server/shellrelay/shellrelay_test.go
@@ -253,3 +253,29 @@ func TestSeedRejectsDuplicate(t *testing.T) {
 	// Assert
 	assert.ErrorContains(t, err, "already exists")
 }
+
+func TestOnCloseFiresOnTeardown(t *testing.T) {
+	t.Parallel()
+	// Arrange: a registry with an onClose hook.
+	type closeCall struct {
+		session string
+		orgID   int64
+	}
+	closed := make(chan closeCall, 4)
+	reg := shellrelay.NewRegistry(nil, time.Minute, shellrelay.WithOnClose(func(session string, orgID int64) {
+		closed <- closeCall{session: session, orgID: orgID}
+	}))
+	assert.NilError(t, reg.Seed("s1", testOrg))
+
+	// Act: tearing the session down fires the hook.
+	reg.Close()
+
+	// Assert: onClose fired once with the session id and owning org.
+	select {
+	case c := <-closed:
+		assert.Equal(t, c.session, "s1")
+		assert.Equal(t, c.orgID, testOrg)
+	case <-time.After(time.Second):
+		t.Fatal("onClose was not called on teardown")
+	}
+}

--- a/internal/store/sql/queries/task.sql
+++ b/internal/store/sql/queries/task.sql
@@ -31,6 +31,11 @@ UPDATE tasks
 SET name = $1, runner = $2, workspace = $3, status = $4, command = $5, version = $6, updated_at = $7, archived = $8, auto_archive = $9, shell_session = $10
 WHERE id = $11 AND org_id = $12;
 
+-- name: ClearShellSession :exec
+UPDATE tasks
+SET shell_session = ''
+WHERE shell_session = $1 AND org_id = $2;
+
 -- name: ListTasksDueForArchive :many
 SELECT id, version, org_id
 FROM tasks

--- a/internal/store/sqlc/task.sql.go
+++ b/internal/store/sqlc/task.sql.go
@@ -10,6 +10,22 @@ import (
 	"time"
 )
 
+const clearShellSession = `-- name: ClearShellSession :exec
+UPDATE tasks
+SET shell_session = ''
+WHERE shell_session = $1 AND org_id = $2
+`
+
+type ClearShellSessionParams struct {
+	ShellSession string `json:"shell_session"`
+	OrgID        int64  `json:"org_id"`
+}
+
+func (q *Queries) ClearShellSession(ctx context.Context, arg ClearShellSessionParams) error {
+	_, err := q.db.ExecContext(ctx, clearShellSession, arg.ShellSession, arg.OrgID)
+	return err
+}
+
 const createTask = `-- name: CreateTask :one
 INSERT INTO tasks (name, runner, workspace, status, command, version, org_id, archived, created_at, updated_at, auto_archive, shell_session)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)

--- a/internal/store/task.go
+++ b/internal/store/task.go
@@ -122,6 +122,17 @@ func (s *Store) DeleteTask(ctx context.Context, tx *sql.Tx, id int64, orgID int6
 	})
 }
 
+// ClearShellSession resets shell_session to empty for the task in orgID that
+// currently holds session. Called when a debug-shell rendezvous tears down so a
+// later restart of that task is a normal agent run, not another shell. A no-op
+// if no task holds the session.
+func (s *Store) ClearShellSession(ctx context.Context, tx *sql.Tx, session string, orgID int64) error {
+	return s.q(tx).ClearShellSession(ctx, sqlc.ClearShellSessionParams{
+		ShellSession: session,
+		OrgID:        orgID,
+	})
+}
+
 func toModelTask(row sqlc.Task) (*model.Task, error) {
 	return &model.Task{
 		ID:           row.ID,

--- a/internal/store/task_test.go
+++ b/internal/store/task_test.go
@@ -1,0 +1,54 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/icholy/xagent/internal/model"
+	"github.com/icholy/xagent/internal/store/teststore"
+	"gotest.tools/v3/assert"
+)
+
+func TestClearShellSession(t *testing.T) {
+	t.Parallel()
+	s := teststore.New(t)
+	org := teststore.CreateOrg(t, s, nil)
+
+	task := &model.Task{
+		Name:         "shell-task",
+		Runner:       "r",
+		Workspace:    "w",
+		Status:       model.TaskStatusCompleted,
+		OrgID:        org.OrgID,
+		ShellSession: "sess-1",
+	}
+	assert.NilError(t, s.CreateTask(t.Context(), nil, task))
+
+	// Clearing with the matching session + org empties the field.
+	assert.NilError(t, s.ClearShellSession(t.Context(), nil, "sess-1", org.OrgID))
+	got, err := s.GetTask(t.Context(), nil, task.ID, org.OrgID)
+	assert.NilError(t, err)
+	assert.Equal(t, got.ShellSession, "")
+}
+
+func TestClearShellSession_WrongOrgNoOp(t *testing.T) {
+	t.Parallel()
+	s := teststore.New(t)
+	org := teststore.CreateOrg(t, s, nil)
+	other := teststore.CreateOrg(t, s, nil)
+
+	task := &model.Task{
+		Name:         "shell-task",
+		Runner:       "r",
+		Workspace:    "w",
+		Status:       model.TaskStatusCompleted,
+		OrgID:        org.OrgID,
+		ShellSession: "sess-2",
+	}
+	assert.NilError(t, s.CreateTask(t.Context(), nil, task))
+
+	// Clearing under a different org must not touch the task.
+	assert.NilError(t, s.ClearShellSession(t.Context(), nil, "sess-2", other.OrgID))
+	got, err := s.GetTask(t.Context(), nil, task.ID, org.OrgID)
+	assert.NilError(t, err)
+	assert.Equal(t, got.ShellSession, "sess-2")
+}


### PR DESCRIPTION
Follow-up on #1113, required now that the driver reads `shell_session` (4a, #1125). Without this, the field stays set after a debug shell ends, so a later restart of that task would boot another shell instead of running the agent.

## Approach
The server owns `shell_session` (neither driver nor runner writes it), so it also clears it — tied to the **shell's own lifecycle**, not to task starts. Clearing in the task-start paths was rejected because automated starts (e.g. a PR-review event routed to the task) would clobber the field / interrupt an in-flight shell.

- `shellrelay.Registry` gains a `WithOnClose(func(session, orgID))` option, invoked once from `teardown` for every end-of-session reason (normal exit, dropped leg, establishment timeout, registry shutdown).
- `server.go` wires it to `store.ClearShellSession`, which runs `UPDATE tasks SET shell_session = '' WHERE shell_session = $1 AND org_id = $2` (new sqlc query + store method).

## Tests
- `shellrelay`: `onClose` fires on teardown with the session id + org.
- `store`: `ClearShellSession` empties the field for the matching session; a wrong-org call is a no-op.

Verified: `go build ./...`, `vet`, `gofmt` clean; server + store suites pass against Postgres.

## Not in scope (remaining on #1113)
- Concurrency policy when an automated start races an in-flight shell (the task is `RUNNING` during a shell; an incoming restart would interrupt it). Documented as a separate follow-up.
- Binding the driver-leg token to the session's task.
- Step 5: reimplement `xagent shell` (the operator CLI).