### PR TITLE
fix(server): wrap a concrete slog handler to avoid startup deadlock

### DIFF
--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -140,8 +141,12 @@ var ServerCommand = &cli.Command{
 		dbPath := cmd.String("db")
 		noAuth := cmd.Bool("no-auth")
 
-		// Enrich logs with org_id, task_id and trace_id from the context.
-		slog.SetDefault(slog.New(logctx.NewHandler(slog.Default().Handler())))
+		// Enrich logs with org_id, task_id and trace_id from the context. The
+		// handler must be a concrete one (not slog.Default().Handler()): the
+		// default handler emits through the log package, and slog.SetDefault
+		// reroutes the log package back through this handler, so wrapping the
+		// default handler would deadlock on the first record.
+		slog.SetDefault(slog.New(logctx.NewHandler(slog.NewTextHandler(os.Stderr, nil))))
 
 		// Initialize OpenTelemetry (configured via OTEL_EXPORTER_OTLP_ENDPOINT env var)
 		otel, err := otelx.Setup(ctx)


### PR DESCRIPTION
## Problem

`mise run dev` starts the server container but it never becomes healthy: it produces **zero logs** and never listens (healthcheck gets connection refused). Not a crash — a silent startup hang.

## Root cause

A re-entrant logging deadlock introduced by the observability change (`26b126ed`). The server installs the context-aware handler as:

```go
slog.SetDefault(slog.New(logctx.NewHandler(slog.Default().Handler())))
```

`slog.Default().Handler()` is the built-in `defaultHandler`, which emits records **through the `log` package**. But `slog.SetDefault` *also* reroutes the `log` package back through the new slog default handler. So the wrapped default handler forms a cycle:

`slog.Warn` → `logctx.Handle` → `defaultHandler` → `log.output` (takes the `log` mutex) → `handlerWriter.Write` → `logctx.Handle` → `defaultHandler` → `log.output` → **same mutex, already held → deadlock**, on the very first record.

Goroutine dump (via SIGQUIT) shows `logctx.Handle` (logctx.go:62) twice in the same stack, blocked on `sync.Mutex.Lock` under `log.(*Logger).output`.

It looked DB-shaped because it only triggers once a working DB lets startup reach the first `slog.Warn` ("SSO authentication disabled"). On a host without a reachable DB, the server errors out *before* that first log, so it never deadlocks.

## Fix

Wrap a concrete handler (`slog.NewTextHandler(os.Stderr, nil)`) — the same pattern the runner already uses — instead of `slog.Default().Handler()`. That writes straight to stderr, breaking the cycle.

## Verification

Fixed binary against a fresh DB now logs the previously-deadlocking path and serves:

```
level=WARN msg="SSO authentication disabled, using dev user"
level=INFO msg="starting server" addr=:6470
GET /ui/ -> http 200
```