### PR TITLE
feat(webui): add task quick-switch menu

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -33,6 +33,7 @@
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^1.0.0",
     "radix-ui": "^1.6.0",

--- a/webui/pnpm-lock.yaml
+++ b/webui/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       date-fns:
         specifier: ^4.1.0
         version: 4.4.0
@@ -1968,6 +1971,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -5016,6 +5025,18 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dialog': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   color-convert@2.0.1:
     dependencies:

--- a/webui/src/components/task-switcher.tsx
+++ b/webui/src/components/task-switcher.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { useQuery } from '@connectrpc/connect-query'
+import { timestampDate } from '@bufbuild/protobuf/wkt'
+import { formatDistanceToNow } from 'date-fns'
+import { listTasks } from '@/gen/xagent/v1/xagent-XAgentService_connectquery'
+import type { Task } from '@/gen/xagent/v1/xagent_pb'
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import { StatusBadge } from '@/components/status-badge'
+import { taskLabel, taskSearchValue } from '@/lib/task'
+import { useOrgId } from '@/hooks/use-org-id'
+
+// The switcher fuzzy-matches client side over a single page of the newest
+// tasks: ListTasks has no server-side search and caps a page at 100, which
+// covers the recent work a quick-switch is for.
+const PAGE_SIZE = 100
+
+// TaskSwitcher is the ctrl/cmd-K quick-switch palette. It is mounted once by the
+// root route so the shortcut works from any page.
+export function TaskSwitcher() {
+  const [open, setOpen] = useState(false)
+  const navigate = useNavigate()
+  const orgId = useOrgId()
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() !== 'k' || !(event.metaKey || event.ctrlKey)) {
+        return
+      }
+      // Ctrl/Cmd-K is the browser's "focus the search bar" binding; claim it.
+      event.preventDefault()
+      setOpen((prev) => !prev)
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  // Only fetch once the palette has been opened. React Query keeps the page
+  // cached afterwards, so reopening renders instantly and refetches behind the
+  // already-visible list.
+  const { data, isLoading } = useQuery(
+    listTasks,
+    { pageSize: PAGE_SIZE, pageToken: '', archived: false },
+    { enabled: open },
+  )
+
+  const tasks = data?.tasks ?? []
+
+  const handleSelect = (task: Task) => {
+    setOpen(false)
+    void navigate({
+      to: '/tasks/$id',
+      params: { id: String(task.id) },
+      search: { org: orgId },
+    })
+  }
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={setOpen}
+      title="Go to recent task"
+      description="Search your recent tasks by name, id, or workspace."
+      className="sm:max-w-2xl"
+    >
+      <CommandInput placeholder="Go to recent task..." />
+      <CommandList className="max-h-[60vh]">
+        <CommandEmpty>{isLoading ? 'Loading tasks...' : 'No tasks found.'}</CommandEmpty>
+        {tasks.map((task) => (
+          <CommandItem
+            key={String(task.id)}
+            value={taskSearchValue(task)}
+            keywords={[task.workspace]}
+            onSelect={() => handleSelect(task)}
+            className="gap-3"
+          >
+            <span className="truncate">{taskLabel(task)}</span>
+            <span className="ml-auto flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
+              <span className="hidden sm:inline">{task.workspace}</span>
+              {task.createdAt && (
+                <span className="hidden sm:inline">
+                  {formatDistanceToNow(timestampDate(task.createdAt), { addSuffix: true })}
+                </span>
+              )}
+              <StatusBadge task={task} />
+            </span>
+          </CommandItem>
+        ))}
+      </CommandList>
+    </CommandDialog>
+  )
+}

--- a/webui/src/components/ui/command.tsx
+++ b/webui/src/components/ui/command.tsx
@@ -1,0 +1,159 @@
+import * as React from 'react'
+import { Command as CommandPrimitive } from 'cmdk'
+import { SearchIcon } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = 'Command Palette',
+  description = 'Search for a command to run...',
+  children,
+  className,
+  showCloseButton = false,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogContent
+        className={cn('overflow-hidden p-0', className)}
+        showCloseButton={showCloseButton}
+      >
+        <DialogHeader className="sr-only">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div data-slot="command-input-wrapper" className="flex h-9 items-center gap-2 border-b px-3">
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          'flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn('max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto', className)}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn('-mx-1 h-px bg-border', className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandShortcut({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn('ml-auto text-xs tracking-widest text-muted-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/webui/src/lib/task.test.ts
+++ b/webui/src/lib/task.test.ts
@@ -1,5 +1,28 @@
 import { describe, it, expect } from 'vitest'
-import { toTaskTab } from './task'
+import { taskLabel, taskSearchValue, toTaskTab } from './task'
+
+describe('taskLabel', () => {
+  it('uses the name when the agent has set one', () => {
+    expect(taskLabel({ id: 42n, name: 'fix the flaky test' })).toBe('fix the flaky test')
+  })
+
+  it('falls back to the id while the task is still unnamed', () => {
+    expect(taskLabel({ id: 42n, name: '' })).toBe('Unnamed - 42')
+  })
+})
+
+describe('taskSearchValue', () => {
+  it('appends the id so same-named tasks stay distinct', () => {
+    const a = taskSearchValue({ id: 1n, name: 'deploy' })
+    const b = taskSearchValue({ id: 2n, name: 'deploy' })
+    expect(a).not.toBe(b)
+    expect(a).toBe('deploy 1')
+  })
+
+  it('keeps the id searchable for unnamed tasks', () => {
+    expect(taskSearchValue({ id: 7n, name: '' })).toBe('Unnamed - 7 7')
+  })
+})
 
 describe('toTaskTab', () => {
   it('passes through the non-default views', () => {

--- a/webui/src/lib/task.ts
+++ b/webui/src/lib/task.ts
@@ -40,6 +40,21 @@ export function canOpenShell(task: TaskLike): boolean {
   }
 }
 
+// taskLabel is a task's display name. A task exists before the agent gets
+// around to naming it, so unnamed tasks fall back to their id rather than
+// rendering as an empty row.
+export function taskLabel(task: Pick<Task, 'id' | 'name'>): string {
+  return task.name || `Unnamed - ${task.id}`
+}
+
+// taskSearchValue is what the quick-switch palette fuzzy-matches a task
+// against. cmdk requires item values to be unique and appends the item's
+// keywords to this string before scoring, so appending the id both
+// disambiguates same-named tasks and makes typing a bare task number find it.
+export function taskSearchValue(task: Pick<Task, 'id' | 'name'>): string {
+  return `${taskLabel(task)} ${task.id}`
+}
+
 // TaskTab identifies which view of the task detail page is shown. It is mirrored
 // in the URL's ?tab= search param so views can be deep-linked and shared. Links
 // are not a view — they live in the task sidebar.

--- a/webui/src/routes/__root.tsx
+++ b/webui/src/routes/__root.tsx
@@ -17,6 +17,7 @@ import { NO_ORG, type AuthTransport } from '@/lib/transport'
 import { useOrgId } from '@/hooks/use-org-id'
 import { useOrgSSE } from '@/hooks/use-org-sse'
 import { ConnectionIndicator } from '@/components/connection-indicator'
+import { TaskSwitcher } from '@/components/task-switcher'
 import {
   Select,
   SelectContent,
@@ -224,6 +225,7 @@ function RootComponent() {
           <Outlet />
         </main>
       </div>
+      <TaskSwitcher />
       <Suspense>
         <ReactQueryDevtools buttonPosition="top-right" />
       </Suspense>


### PR DESCRIPTION
Closes #1510

`Ctrl-K` / `Cmd-K` from any page opens a command palette that fuzzy-matches tasks and jumps to the selected one.

## Behavior

- Global shortcut toggles the palette; `Esc` closes it. It calls `preventDefault` so the browser's search-bar binding doesn't win.
- Fuzzy matching over task **name**, **id**, and **workspace**. cmdk appends an item's keywords to its value before scoring, so typing a bare task number finds that task.
- Arrow keys / `Enter` to select; navigates to `/tasks/$id` preserving `?org=`.
- Rows show name, workspace, relative created time, and status badge.

## Why client-side matching

`ListTasks` has no server-side search field and caps a page at 100 (`internal/store/task.go`), so the palette fetches one page of the newest **active** tasks and matches in the browser — no proto or server change. That covers the recent work a quick-switch is for; the full task list stays the place to find older or archived tasks.

The list is only fetched once the palette has been opened, and React Query keeps it cached so reopening is instant.

## Notes

- Adds `cmdk` and the shadcn `command` primitive. The generator wanted to overwrite `dialog.tsx`; it wasn't allowed to, so `command.tsx` is wired to the existing dialog instead.
- `taskLabel` / `taskSearchValue` live in `lib/task.ts` with unit tests, matching where the other pure task helpers sit.
- Keyboard-only, no nav trigger — matches the issue as written, though it does mean the feature is undiscoverable without one. Easy follow-up if you want it.

## Verification

`pnpm test` (45 passed), `tsc -b`, `pnpm lint`, and `pnpm build` all clean. Also exercised by hand in the browser against a local dev server.