### PR TITLE
feat(webui): surface archive as an icon button beside the task menu

### DIFF
--- a/webui/src/components/archive-button.tsx
+++ b/webui/src/components/archive-button.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
-import { Loader2 } from 'lucide-react'
+import { Archive, ArchiveRestore, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { autoArchiveDeadline } from '@/lib/task'
+import { autoArchiveDeadline, canArchiveTask, canUnarchiveTask } from '@/lib/task'
 import { formatCountdown } from '@/lib/duration'
 import type { Task } from '@/gen/xagent/v1/xagent_pb'
 
@@ -22,31 +22,49 @@ function useAutoArchiveCountdown(task: ArchiveTask): string | null {
   return formatCountdown(deadlineTime - now)
 }
 
-// ArchiveButton renders the manual archive control. When the task is scheduled
-// to be auto-archived, it shows a live countdown in the label ("Archive (5m)")
-// so the automatic behavior is co-located with the manual action.
+// ArchiveButton is the manual archive/unarchive control, shared by the task list
+// and the task page header. It renders as a compact icon button; when the task is
+// scheduled to be auto-archived, the live countdown ("5m") sits beside the icon so
+// the automatic behavior stays visible next to the manual action. The icon flips
+// to a restore glyph when the server exposes unarchive instead of archive.
+//
+// `compact` shrinks it to sit inside a table row. `onUnarchive` is only needed
+// where unarchive is reachable (the task page); the list is filtered to archivable
+// tasks and never surfaces it.
 export function ArchiveButton({
   task,
   onArchive,
+  onUnarchive,
   pending,
   disabled,
+  compact,
 }: {
   task: ArchiveTask
   onArchive: () => void
+  onUnarchive?: () => void
   pending: boolean
   disabled?: boolean
+  compact?: boolean
 }) {
   const countdown = useAutoArchiveCountdown(task)
+  const unarchive = canUnarchiveTask(task)
+  const canAct = canArchiveTask(task) || unarchive
+  const label = unarchive ? 'Unarchive task' : 'Archive task'
+  const Icon = unarchive ? ArchiveRestore : Archive
+  // Icon-only unless a countdown needs room; sizes track their host (compact for
+  // the dense table row, full height to line up with the task-page menu button).
+  const size = countdown ? (compact ? 'sm' : 'default') : compact ? 'icon-sm' : 'icon'
   return (
     <Button
       variant="outline"
-      size="sm"
-      onClick={onArchive}
-      disabled={disabled ?? pending}
-      title={countdown ? `Auto-archives in ${countdown}` : undefined}
+      size={size}
+      onClick={unarchive ? onUnarchive : onArchive}
+      disabled={(disabled ?? pending) || !canAct}
+      aria-label={label}
+      title={countdown ? `Auto-archives in ${countdown}` : label}
     >
-      {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-      {countdown ? `Archive (${countdown})` : 'Archive'}
+      {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Icon className="h-4 w-4" />}
+      {countdown && <span className="tabular-nums">{countdown}</span>}
     </Button>
   )
 }

--- a/webui/src/components/task-actions-menu.tsx
+++ b/webui/src/components/task-actions-menu.tsx
@@ -21,13 +21,7 @@ import {
   durationToMillis,
   formatCountdown,
 } from '@/lib/duration'
-import {
-  canArchiveTask,
-  canCancelTask,
-  canRestartTask,
-  canUnarchiveTask,
-  isArchivedTask,
-} from '@/lib/task'
+import { canCancelTask, canRestartTask, isArchivedTask } from '@/lib/task'
 import type { Duration } from '@bufbuild/protobuf/wkt'
 import type { Task } from '@/gen/xagent/v1/xagent_pb'
 
@@ -44,10 +38,10 @@ const AUTO_ARCHIVE_PRESETS: { value: string; label: string }[] = [
   { value: String(7 * 24 * 60 * 60), label: '7 days' },
 ]
 
-// TaskActionsMenu is the overflow (…) menu in the task page header. It is the
-// single entry point for every task action: the auto-archive delay (a duration
-// submenu), cancel, restart, and archive/unarchive. Each action is shown only
-// when the server reports it as available for the task's current state.
+// TaskActionsMenu is the overflow (…) menu in the task page header. It hosts the
+// auto-archive delay (a duration submenu) plus cancel and restart; archive and
+// unarchive live in a dedicated icon button beside this menu. Each action is
+// shown only when the server reports it as available for the task's state.
 export function TaskActionsMenu({
   task,
   onAutoArchiveChange,
@@ -56,10 +50,6 @@ export function TaskActionsMenu({
   cancelPending,
   onRestart,
   restartPending,
-  onArchive,
-  archivePending,
-  onUnarchive,
-  unarchivePending,
 }: {
   task: ActionsTask
   onAutoArchiveChange: (autoArchive: Duration) => void
@@ -68,10 +58,6 @@ export function TaskActionsMenu({
   cancelPending?: boolean
   onRestart: () => void
   restartPending?: boolean
-  onArchive: () => void
-  archivePending?: boolean
-  onUnarchive: () => void
-  unarchivePending?: boolean
 }) {
   const current = autoArchiveSelectValue(task.autoArchive)
   const preset = AUTO_ARCHIVE_PRESETS.find((p) => p.value === current)
@@ -81,12 +67,9 @@ export function TaskActionsMenu({
   const customLabel =
     !preset && task.autoArchive ? formatCountdown(durationToMillis(task.autoArchive)) : null
   const currentLabel = preset?.label ?? customLabel ?? 'Never'
-  const pending =
-    autoArchivePending || cancelPending || restartPending || archivePending || unarchivePending
+  const pending = autoArchivePending || cancelPending || restartPending
   const showCancel = canCancelTask(task)
   const showRestart = canRestartTask(task)
-  const showArchive = canArchiveTask(task)
-  const showUnarchive = canUnarchiveTask(task)
 
   return (
     <DropdownMenu>
@@ -106,13 +89,8 @@ export function TaskActionsMenu({
           </DropdownMenuItem>
         )}
         {showRestart && <DropdownMenuItem onSelect={onRestart}>Restart task</DropdownMenuItem>}
-        {/* Archive-state-aware: the server exposes exactly one of these actions. */}
-        {showUnarchive && (
-          <DropdownMenuItem onSelect={onUnarchive}>Unarchive task</DropdownMenuItem>
-        )}
-        {showArchive && <DropdownMenuItem onSelect={onArchive}>Archive task</DropdownMenuItem>}
 
-        {(showCancel || showRestart || showArchive || showUnarchive) && <DropdownMenuSeparator />}
+        {(showCancel || showRestart) && <DropdownMenuSeparator />}
 
         <DropdownMenuSub>
           {/* Disabled once archived: an archived task no longer auto-archives. */}

--- a/webui/src/routes/tasks.$id.tsx
+++ b/webui/src/routes/tasks.$id.tsx
@@ -20,6 +20,7 @@ import { useShellState } from '@/hooks/use-shell-state'
 import { isShellActive } from '@/lib/shell-sessions'
 import { cn } from '@/lib/utils'
 import { ArchivedBadge } from '@/components/archived-badge'
+import { ArchiveButton } from '@/components/archive-button'
 import { TaskActionsMenu } from '@/components/task-actions-menu'
 import { StatusBadge } from '@/components/status-badge'
 import { Button } from '@/components/ui/button'
@@ -200,6 +201,18 @@ function TaskDetail() {
               </TabsTrigger>
             </TabsList>
           </Tabs>
+          {/* Archive sits just left of the overflow menu as its own icon button:
+              it's the most common single-click action, so it stays one tap away
+              rather than buried in the menu. The icon flips between archive and
+              restore to match whichever action the server exposes, and it greys
+              out (rather than disappearing) when neither is available so the
+              header layout doesn't shift as the task changes state. */}
+          <ArchiveButton
+            task={task}
+            onArchive={handleArchive}
+            onUnarchive={handleUnarchive}
+            pending={archiveMutation.isPending || unarchiveMutation.isPending}
+          />
           <TaskActionsMenu
             task={task}
             onAutoArchiveChange={(autoArchive) =>
@@ -210,10 +223,6 @@ function TaskDetail() {
             cancelPending={cancelMutation.isPending}
             onRestart={handleRestart}
             restartPending={restartMutation.isPending}
-            onArchive={handleArchive}
-            archivePending={archiveMutation.isPending}
-            onUnarchive={handleUnarchive}
-            unarchivePending={unarchiveMutation.isPending}
           />
         </div>
       </div>

--- a/webui/src/routes/tasks.index.tsx
+++ b/webui/src/routes/tasks.index.tsx
@@ -157,6 +157,7 @@ function TaskRow({ task, onUpdate }: { task: Task; onUpdate: () => void }) {
             task={task}
             onArchive={handleArchive}
             pending={archiveMutation.isPending}
+            compact
           />
         )}
       </TableCell>


### PR DESCRIPTION
## Summary

Brings the archive action back out of the overflow (…) menu and into a dedicated **icon button**, per request.

- **Task page:** an archive icon button sits just to the **left** of the overflow menu. It flips to a restore glyph when the server exposes *unarchive*, and **greys out (disabled) instead of disappearing** when neither action is available, so the header layout stays stable as the task changes state.
- **Task list:** the archive control now uses the same **icon** button (compact size), staying hidden when a row isn't archivable.
- **Auto-archive countdown** stays visible beside the icon in **both** places (e.g. `5m`).
- `archive`/`unarchive` are removed from `TaskActionsMenu`; `ArchiveButton` is now the single shared control for both call sites.

## Testing

- `pnpm lint` — clean
- `tsc --noEmit` — clean
- Verified visually on the local task page via Playwright.