### PR TITLE
fix(webui): align add instruction send button with composer input

### DIFF
--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -275,7 +275,7 @@ function TaskDetail() {
                   />
                   <Button
                     type="submit"
-                    size="icon"
+                    size="icon-lg"
                     disabled={updateMutation.isPending}
                     title="Send instruction"
                   >


### PR DESCRIPTION
## Summary

Fixes #1005 — the "add instruction" send button on the task page was vertically misaligned with the composer input.

**Root cause:** The form uses `items-end` (bottom-aligned) with a `min-h-[40px]` textarea, but the send button used `size="icon"` (36px). Bottom-aligned, the shorter button sat 4px below the input's top edge, so it looked sunk.

## Change

Switch the send button to `size="icon-lg"` (40px) so it matches the textarea's min-height.

## Verification

Tested each candidate live with Playwright at `/ui/tasks/478`:

- **Shrink input to 36px** — doesn't align: the textarea's `field-sizing-content` renders it at ~38px, leaving a 2px gap.
- **Center the 36px button** (`items-center`) — balanced at rest, but breaks once the composer grows multi-line (button floats to the middle).
- **Button → 40px (this PR)** — the only option that's pixel-perfect *and* keeps the button pinned to the bottom as the textarea grows.

After the change, both textarea and button measure top 599 / bottom 639 / height 40 — exact alignment. `pnpm lint` passes clean.

> Note: this is the same one-line change as the previously-closed #1006, but that one shipped unverified. This time the alignment (and the rejection of the alternatives) is confirmed live.